### PR TITLE
fix: remove duplicate --all-targets argument from rust-analyzer settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,6 @@
     "rust-analyzer.cargo.buildScripts.enable": true,
     "rust-analyzer.check.command": "clippy",
     "rust-analyzer.check.extraArgs": [
-        "--all-targets",
         "--all-features"
     ],
     "rust-analyzer.checkOnSave": true,


### PR DESCRIPTION
Removes the duplicate \`--all-targets\` argument from \`.vscode/settings.json\` to fix \`rust-analyzer\` failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストに対応するエンドユーザー向けの変更はありません。開発環境の設定を更新しました。

* **Chores**
  * 開発ツール設定を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->