### PR TITLE
Refactor CLI and integrate LSP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,6 +2750,8 @@ dependencies = [
  "serde_json",
  "tempfile",
  "texide_core",
+ "texide_lsp",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/texide_cli/Cargo.toml
+++ b/crates/texide_cli/Cargo.toml
@@ -18,6 +18,8 @@ miette = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
+texide_lsp = { version = "0.1.0", path = "../texide_lsp" }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/crates/texide_lsp/Cargo.toml
+++ b/crates/texide_lsp/Cargo.toml
@@ -7,9 +7,6 @@ repository.workspace = true
 rust-version.workspace = true
 description = "LSP server for Texide"
 
-[[bin]]
-name = "texide-lsp"
-path = "src/main.rs"
 
 [dependencies]
 texide_core = { workspace = true, features = ["native"] }

--- a/crates/texide_lsp/src/lib.rs
+++ b/crates/texide_lsp/src/lib.rs
@@ -10,7 +10,6 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 use tracing::{debug, error, info};
-use tracing_subscriber::EnvFilter;
 
 use texide_core::{
     Diagnostic as TexideDiagnostic, Linter, LinterConfig, Severity as TexideSeverity,
@@ -351,16 +350,10 @@ impl LanguageServer for Backend {
     }
 }
 
-#[tokio::main]
-async fn main() {
-    // Initialize logging
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::from_default_env().add_directive("texide_lsp=debug".parse().unwrap()),
-        )
-        .with_writer(std::io::stderr)
-        .init();
-
+/// Starts the LSP server.
+///
+/// This function does not return unless an error occurs or the server shuts down.
+pub async fn run() {
     info!("Texide LSP server starting...");
 
     let stdin = tokio::io::stdin();


### PR DESCRIPTION
## Changes
- Refactored CLI commands to use nested \`rules\` subcommand.
  - \`texide create-rule\` -> \`texide rules create\`
  - \`texide add-rule\` -> \`texide rules add\`
- Converted \`texide_lsp\` from a standalone binary to a library.
- Integrated LSP server into the main \`texide\` CLI.
  - Now available via \`texide lsp\` command.
- Updated \`texide_cli\` dependencies to include \`texide_lsp\` and \`tokio\`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * LSP（言語サーバープロトコル）サーバーを開始する新しいコマンドを追加しました。
  * ルール管理コマンドをより明確な階層構造に再構成しました。

* **改善**
  * ログ出力の処理を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->