### PR TITLE
chore: configure git worktree support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ TODO.md
 
 # Cache directories
 .texide-cache/
+
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,17 @@ Texide is a high-performance natural language linter written in Rust, inspired b
     - PR description must be clear.
 5.  **Tests must pass** before requesting review.
 
+## Worktree Management
+
+When working on multiple tasks or expecting to switch contexts often, use **git worktrees** configured in the `.worktrees/` directory.
+
+- **Create a new worktree**: Use the make command.
+  ```bash
+  make worktree name=feat/my-feature
+  ```
+- **Directory**: All worktrees should be located in `.worktrees/`.
+- **Reason**: This keeps the main workspace clean and allows for parallel task execution without switching branches in the main directory.
+
 ## Common Commands
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,14 @@ git checkout -b feature/your-feature-name
 # or fix/bug-name, docs/update-readme, etc.
 ```
 
+> [!TIP]
+> **Use Git Worktrees for multitasking**
+> If you need to switch between branches frequently, consider using worktrees:
+> ```bash
+> make worktree name=feature/your-next-task
+> ```
+> This creates a new directory in `.worktrees/feature/your-next-task` linked to the branch.
+
 ### 2. Make Your Changes
 
 - Write code with English comments

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,14 @@ release-all: release wasm
 clean:
 	cargo clean
 	cd rules && cargo clean
+
+# =============================================================================
+# Git Configuration
+# =============================================================================
+
+# Create a new git worktree
+# Usage: make worktree name=my-branch [base=main]
+BASE ?= main
+worktree:
+	@if [ -z "$(name)" ]; then echo "Error: name is required. Usage: make worktree name=<branch-name>"; exit 1; fi
+	git worktree add -b $(name) .worktrees/$(name) $(BASE)


### PR DESCRIPTION
This PR creates a standard configuration for using git worktrees in .worktrees/ directory. It includes a Makefile command `make worktree` and documentation updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Git worktrees を使用した開発フローに関する新しいドキュメントを追加しました。並行タスクを効率的に管理できます。

* **Chores**
  * `make worktree` コマンドで新しい worktree を作成できるようになりました。
  * worktree ディレクトリをバージョン管理から除外するよう設定しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->