### PR TITLE
feat(registry): implement ManifestFetcher for plugin manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -465,6 +465,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -558,6 +564,16 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1097,6 +1113,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,8 +1279,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1434,6 +1467,23 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1455,9 +1505,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1777,7 +1829,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.13.1",
  "rustls",
  "serde",
  "serde_json",
@@ -1857,6 +1909,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsp-types"
@@ -1973,6 +2031,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minicov"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2085,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2149,10 +2230,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2448,6 +2573,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,8 +2658,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2489,7 +2679,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2499,6 +2699,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2643,6 +2852,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2854,10 +3107,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -2866,6 +3119,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2875,7 +3129,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2884,7 +3138,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2914,6 +3168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2939,12 +3199,25 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
  "bitflags 2.10.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3051,6 +3324,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3216,6 +3501,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3388,6 +3694,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3785,9 +4101,11 @@ name = "tsuzulint_registry"
 version = "0.1.0"
 dependencies = [
  "jsonschema",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 
@@ -3953,6 +4271,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -4550,6 +4874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,6 +5034,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/crates/tsuzulint_registry/Cargo.toml
+++ b/crates/tsuzulint_registry/Cargo.toml
@@ -8,12 +8,13 @@ license.workspace = true
 
 [dependencies]
 jsonschema.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 
 # Future dependencies for registry interaction
-# reqwest.workspace = true
 # sha2.workspace = true
 # semver.workspace = true

--- a/crates/tsuzulint_registry/src/error.rs
+++ b/crates/tsuzulint_registry/src/error.rs
@@ -1,0 +1,24 @@
+//! Error types for manifest fetching operations.
+
+use crate::ManifestError;
+use thiserror::Error;
+
+/// Error type for manifest fetch operations.
+#[derive(Debug, Error)]
+pub enum FetchError {
+    /// Network request failed.
+    #[error("Network error: {0}")]
+    NetworkError(#[from] reqwest::Error),
+
+    /// Resource not found.
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    /// Manifest parsing or validation failed.
+    #[error("Invalid manifest: {0}")]
+    InvalidManifest(#[from] ManifestError),
+
+    /// File system I/O error.
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+}

--- a/crates/tsuzulint_registry/src/fetcher.rs
+++ b/crates/tsuzulint_registry/src/fetcher.rs
@@ -1,0 +1,242 @@
+//! Manifest fetcher for plugin sources.
+
+use crate::error::FetchError;
+use crate::manifest::{ExternalRuleManifest, validate_manifest};
+use std::path::PathBuf;
+
+/// Source of a plugin manifest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PluginSource {
+    /// GitHub repository source.
+    /// Format: `owner/repo` or `owner/repo@version`
+    GitHub {
+        owner: String,
+        repo: String,
+        version: Option<String>,
+    },
+    /// Direct URL to a manifest file.
+    Url(String),
+    /// Local filesystem path to a manifest file.
+    Path(PathBuf),
+}
+
+impl PluginSource {
+    /// Create a new GitHub source.
+    pub fn github(owner: impl Into<String>, repo: impl Into<String>) -> Self {
+        Self::GitHub {
+            owner: owner.into(),
+            repo: repo.into(),
+            version: None,
+        }
+    }
+
+    /// Create a new GitHub source with a specific version.
+    pub fn github_with_version(
+        owner: impl Into<String>,
+        repo: impl Into<String>,
+        version: impl Into<String>,
+    ) -> Self {
+        Self::GitHub {
+            owner: owner.into(),
+            repo: repo.into(),
+            version: Some(version.into()),
+        }
+    }
+
+    /// Create a new URL source.
+    pub fn url(url: impl Into<String>) -> Self {
+        Self::Url(url.into())
+    }
+
+    /// Create a new path source.
+    pub fn path(path: impl Into<PathBuf>) -> Self {
+        Self::Path(path.into())
+    }
+}
+
+/// Fetcher for plugin manifests from various sources.
+pub struct ManifestFetcher {
+    client: reqwest::Client,
+}
+
+impl Default for ManifestFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ManifestFetcher {
+    /// Create a new manifest fetcher.
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Fetch a manifest from the given source.
+    pub async fn fetch(&self, source: &PluginSource) -> Result<ExternalRuleManifest, FetchError> {
+        match source {
+            PluginSource::GitHub {
+                owner,
+                repo,
+                version,
+            } => {
+                self.fetch_from_github(owner, repo, version.as_deref())
+                    .await
+            }
+            PluginSource::Url(url) => self.fetch_from_url(url).await,
+            PluginSource::Path(path) => self.fetch_from_path(path).await,
+        }
+    }
+
+    /// Fetch manifest from GitHub Releases.
+    async fn fetch_from_github(
+        &self,
+        owner: &str,
+        repo: &str,
+        version: Option<&str>,
+    ) -> Result<ExternalRuleManifest, FetchError> {
+        let url = match version {
+            Some(v) => format!(
+                "https://github.com/{owner}/{repo}/releases/download/v{v}/tsuzulint-rule.json"
+            ),
+            None => format!(
+                "https://github.com/{owner}/{repo}/releases/latest/download/tsuzulint-rule.json"
+            ),
+        };
+
+        self.fetch_from_url(&url).await
+    }
+
+    /// Fetch manifest from a URL.
+    async fn fetch_from_url(&self, url: &str) -> Result<ExternalRuleManifest, FetchError> {
+        let response = self.client.get(url).send().await?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(FetchError::NotFound(format!("Manifest not found at {url}")));
+        }
+
+        let text = response.error_for_status()?.text().await?;
+        let manifest = validate_manifest(&text)?;
+        Ok(manifest)
+    }
+
+    /// Fetch manifest from a local file path.
+    async fn fetch_from_path(&self, path: &PathBuf) -> Result<ExternalRuleManifest, FetchError> {
+        if !path.exists() {
+            return Err(FetchError::NotFound(format!(
+                "Manifest file not found: {}",
+                path.display()
+            )));
+        }
+
+        let content = tokio::fs::read_to_string(path).await?;
+        let manifest = validate_manifest(&content)?;
+        Ok(manifest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plugin_source_github() {
+        let source = PluginSource::github("simorgh3196", "tsuzulint-rule-no-todo");
+        assert_eq!(
+            source,
+            PluginSource::GitHub {
+                owner: "simorgh3196".to_string(),
+                repo: "tsuzulint-rule-no-todo".to_string(),
+                version: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_plugin_source_github_with_version() {
+        let source =
+            PluginSource::github_with_version("simorgh3196", "tsuzulint-rule-no-todo", "1.0.0");
+        assert_eq!(
+            source,
+            PluginSource::GitHub {
+                owner: "simorgh3196".to_string(),
+                repo: "tsuzulint-rule-no-todo".to_string(),
+                version: Some("1.0.0".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn test_plugin_source_url() {
+        let source = PluginSource::url("https://example.com/tsuzulint-rule.json");
+        assert_eq!(
+            source,
+            PluginSource::Url("https://example.com/tsuzulint-rule.json".to_string())
+        );
+    }
+
+    #[test]
+    fn test_plugin_source_path() {
+        let source = PluginSource::path("./local/tsuzulint-rule.json");
+        assert_eq!(
+            source,
+            PluginSource::Path(PathBuf::from("./local/tsuzulint-rule.json"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_path_success() {
+        // Use our test fixture with a valid URI-format wasm field
+        let manifest_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/valid-manifest.json");
+
+        eprintln!("Testing with manifest path: {}", manifest_path.display());
+
+        let fetcher = ManifestFetcher::new();
+        let result = fetcher.fetch(&PluginSource::Path(manifest_path)).await;
+
+        match &result {
+            Ok(manifest) => {
+                assert_eq!(manifest.rule.name, "test-rule");
+            }
+            Err(e) => {
+                panic!("Failed to fetch manifest: {e}");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_path_not_found() {
+        let fetcher = ManifestFetcher::new();
+        let result = fetcher
+            .fetch(&PluginSource::Path(PathBuf::from(
+                "/nonexistent/tsuzulint-rule.json",
+            )))
+            .await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            FetchError::NotFound(msg) => {
+                assert!(msg.contains("not found"));
+            }
+            _ => panic!("Expected NotFound error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fetch_from_path_invalid_manifest() {
+        // Use our test fixture with an invalid manifest (missing required fields)
+        let manifest_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/invalid-manifest.json");
+
+        let fetcher = ManifestFetcher::new();
+        let result = fetcher.fetch(&PluginSource::Path(manifest_path)).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            FetchError::InvalidManifest(_) => {}
+            e => panic!("Expected InvalidManifest error, got: {e}"),
+        }
+    }
+}

--- a/crates/tsuzulint_registry/src/lib.rs
+++ b/crates/tsuzulint_registry/src/lib.rs
@@ -1,5 +1,9 @@
 //! TsuzuLint Plugin Registry and Manifest Management.
 
+pub mod error;
+pub mod fetcher;
 pub mod manifest;
 
+pub use error::FetchError;
+pub use fetcher::{ManifestFetcher, PluginSource};
 pub use manifest::{ExternalRuleManifest, ManifestError};

--- a/crates/tsuzulint_registry/tests/fixtures/invalid-manifest.json
+++ b/crates/tsuzulint_registry/tests/fixtures/invalid-manifest.json
@@ -1,0 +1,5 @@
+{
+    "rule": {
+        "name": "invalid"
+    }
+}

--- a/crates/tsuzulint_registry/tests/fixtures/valid-manifest.json
+++ b/crates/tsuzulint_registry/tests/fixtures/valid-manifest.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://raw.githubusercontent.com/simorgh3196/tsuzulint/main/schemas/v1/rule.json",
+    "rule": {
+        "name": "test-rule",
+        "version": "1.0.0",
+        "description": "Test rule for fetcher tests",
+        "fixable": false
+    },
+    "artifacts": {
+        "wasm": "https://example.com/test-rule.wasm",
+        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+    }
+}


### PR DESCRIPTION
## Summary

Implement functionality to fetch `tsuzulint-rule.json` manifests from GitHub Releases, URLs, or local paths.

## Changes

### New Files
- `crates/tsuzulint_registry/src/error.rs` - `FetchError` enum
- `crates/tsuzulint_registry/src/fetcher.rs` - `PluginSource`, `ManifestFetcher`
- `crates/tsuzulint_registry/tests/fixtures/` - Test manifests

### Modified Files
- `crates/tsuzulint_registry/Cargo.toml` - Added reqwest, tokio dependencies
- `crates/tsuzulint_registry/src/lib.rs` - Module exports

## New Types

```rust
pub enum PluginSource {
    GitHub { owner: String, repo: String, version: Option<String> },
    Url(String),
    Path(PathBuf),
}

pub struct ManifestFetcher { client: reqwest::Client }

pub enum FetchError {
    NetworkError(reqwest::Error),
    NotFound(String),
    InvalidManifest(ManifestError),
    IoError(std::io::Error),
}
```

## Testing

- 10 tests passing (PluginSource construction, path fetch success/not found/invalid manifest)
- Network fetch integration tests deferred to separate issue

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プラグインマニフェストを複数のソースから取得できるようになりました（GitHub リリース、URL、ローカルファイル）
  * マニフェスト取得時のエラーハンドリングが強化されました

* **テスト**
  * マニフェスト検証用のテストフィクスチャを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->