### PR TITLE
🧹 Deduplicate config file finding logic

### DIFF
--- a/crates/tsuzulint_core/src/config.rs
+++ b/crates/tsuzulint_core/src/config.rs
@@ -119,6 +119,21 @@ impl RuleOption {
 }
 
 impl LinterConfig {
+    /// Supported configuration files in order of precedence.
+    pub const CONFIG_FILES: &'static [&'static str] = &[".tsuzulint.jsonc", ".tsuzulint.json"];
+
+    /// Attempts to find a configuration file in the given directory.
+    pub fn discover(base_dir: impl AsRef<Path>) -> Option<PathBuf> {
+        let base_dir = base_dir.as_ref();
+        for name in Self::CONFIG_FILES {
+            let path = base_dir.join(name);
+            if path.exists() {
+                return Some(path);
+            }
+        }
+        None
+    }
+
     /// Creates a new empty configuration.
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
🎯 **What:** This PR deduplicates the configuration file finding logic by centralizing it in the `LinterConfig` struct within the `tsuzulint_core` crate.

💡 **Why:** Centralizing this logic improves maintainability and ensures consistency across the CLI and LSP implementations. It also makes it easier to add or change supported configuration file names in the future.

✅ **Verification:** 
- The changes were manually verified for logical correctness.
- The `LinterConfig::discover` method correctly implements the original search order (`.tsuzulint.jsonc` then `.tsuzulint.json`).
- Call sites in `tsuzulint_cli` and `tsuzulint_lsp` were updated and confirmed to be functionally equivalent to the original code.
- `cargo fmt` was run to ensure consistent formatting.

✨ **Result:** A cleaner, more maintainable codebase with consistent configuration discovery across all components.

---
*PR created automatically by Jules for task [4122084652146706492](https://jules.google.com/task/4122084652146706492) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 設定ファイルの検出メカニズムを統一し、より信頼性の高い設定ファイル検出を実現
  * LSP での設定ファイル変更検出を改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->