### PR TITLE
🧹 Remove deprecated `plugins` field from `LinterConfig`

### DIFF
--- a/crates/tsuzulint_core/src/config.rs
+++ b/crates/tsuzulint_core/src/config.rs
@@ -26,10 +26,6 @@ pub struct LinterConfig {
     #[serde(default)]
     pub options: HashMap<String, RuleOption>,
 
-    /// Plugin names to load (for backward compatibility or simpler plugin lists).
-    #[serde(default)]
-    pub plugins: Vec<String>,
-
     /// File patterns to include.
     #[serde(default)]
     pub include: Vec<String>,
@@ -139,7 +135,6 @@ impl LinterConfig {
         Self {
             rules: Vec::new(),
             options: HashMap::new(),
-            plugins: Vec::new(),
             include: Vec::new(),
             exclude: Vec::new(),
             cache: true,
@@ -324,7 +319,6 @@ mod tests {
         let config = LinterConfig::default();
         assert!(config.rules.is_empty());
         assert!(config.options.is_empty());
-        assert!(config.plugins.is_empty());
         assert!(config.include.is_empty());
         assert!(config.exclude.is_empty());
         assert!(config.cache);

--- a/crates/tsuzulint_core/src/linter.rs
+++ b/crates/tsuzulint_core/src/linter.rs
@@ -281,11 +281,6 @@ impl Linter {
             }
         };
 
-        // Load legacy plugins list
-        for plugin_name in &config.plugins {
-            load_plugin(plugin_name, host);
-        }
-
         // Load rules from new rules array
         for rule_def in &config.rules {
             use crate::config::RuleDefinition;


### PR DESCRIPTION
TARGET: `crates/tsuzulint_core/src/config.rs` and `crates/tsuzulint_core/src/linter.rs`

### 🎯 What
Removed the `plugins` field from `LinterConfig` and the corresponding loading logic in `Linter`.

### 💡 Why
The `plugins` field was deprecated and caused confusion as it was duplicative of `rules` and not present in the JSON schema, leading to validation errors. The user confirmed it is safe to remove as the product is not yet released.

### ✅ Verification
Ran `cargo test -p tsuzulint_core` and verified that all tests passed (71 passed, 0 failed).
Verified that the removed field no longer causes issues in `config.rs`.

### ✨ Result
Cleaner configuration structure and removal of dead/deprecated code.

---
*PR created automatically by Jules for task [15647640432324709201](https://jules.google.com/task/15647640432324709201) started by @simorgh3196*