### PR TITLE
🔒 Fix command injection vulnerability in VS Code extension

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -21,6 +21,7 @@
             "title": "TsuzuLint",
             "properties": {
                 "tsuzulint.executablePath": {
+                    "scope": "machine",
                     "type": "string",
                     "default": "tzlint",
                     "description": "Path to the tzlint executable. If not specified, look for 'tzlint' in PATH."


### PR DESCRIPTION
🎯 **What:**
Restricted the `tsuzulint.executablePath` configuration setting to `machine` scope.

⚠️ **Risk:**
Previously, this setting had the default `window` scope, allowing workspace-level overrides (e.g., in `.vscode/settings.json`). This created a security vulnerability where a malicious repository could configure the extension to execute an arbitrary binary instead of the legitimate `tzlint` executable.

🛡️ **Solution:**
By setting `"scope": "machine"`, the configuration can now only be set in User Settings or Machine Settings (remote), preventing workspace-level hijacking. This aligns with VS Code security best practices for executable paths.

✅ **Verification:**
- Validated `package.json` syntax.
- Verified that the `scope` property is correctly added.
- Ensured the extension still builds (despite tooling warnings about large diffs during build).

---
*PR created automatically by Jules for task [15886796723125928794](https://jules.google.com/task/15886796723125928794) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores（その他の変更）**
  * VS Code拡張機能の tsuzulint.executablePath 設定のスコープをマシン単位に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->