### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Extism sandbox file access

### DIFF
--- a/crates/tsuzulint_plugin/src/executor_extism.rs
+++ b/crates/tsuzulint_plugin/src/executor_extism.rs
@@ -3,7 +3,7 @@
 //! This module provides high-performance WASM execution using Extism,
 //! which internally uses wasmtime for JIT compilation.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 
 use extism::{Manifest, Plugin, Wasm};
@@ -70,6 +70,12 @@ impl ExtismExecutor {
 
         // Deny all network access
         manifest.allowed_hosts = Some(vec![]);
+
+        // Deny all file system access
+        manifest.allowed_paths = Some(BTreeMap::new());
+
+        // Clear configuration to prevent environment leakage
+        manifest.config = BTreeMap::new();
 
         manifest
     }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Extism sandbox file access

🚨 Severity: CRITICAL
💡 Vulnerability: WASM plugins running via Extism (native backend) could potentially access the host file system if the default `allowed_paths` configuration allows it (or if it changes in future versions).
🎯 Impact: Malicious or buggy plugins could read sensitive files from the user's machine.
🔧 Fix: Explicitly set `allowed_paths` to an empty map in `crates/tsuzulint_plugin/src/executor_extism.rs`. Also clear `config` map.
✅ Verification: Code review confirmed explicit configuration. Tests passed.

---
*PR created automatically by Jules for task [16344392952381970737](https://jules.google.com/task/16344392952381970737) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * プラグイン実行のセキュリティを強化しました。ファイルシステムへのアクセス制限と環境設定のリセットを追加し、より安全な実行環境を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->