### PR TITLE
🦀 Ferris: simplify CacheEntry validation

### DIFF
--- a/crates/tsuzulint_cache/Cargo.toml
+++ b/crates/tsuzulint_cache/Cargo.toml
@@ -7,6 +7,11 @@ repository.workspace = true
 rust-version.workspace = true
 description = "Caching layer for TsuzuLint"
 
+[features]
+default = ["native"]
+native = ["tsuzulint_plugin/native"]
+browser = ["tsuzulint_plugin/browser"]
+
 [dependencies]
 tsuzulint_plugin = { workspace = true }
 tsuzulint_ast = { workspace = true }

--- a/crates/tsuzulint_cache/src/entry.rs
+++ b/crates/tsuzulint_cache/src/entry.rs
@@ -71,28 +71,9 @@ impl CacheEntry {
         config_hash: &str,
         rule_versions: &HashMap<String, String>,
     ) -> bool {
-        // Check content hash
-        if self.content_hash != content_hash {
-            return false;
-        }
-
-        // Check config hash
-        if self.config_hash != config_hash {
-            return false;
-        }
-
-        // Check rule versions
-        if self.rule_versions.len() != rule_versions.len() {
-            return false;
-        }
-
-        for (name, version) in &self.rule_versions {
-            if rule_versions.get(name) != Some(version) {
-                return false;
-            }
-        }
-
-        true
+        self.content_hash == content_hash
+            && self.config_hash == config_hash
+            && self.rule_versions == *rule_versions
     }
 }
 


### PR DESCRIPTION
Refactored `CacheEntry::is_valid` to use idiomatic `HashMap` equality check.
Added feature flags to `tsuzulint_cache` for better testing support.
Added journal entry.

---
*PR created automatically by Jules for task [407313155563804797](https://jules.google.com/task/407313155563804797) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * キャッシュ検証処理のロジックを簡潔に改善し、効率性を向上させました。

* **Chores**
  * ビルド設定を拡張し、複数のプラットフォーム環境に対応できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->