### PR TITLE
🧹 Improve error handling in LinterConfig::hash

### DIFF
--- a/crates/tsuzulint_core/src/linter.rs
+++ b/crates/tsuzulint_core/src/linter.rs
@@ -72,7 +72,7 @@ impl Linter {
         Self::load_configured_rules(&config, &mut host);
 
         // Pre-compute config hash
-        let config_hash = config.hash();
+        let config_hash = config.hash()?;
 
         Ok(Self {
             config,
@@ -1225,7 +1225,7 @@ mod tests {
     #[test]
     fn test_linter_config_hash_caching() {
         let (config, _temp) = test_config();
-        let expected_hash = config.hash();
+        let expected_hash = config.hash().unwrap();
         let linter = Linter::new(config).unwrap();
 
         // Verify that the hash stored in Linter matches the one computed from config


### PR DESCRIPTION
Improved robustness of configuration hashing by implementing explicit error handling. Changed `LinterConfig::hash` to return `Result<String, LinterError>` and updated all callers and tests accordingly.

---
*PR created automatically by Jules for task [13742994373535213552](https://jules.google.com/task/13742994373535213552) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * エラーハンドリングの改善により、ハッシング処理の失敗時に適切にエラーが伝播されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->