### PR TITLE
⚡ Optimize Diagnostic Deduplication via String Cloning avoidance

### DIFF
--- a/crates/tsuzulint_core/src/linter.rs
+++ b/crates/tsuzulint_core/src/linter.rs
@@ -699,7 +699,7 @@ impl Linter {
             global_keys.insert(d);
         }
 
-        all_diagnostics.sort();
+        all_diagnostics.sort_unstable();
         all_diagnostics.dedup();
         let final_diagnostics = all_diagnostics;
 


### PR DESCRIPTION
Optimized diagnostic deduplication by implementing comparison traits on `Diagnostic` and using `sort`/`dedup` in the linter.

---
*PR created automatically by Jules for task [3723005120346882941](https://jules.google.com/task/3723005120346882941) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 診断メッセージの重複排除を統一的なソート＋重複削除へ最適化し、処理がより安定・効率化
  * 診断の内部追跡を簡素化してフィルタリング処理を整備

* **Tests**
  * 診断の等価性・整列・ハッシュ動作を検証するテストを追加
  * リファクタリングに伴うテストを更新

* **Style**
  * 修正情報（Fix）の比較可能性を向上する変更を実施
<!-- end of auto-generated comment: release notes by coderabbit.ai -->