### PR TITLE
⚡ Bolt: Optimize diagnostic sorting and allocation

### DIFF
--- a/crates/tsuzulint_core/src/linter.rs
+++ b/crates/tsuzulint_core/src/linter.rs
@@ -862,6 +862,13 @@ impl Linter {
         diagnostics: &[tsuzulint_plugin::Diagnostic],
         global_keys: &HashSet<&tsuzulint_plugin::Diagnostic>,
     ) -> Vec<BlockCacheEntry> {
+        debug_assert!(
+            diagnostics
+                .windows(2)
+                .all(|w| w[0].span.start <= w[1].span.start),
+            "distribute_diagnostics: diagnostics must be sorted by span.start"
+        );
+
         // Ensure blocks are sorted by start position for the sweep-line algorithm to work correctly
         blocks.sort_by_key(|b| b.span.start);
 


### PR DESCRIPTION
💡 What: Optimized diagnostic collection in the linter by removing redundant sorting operations and pre-allocating memory.
🎯 Why: Diagnostic sorting O(N log N) was performed twice (once via `sort_unstable` + `dedup` and again via `sort_by`), but `Diagnostic::Ord` already ensures sorting by position. Pre-allocation prevents multiple `Vec` reallocations.
📊 Impact: Eliminates one O(N log N) sort and one O(N) sort (in `distribute_diagnostics`), and reduces allocator pressure.
🔬 Measurement: Verified with `cargo test -p tsuzulint_core` ensuring `test_lint_file_output_sorted` still passes.

---
*PR created automatically by Jules for task [13658620813155584121](https://jules.google.com/task/13658620813155584121) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **最適化**
  * 診断配列の事前割当てを導入し再割当を削減、処理性能を改善しました。
  * 内部での二重ソートを排除し、既存の並び替えに依存して効率化しました。
  * 配列を不変で扱う変更により安全性と意図が明確になりました。

* **注意事項**
  * 診断の配分処理は入力が開始位置で事前にソートされていることを前提とします。前提が満たされないと誤割当やパニックが発生する可能性があります。

* **テスト**
  * テストを拡充し、入力を明示的にソートするよう更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
