### PR TITLE
Refactor GlobMatcher to reduce duplication

### DIFF
--- a/crates/tsuzulint_core/src/walker.rs
+++ b/crates/tsuzulint_core/src/walker.rs
@@ -541,10 +541,20 @@ mod tests {
 
     #[test]
     fn test_glob_matcher_invalid_pattern() {
-        // This should log a warning but not panic
-        let matcher = GlobMatcher::new(&["[invalid".to_string()], &[]);
+        // "invalid[" is an invalid glob pattern. It should be logged and skipped, but valid ones are included.
+        let matcher = GlobMatcher::new(&["invalid[".to_string(), "*.md".to_string()], &[]);
 
-        // Invalid pattern is skipped, so the set is effectively empty (matches nothing)
-        assert!(!matcher.should_include(Path::new("test.md")));
+        assert!(matcher.should_include(Path::new("test.md")));
+        assert!(!matcher.should_include(Path::new("test.txt")));
+
+        let matcher2 = GlobMatcher::new(&[], &["invalid[".to_string(), "*.txt".to_string()]);
+        assert!(matcher2.should_include(Path::new("test.md")));
+        assert!(!matcher2.should_include(Path::new("test.txt")));
+    }
+
+    #[test]
+    fn test_build_globset_empty() {
+        let set = GlobMatcher::build_globset(&[], "test");
+        assert!(set.is_none());
     }
 }


### PR DESCRIPTION
Refactored `GlobMatcher` in `crates/tsuzulint_core/src/walker.rs` to remove duplicated code for building include and exclude `GlobSet`s.

Verified with:
- `cargo test -p tsuzulint_core`
- `cargo clippy -p tsuzulint_core`

---
*PR created automatically by Jules for task [6311459846966775843](https://jules.google.com/task/6311459846966775843) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * パターン処理ロジックを統合し、無効なパターンや構築失敗時の警告出力を一元化しました。
  * 空のパターン集合は明確に無視されるようになり、個別チェックを削減。
  * 外部の振る舞いは維持しつつ、エラーハンドリングと処理効率を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->