### PR TITLE
refactor(lsp): split lib.rs into focused modules

### DIFF
--- a/crates/tsuzulint_lsp/src/config.rs
+++ b/crates/tsuzulint_lsp/src/config.rs
@@ -1,0 +1,48 @@
+//! Configuration management for LSP server.
+
+use tracing::{error, info};
+
+use tsuzulint_core::{Linter, LinterConfig};
+
+use crate::state::BackendState;
+
+/// Reloads configuration from the workspace root.
+pub fn reload_config(state: &BackendState) {
+    let root_guard = match state.workspace_root.read() {
+        Ok(g) => g,
+        Err(e) => {
+            error!("Workspace root lock poisoned: {}", e);
+            return;
+        }
+    };
+
+    let path = match root_guard.as_ref() {
+        Some(p) => p,
+        None => return,
+    };
+
+    if let Some(config_path) = LinterConfig::discover(path) {
+        info!("Found config file: {}", config_path.display());
+        match LinterConfig::from_file(&config_path) {
+            Ok(config) => {
+                info!("Loaded configuration from workspace");
+                match state.linter.write() {
+                    Ok(mut linter_guard) => match Linter::new(config) {
+                        Ok(new_linter) => {
+                            *linter_guard = Some(new_linter);
+                            info!("Linter re-initialized with new config");
+                        }
+                        Err(e) => {
+                            error!("Failed to create new linter: {}", e);
+                            *linter_guard = None;
+                        }
+                    },
+                    Err(e) => error!("Linter lock poisoned: {}", e),
+                }
+            }
+            Err(e) => {
+                error!("Failed to load config: {}", e);
+            }
+        }
+    }
+}

--- a/crates/tsuzulint_lsp/src/conversion.rs
+++ b/crates/tsuzulint_lsp/src/conversion.rs
@@ -1,0 +1,127 @@
+//! LSP type conversion utilities.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
+
+use tsuzulint_core::{Diagnostic as TsuzuLintDiagnostic, Severity as TsuzuLintSeverity};
+
+/// Converts a TsuzuLint diagnostic to an LSP diagnostic.
+pub fn to_lsp_diagnostic(diag: &TsuzuLintDiagnostic, text: &str) -> Option<Diagnostic> {
+    let range = offset_to_range(diag.span.start as usize, diag.span.end as usize, text)?;
+
+    let severity = match diag.severity {
+        TsuzuLintSeverity::Error => DiagnosticSeverity::ERROR,
+        TsuzuLintSeverity::Warning => DiagnosticSeverity::WARNING,
+        TsuzuLintSeverity::Info => DiagnosticSeverity::INFORMATION,
+    };
+
+    Some(Diagnostic {
+        range,
+        severity: Some(severity),
+        code: Some(NumberOrString::String(diag.rule_id.clone())),
+        source: Some("tsuzulint".to_string()),
+        message: diag.message.clone(),
+        ..Default::default()
+    })
+}
+
+/// Converts byte offsets to an LSP range.
+pub fn offset_to_range(start: usize, end: usize, text: &str) -> Option<Range> {
+    let start_pos = offset_to_position(start, text)?;
+    let end_pos = offset_to_position(end, text)?;
+    Some(Range::new(start_pos, end_pos))
+}
+
+/// Converts a byte offset to an LSP position.
+pub fn offset_to_position(offset: usize, text: &str) -> Option<Position> {
+    if offset > text.len() {
+        return None;
+    }
+
+    let mut line = 0u32;
+    let mut col = 0u32;
+    let mut current_offset = 0;
+
+    for ch in text.chars() {
+        if current_offset >= offset {
+            break;
+        }
+
+        if ch == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += ch.len_utf16() as u32;
+        }
+
+        current_offset += ch.len_utf8();
+    }
+
+    Some(Position::new(line, col))
+}
+
+/// Helper to compare Positions (p1 <= p2)
+pub fn positions_le(p1: Position, p2: Position) -> bool {
+    p1.line < p2.line || (p1.line == p2.line && p1.character <= p2.character)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_offset_to_position_basic_ascii() {
+        let text = "Hello World";
+        assert_eq!(offset_to_position(0, text), Some(Position::new(0, 0)));
+        assert_eq!(offset_to_position(5, text), Some(Position::new(0, 5)));
+        assert_eq!(offset_to_position(10, text), Some(Position::new(0, 10)));
+        assert_eq!(offset_to_position(11, text), Some(Position::new(0, 11)));
+        assert_eq!(offset_to_position(12, text), None);
+    }
+
+    #[test]
+    fn test_offset_to_position_multiline() {
+        let text = "Line 1\nLine 2\nLine 3";
+        assert_eq!(offset_to_position(7, text), Some(Position::new(1, 0)));
+        assert_eq!(offset_to_position(20, text), Some(Position::new(2, 6)));
+    }
+
+    #[test]
+    fn test_offset_to_position_unicode_multibyte() {
+        let text = "あいう";
+        assert_eq!(offset_to_position(0, text), Some(Position::new(0, 0)));
+        assert_eq!(offset_to_position(3, text), Some(Position::new(0, 1)));
+        assert_eq!(offset_to_position(6, text), Some(Position::new(0, 2)));
+        assert_eq!(offset_to_position(9, text), Some(Position::new(0, 3)));
+    }
+
+    #[test]
+    fn test_offset_to_position_supplementary_plane_chars() {
+        let text = "a🎉b";
+        assert_eq!(offset_to_position(0, text), Some(Position::new(0, 0)));
+        assert_eq!(offset_to_position(1, text), Some(Position::new(0, 1)));
+        assert_eq!(offset_to_position(5, text), Some(Position::new(0, 3)));
+    }
+
+    #[test]
+    fn test_offset_to_position_empty_string() {
+        assert_eq!(offset_to_position(0, ""), Some(Position::new(0, 0)));
+        assert_eq!(offset_to_position(1, ""), None);
+    }
+
+    #[test]
+    fn test_positions_le() {
+        let p1 = Position::new(0, 5);
+        let p2 = Position::new(0, 10);
+        assert!(positions_le(p1, p2));
+        assert!(!positions_le(p2, p1));
+
+        let p3 = Position::new(1, 0);
+        let p4 = Position::new(2, 5);
+        assert!(positions_le(p3, p4));
+        assert!(!positions_le(p4, p3));
+
+        let p5 = Position::new(0, 5);
+        let p6 = Position::new(0, 5);
+        assert!(positions_le(p5, p6));
+    }
+}

--- a/crates/tsuzulint_lsp/src/debounce.rs
+++ b/crates/tsuzulint_lsp/src/debounce.rs
@@ -1,0 +1,50 @@
+//! Debouncing utilities for LSP notifications.
+
+use std::time::Duration;
+
+use tower_lsp::lsp_types::Url;
+use tracing::error;
+
+use crate::state::{BackendState, SharedState};
+
+/// Default debounce delay in milliseconds.
+pub const DEFAULT_DEBOUNCE_MS: u64 = 300;
+
+/// Spawns a debounced validation task.
+///
+/// This function waits for the debounce period, then checks if the document
+/// version is still the same before triggering validation.
+pub fn spawn_debounced_validation<F>(
+    state: SharedState,
+    uri: Url,
+    text: String,
+    version: i32,
+    validate_fn: F,
+) where
+    F: FnOnce(Url, String, Option<i32>) + Send + 'static,
+{
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(DEFAULT_DEBOUNCE_MS)).await;
+
+        let should_validate = check_version(&state, &uri, version);
+
+        if should_validate {
+            validate_fn(uri, text, Some(version));
+        }
+    });
+}
+
+/// Checks if the document version is still current.
+fn check_version(state: &BackendState, uri: &Url, version: i32) -> bool {
+    let docs = match state.documents.read() {
+        Ok(g) => g,
+        Err(e) => {
+            error!("Documents lock poisoned: {}", e);
+            return false;
+        }
+    };
+
+    docs.get(uri)
+        .map(|doc| doc.version == version)
+        .unwrap_or(false)
+}

--- a/crates/tsuzulint_lsp/src/handler/code_action.rs
+++ b/crates/tsuzulint_lsp/src/handler/code_action.rs
@@ -1,0 +1,126 @@
+//! Code action handler for auto-fix support.
+
+use std::collections::HashMap;
+
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tracing::debug;
+
+use crate::conversion::{offset_to_range, positions_le};
+use crate::state::SharedState;
+use tsuzulint_core::Diagnostic as TsuzuLintDiagnostic;
+
+/// Handles the `textDocument/codeAction` request.
+pub async fn handle_code_action(
+    state: &SharedState,
+    diagnostics: &[TsuzuLintDiagnostic],
+    params: CodeActionParams,
+) -> Result<Option<CodeActionResponse>> {
+    debug!("Code action request: {}", params.text_document.uri);
+
+    let uri = &params.text_document.uri;
+    let text = match get_document_content(state, uri) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let mut actions = Vec::new();
+
+    let (wants_fix_all, wants_quickfix) = match &params.context.only {
+        Some(only) => (
+            only.contains(&CodeActionKind::SOURCE_FIX_ALL),
+            only.contains(&CodeActionKind::QUICKFIX),
+        ),
+        None => (true, true),
+    };
+
+    if wants_fix_all {
+        add_fix_all_actions(diagnostics, &text, uri, &mut actions);
+    }
+
+    if wants_quickfix {
+        add_quickfix_actions(diagnostics, &text, uri, &params.range, &mut actions);
+    }
+
+    Ok(Some(actions))
+}
+
+fn add_fix_all_actions(
+    diagnostics: &[TsuzuLintDiagnostic],
+    text: &str,
+    uri: &Url,
+    actions: &mut Vec<CodeActionOrCommand>,
+) {
+    let mut edits = Vec::new();
+    let mut fixable_diags: Vec<_> = diagnostics.iter().filter(|d| d.fix.is_some()).collect();
+
+    fixable_diags.sort_by(|a, b| b.span.start.cmp(&a.span.start));
+
+    for diag in fixable_diags {
+        if let Some(ref fix) = diag.fix
+            && let Some(range) =
+                offset_to_range(fix.span.start as usize, fix.span.end as usize, text)
+        {
+            edits.push(TextEdit {
+                range,
+                new_text: fix.text.clone(),
+            });
+        }
+    }
+
+    if !edits.is_empty() {
+        let mut changes = HashMap::new();
+        changes.insert(uri.clone(), edits);
+
+        let action = CodeAction {
+            title: "Fix all TsuzuLint issues".to_string(),
+            kind: Some(CodeActionKind::SOURCE_FIX_ALL),
+            edit: Some(WorkspaceEdit {
+                changes: Some(changes),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        actions.push(CodeActionOrCommand::CodeAction(action));
+    }
+}
+
+fn add_quickfix_actions(
+    diagnostics: &[TsuzuLintDiagnostic],
+    text: &str,
+    uri: &Url,
+    request_range: &Range,
+    actions: &mut Vec<CodeActionOrCommand>,
+) {
+    for diag in diagnostics {
+        if let Some(ref fix) = diag.fix
+            && let Some(range) =
+                offset_to_range(fix.span.start as usize, fix.span.end as usize, text)
+            && positions_le(range.start, request_range.end)
+            && positions_le(request_range.start, range.end)
+        {
+            let action = CodeAction {
+                title: format!("Fix: {}", diag.message),
+                kind: Some(CodeActionKind::QUICKFIX),
+                diagnostics: None,
+                edit: Some(WorkspaceEdit {
+                    changes: Some(HashMap::from([(
+                        uri.clone(),
+                        vec![TextEdit {
+                            range,
+                            new_text: fix.text.clone(),
+                        }],
+                    )])),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            actions.push(CodeActionOrCommand::CodeAction(action));
+        }
+    }
+}
+
+fn get_document_content(state: &SharedState, uri: &Url) -> Option<String> {
+    let docs = state.documents.read().ok()?;
+    docs.get(uri).map(|d| d.text.clone())
+}

--- a/crates/tsuzulint_lsp/src/handler/documents.rs
+++ b/crates/tsuzulint_lsp/src/handler/documents.rs
@@ -1,0 +1,95 @@
+//! Document lifecycle handlers (open, change, save, close).
+
+use tower_lsp::lsp_types::*;
+use tracing::{debug, error};
+
+use crate::state::{DocumentData, SharedState};
+
+/// Handles the `textDocument/didOpen` notification.
+pub async fn handle_did_open(
+    state: &SharedState,
+    params: DidOpenTextDocumentParams,
+) -> (Url, String, Option<i32>) {
+    debug!("Document opened: {}", params.text_document.uri);
+
+    {
+        let mut docs = match state.documents.write() {
+            Ok(guard) => guard,
+            Err(e) => {
+                error!("Documents lock poisoned: {}", e);
+                return (params.text_document.uri, String::new(), None);
+            }
+        };
+        docs.insert(
+            params.text_document.uri.clone(),
+            DocumentData {
+                text: params.text_document.text.clone(),
+                version: params.text_document.version,
+            },
+        );
+    }
+
+    (
+        params.text_document.uri,
+        params.text_document.text,
+        Some(params.text_document.version),
+    )
+}
+
+/// Handles the `textDocument/didChange` notification.
+///
+/// Returns the URI, text, and version for debounced validation.
+pub async fn handle_did_change(
+    state: &SharedState,
+    params: DidChangeTextDocumentParams,
+) -> Option<(Url, String, i32)> {
+    debug!("Document changed: {}", params.text_document.uri);
+
+    let change = params.content_changes.into_iter().next()?;
+    let uri = params.text_document.uri.clone();
+    let version = params.text_document.version;
+    let text = change.text;
+
+    {
+        let mut docs = match state.documents.write() {
+            Ok(guard) => guard,
+            Err(e) => {
+                error!("Documents lock poisoned: {}", e);
+                return None;
+            }
+        };
+        docs.insert(
+            uri.clone(),
+            DocumentData {
+                text: text.clone(),
+                version,
+            },
+        );
+    }
+
+    Some((uri, text, version))
+}
+
+/// Handles the `textDocument/didSave` notification.
+pub async fn handle_did_save(params: DidSaveTextDocumentParams) -> (Url, Option<String>) {
+    debug!("Document saved: {}", params.text_document.uri);
+    (params.text_document.uri, params.text)
+}
+
+/// Handles the `textDocument/didClose` notification.
+pub async fn handle_did_close(state: &SharedState, params: DidCloseTextDocumentParams) -> Url {
+    debug!("Document closed: {}", params.text_document.uri);
+
+    {
+        let mut docs = match state.documents.write() {
+            Ok(guard) => guard,
+            Err(e) => {
+                error!("Documents lock poisoned: {}", e);
+                return params.text_document.uri;
+            }
+        };
+        docs.remove(&params.text_document.uri);
+    }
+
+    params.text_document.uri
+}

--- a/crates/tsuzulint_lsp/src/handler/files.rs
+++ b/crates/tsuzulint_lsp/src/handler/files.rs
@@ -1,0 +1,27 @@
+//! Watched files handler.
+
+use tower_lsp::lsp_types::*;
+use tracing::{debug, info};
+
+use crate::config::reload_config;
+use crate::state::BackendState;
+
+/// Handles the `workspace/didChangeWatchedFiles` notification.
+pub async fn handle_did_change_watched_files(
+    state: &BackendState,
+    params: DidChangeWatchedFilesParams,
+) {
+    debug!("Watched files changed: {:?}", params.changes);
+
+    let config_changed = params.changes.iter().any(|change| {
+        let path = change.uri.path();
+        tsuzulint_core::LinterConfig::CONFIG_FILES
+            .iter()
+            .any(|name| path.ends_with(name))
+    });
+
+    if config_changed {
+        info!("Configuration file changed, reloading...");
+        reload_config(state);
+    }
+}

--- a/crates/tsuzulint_lsp/src/handler/initialize.rs
+++ b/crates/tsuzulint_lsp/src/handler/initialize.rs
@@ -1,0 +1,73 @@
+//! Initialize and shutdown handlers.
+
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tracing::info;
+
+use crate::config::reload_config;
+use crate::state::BackendState;
+
+/// Handles the `initialize` LSP request.
+pub async fn handle_initialize(
+    state: &BackendState,
+    _client: &tower_lsp::Client,
+    params: InitializeParams,
+) -> Result<InitializeResult> {
+    info!("TsuzuLint LSP server initializing...");
+
+    if let Some(path) = params.root_uri.and_then(|u| u.to_file_path().ok()) {
+        match state.workspace_root.write() {
+            Ok(mut root) => {
+                *root = Some(path);
+            }
+            Err(e) => {
+                tracing::error!("Workspace root lock poisoned: {}", e);
+                return Ok(InitializeResult::default());
+            }
+        }
+
+        reload_config(state);
+    }
+
+    Ok(InitializeResult {
+        capabilities: ServerCapabilities {
+            text_document_sync: Some(TextDocumentSyncCapability::Options(
+                TextDocumentSyncOptions {
+                    open_close: Some(true),
+                    change: Some(TextDocumentSyncKind::FULL),
+                    save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                        include_text: Some(true),
+                    })),
+                    ..Default::default()
+                },
+            )),
+            code_action_provider: Some(CodeActionProviderCapability::Options(CodeActionOptions {
+                code_action_kinds: Some(vec![
+                    CodeActionKind::QUICKFIX,
+                    CodeActionKind::SOURCE_FIX_ALL,
+                ]),
+                resolve_provider: Some(false),
+                work_done_progress_options: Default::default(),
+            })),
+            document_symbol_provider: Some(OneOf::Left(true)),
+            ..Default::default()
+        },
+        server_info: Some(ServerInfo {
+            name: "tsuzulint-lsp".to_string(),
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        }),
+    })
+}
+
+/// Handles the `initialized` LSP notification.
+pub async fn handle_initialized(client: &tower_lsp::Client) {
+    client
+        .log_message(MessageType::INFO, "TsuzuLint LSP server initialized!")
+        .await;
+}
+
+/// Handles the `shutdown` LSP request.
+pub async fn handle_shutdown() -> Result<()> {
+    info!("TsuzuLint LSP server shutting down...");
+    Ok(())
+}

--- a/crates/tsuzulint_lsp/src/handler/mod.rs
+++ b/crates/tsuzulint_lsp/src/handler/mod.rs
@@ -1,0 +1,13 @@
+//! LSP request/notification handlers.
+
+mod code_action;
+mod documents;
+mod files;
+mod initialize;
+mod symbols;
+
+pub use code_action::handle_code_action;
+pub use documents::{handle_did_change, handle_did_close, handle_did_open, handle_did_save};
+pub use files::handle_did_change_watched_files;
+pub use initialize::{handle_initialize, handle_initialized, handle_shutdown};
+pub use symbols::handle_document_symbol;

--- a/crates/tsuzulint_lsp/src/handler/symbols.rs
+++ b/crates/tsuzulint_lsp/src/handler/symbols.rs
@@ -1,0 +1,128 @@
+//! Document symbol extraction for outline view.
+
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+use tracing::{debug, error};
+
+use tsuzulint_ast::{AstArena, NodeType, TxtNode};
+use tsuzulint_parser::{MarkdownParser, Parser, PlainTextParser};
+
+use crate::conversion::offset_to_range;
+use crate::state::SharedState;
+
+/// Handles the `textDocument/documentSymbol` request.
+pub async fn handle_document_symbol(
+    state: &SharedState,
+    params: DocumentSymbolParams,
+) -> Result<Option<DocumentSymbolResponse>> {
+    debug!("Document symbol request: {}", params.text_document.uri);
+
+    let uri = &params.text_document.uri;
+    let text = match get_document_content(state, uri) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let path = match uri.to_file_path() {
+        Ok(p) => p,
+        Err(_) => std::path::PathBuf::from("untitled"),
+    };
+
+    let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let parser: Box<dyn Parser> = if extension == "md" || extension == "markdown" {
+        Box::new(MarkdownParser::new())
+    } else {
+        Box::new(PlainTextParser::new())
+    };
+
+    let arena = AstArena::new();
+    let ast = match parser.parse(&arena, &text) {
+        Ok(ast) => ast,
+        Err(e) => {
+            error!("Failed to parse document for symbols: {}", e);
+            return Ok(None);
+        }
+    };
+
+    let symbols = SymbolExtractor::new(&text).extract(&ast);
+    Ok(Some(DocumentSymbolResponse::Nested(symbols)))
+}
+
+/// Symbol extractor utility.
+pub struct SymbolExtractor<'a> {
+    text: &'a str,
+}
+
+impl<'a> SymbolExtractor<'a> {
+    /// Creates a new symbol extractor.
+    pub fn new(text: &'a str) -> Self {
+        Self { text }
+    }
+
+    /// Extracts document symbols from the AST.
+    pub fn extract(&self, node: &TxtNode) -> Vec<DocumentSymbol> {
+        let mut symbols = Vec::new();
+
+        for child in node.children.iter() {
+            let symbol_kind = match child.node_type {
+                NodeType::Header => SymbolKind::STRING,
+                NodeType::CodeBlock => SymbolKind::FUNCTION,
+                _ => continue,
+            };
+
+            let mut detail = String::new();
+            if child.node_type == NodeType::Header {
+                self.collect_text(child, &mut detail);
+            } else if child.node_type == NodeType::CodeBlock {
+                detail = "Code Block".to_string();
+            }
+
+            if let Some(range) = offset_to_range(
+                child.span.start as usize,
+                child.span.end as usize,
+                self.text,
+            ) {
+                let selection_range = range;
+
+                #[allow(deprecated)]
+                let symbol = DocumentSymbol {
+                    name: if detail.is_empty() {
+                        format!("{}", child.node_type)
+                    } else {
+                        detail
+                    },
+                    detail: None,
+                    kind: symbol_kind,
+                    tags: None,
+                    deprecated: None,
+                    range,
+                    selection_range,
+                    children: None,
+                };
+
+                symbols.push(symbol);
+            }
+        }
+
+        symbols
+    }
+
+    /// Recursively collects text from Str nodes.
+    fn collect_text(&self, node: &TxtNode, out: &mut String) {
+        if node.node_type == NodeType::Str {
+            let start = node.span.start as usize;
+            let end = node.span.end as usize;
+            if start <= end && end <= self.text.len() {
+                out.push_str(&self.text[start..end]);
+            }
+        }
+        for child in node.children.iter() {
+            self.collect_text(child, out);
+        }
+    }
+}
+
+fn get_document_content(state: &SharedState, uri: &Url) -> Option<String> {
+    let docs = state.documents.read().ok()?;
+    docs.get(uri).map(|d| d.text.clone())
+}

--- a/crates/tsuzulint_lsp/src/lib.rs
+++ b/crates/tsuzulint_lsp/src/lib.rs
@@ -3,8 +3,13 @@
 //! Language Server Protocol implementation for TsuzuLint.
 //! Provides real-time linting in editors.
 
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+mod config;
+mod conversion;
+mod debounce;
+mod handler;
+mod state;
+
+use std::sync::Arc;
 
 #[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -17,25 +22,16 @@ use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 use tracing::{debug, error, info};
 
-use tsuzulint_ast::{AstArena, NodeType, TxtNode};
-use tsuzulint_core::{
-    Diagnostic as TsuzuLintDiagnostic, Linter, LinterConfig, Severity as TsuzuLintSeverity,
+use tsuzulint_core::{Diagnostic as TsuzuLintDiagnostic, Linter, LinterConfig};
+
+use conversion::to_lsp_diagnostic;
+use debounce::spawn_debounced_validation;
+use handler::{
+    handle_code_action, handle_did_change, handle_did_change_watched_files, handle_did_close,
+    handle_did_open, handle_did_save, handle_document_symbol, handle_initialize,
+    handle_initialized, handle_shutdown,
 };
-use tsuzulint_parser::{MarkdownParser, Parser, PlainTextParser};
-
-struct DocumentData {
-    text: String,
-    version: i32,
-}
-
-pub(crate) struct BackendState {
-    /// Document contents cache.
-    documents: RwLock<HashMap<Url, DocumentData>>,
-    /// Linter instance (may be None if initialization failed).
-    linter: RwLock<Option<Linter>>,
-    /// Workspace root path.
-    workspace_root: RwLock<Option<std::path::PathBuf>>,
-}
+use state::{BackendState, SharedState};
 
 /// The LSP backend for TsuzuLint.
 #[derive(Clone)]
@@ -43,20 +39,16 @@ pub struct Backend {
     /// LSP client for sending notifications.
     client: Client,
     /// Shared state
-    state: Arc<BackendState>,
+    state: SharedState,
 }
 
 impl Backend {
     /// Creates a new backend with the given client.
     pub fn new(client: Client) -> Self {
-        // Initialize linter with default config
-        // Real config will be loaded during `initialize` if available
         let config = LinterConfig::new();
         let linter = match Linter::new(config) {
             Ok(l) => Some(l),
             Err(e) => {
-                // Log error and set linter to None
-                // The LSP will continue to work but without linting capabilities
                 error!(
                     "Failed to initialize linter: {}. LSP will run without linting.",
                     e
@@ -67,16 +59,12 @@ impl Backend {
 
         Self {
             client,
-            state: Arc::new(BackendState {
-                documents: RwLock::new(HashMap::new()),
-                linter: RwLock::new(linter),
-                workspace_root: RwLock::new(None),
-            }),
+            state: Arc::new(BackendState::with_linter(linter)),
         }
     }
 
     /// Validates a document and publishes diagnostics.
-    async fn validate_document(&self, uri: &Url, text: &str, version: Option<i32>) {
+    async fn validate_document(&self, uri: Url, text: String, version: Option<i32>) {
         debug!("Validating document: {}", uri);
 
         let path = match uri.to_file_path() {
@@ -87,30 +75,25 @@ impl Backend {
             }
         };
 
-        let diagnostics = self.lint_text(text, &path).await;
+        let diagnostics = self.lint_text(&text, &path).await;
 
-        // Convert to LSP diagnostics
         let lsp_diagnostics: Vec<Diagnostic> = diagnostics
             .into_iter()
-            .filter_map(|d| self.to_lsp_diagnostic(&d, text))
+            .filter_map(|d| to_lsp_diagnostic(&d, &text))
             .collect();
 
         self.client
-            .publish_diagnostics(uri.clone(), lsp_diagnostics, version)
+            .publish_diagnostics(uri, lsp_diagnostics, version)
             .await;
     }
 
     /// Lints text and returns TsuzuLint diagnostics.
-    ///
-    /// This method offloads the blocking lint operation to `spawn_blocking`
-    /// to avoid blocking the async runtime.
     async fn lint_text(&self, text: &str, path: &std::path::Path) -> Vec<TsuzuLintDiagnostic> {
         let state = self.state.clone();
         let text = text.to_string();
         let path = path.to_path_buf();
 
         tokio::task::spawn_blocking(move || {
-            // Simulate load for testing (injected delay via static)
             #[cfg(test)]
             {
                 let delay_ms = TEST_LINT_DELAY_MS.load(Ordering::Relaxed);
@@ -119,7 +102,6 @@ impl Backend {
                 }
             }
 
-            // Safely acquire read lock, handling potential poisoning
             let linter_guard = match state.linter.read() {
                 Ok(guard) => guard,
                 Err(poisoned) => {
@@ -128,7 +110,6 @@ impl Backend {
                 }
             };
 
-            // Check if linter is available
             let linter = match linter_guard.as_ref() {
                 Some(l) => l,
                 None => {
@@ -152,175 +133,6 @@ impl Backend {
         })
     }
 
-    /// Converts a TsuzuLint diagnostic to an LSP diagnostic.
-    fn to_lsp_diagnostic(&self, diag: &TsuzuLintDiagnostic, text: &str) -> Option<Diagnostic> {
-        let range = self.offset_to_range(diag.span.start as usize, diag.span.end as usize, text)?;
-
-        let severity = match diag.severity {
-            TsuzuLintSeverity::Error => DiagnosticSeverity::ERROR,
-            TsuzuLintSeverity::Warning => DiagnosticSeverity::WARNING,
-            TsuzuLintSeverity::Info => DiagnosticSeverity::INFORMATION,
-        };
-
-        Some(Diagnostic {
-            range,
-            severity: Some(severity),
-            code: Some(NumberOrString::String(diag.rule_id.clone())),
-            source: Some("tsuzulint".to_string()),
-            message: diag.message.clone(),
-            ..Default::default()
-        })
-    }
-
-    /// Converts byte offsets to an LSP range.
-    fn offset_to_range(&self, start: usize, end: usize, text: &str) -> Option<Range> {
-        let start_pos = Self::offset_to_position(start, text)?;
-        let end_pos = Self::offset_to_position(end, text)?;
-        Some(Range::new(start_pos, end_pos))
-    }
-
-    /// Converts a byte offset to an LSP position.
-    fn offset_to_position(offset: usize, text: &str) -> Option<Position> {
-        if offset > text.len() {
-            return None;
-        }
-
-        let mut line = 0u32;
-        let mut col = 0u32;
-        let mut current_offset = 0;
-
-        for ch in text.chars() {
-            if current_offset >= offset {
-                break;
-            }
-
-            if ch == '\n' {
-                line += 1;
-                col = 0;
-            } else {
-                col += ch.len_utf16() as u32;
-            }
-
-            current_offset += ch.len_utf8();
-        }
-
-        Some(Position::new(line, col))
-    }
-
-    /// Helper to compare Positions (p1 <= p2)
-    fn positions_le(&self, p1: Position, p2: Position) -> bool {
-        p1.line < p2.line || (p1.line == p2.line && p1.character <= p2.character)
-    }
-
-    /// Extracts document symbols from AST.
-    fn extract_symbols(&self, node: &TxtNode, text: &str) -> Vec<DocumentSymbol> {
-        let mut symbols = Vec::new();
-
-        // We only care about specific block elements for the outline
-        for child in node.children.iter() {
-            let symbol_kind = match child.node_type {
-                // H1 -> File/Class, H2 -> Method/Module. Using String for now.
-                NodeType::Header => SymbolKind::STRING,
-                NodeType::CodeBlock => SymbolKind::FUNCTION,
-                _ => continue,
-            };
-
-            // Extract details (e.g., header text)
-            let mut detail = String::new();
-            if child.node_type == NodeType::Header {
-                // Collect text children
-                self.collect_text(child, &mut detail, text);
-            } else if child.node_type == NodeType::CodeBlock {
-                detail = "Code Block".to_string();
-            }
-
-            // Convert range
-            if let Some(range) =
-                self.offset_to_range(child.span.start as usize, child.span.end as usize, text)
-            {
-                // For selection range, ideally we want just the header text, but full range is fine for now
-                let selection_range = range;
-
-                #[allow(deprecated)]
-                let symbol = DocumentSymbol {
-                    name: if detail.is_empty() {
-                        format!("{}", child.node_type)
-                    } else {
-                        detail
-                    },
-                    detail: None,
-                    kind: symbol_kind,
-                    tags: None,
-                    deprecated: None,
-                    range,
-                    selection_range,
-                    children: None, // Flat list for now
-                };
-
-                symbols.push(symbol);
-            }
-        }
-
-        symbols
-    }
-
-    fn collect_text(&self, node: &TxtNode, out: &mut String, source: &str) {
-        if node.node_type == NodeType::Str {
-            let start = node.span.start as usize;
-            let end = node.span.end as usize;
-            if start <= end && end <= source.len() {
-                out.push_str(&source[start..end]);
-            }
-        }
-        for child in node.children.iter() {
-            self.collect_text(child, out, source);
-        }
-    }
-
-    /// Reloads configuration from the workspace root.
-    fn reload_config(&self) {
-        let root_guard = match self.state.workspace_root.read() {
-            Ok(g) => g,
-            Err(e) => {
-                error!("Workspace root lock poisoned: {}", e);
-                return;
-            }
-        };
-
-        let path = match root_guard.as_ref() {
-            Some(p) => p,
-            None => {
-                // No root path, cannot load config
-                return;
-            }
-        };
-
-        if let Some(config_path) = LinterConfig::discover(path) {
-            info!("Found config file: {}", config_path.display());
-            match LinterConfig::from_file(&config_path) {
-                Ok(config) => {
-                    info!("Loaded configuration from workspace");
-                    match self.state.linter.write() {
-                        Ok(mut linter_guard) => match Linter::new(config) {
-                            Ok(new_linter) => {
-                                *linter_guard = Some(new_linter);
-                                info!("Linter re-initialized with new config");
-                            }
-                            Err(e) => {
-                                error!("Failed to create new linter: {}", e);
-                                *linter_guard = None;
-                            }
-                        },
-                        Err(e) => error!("Linter lock poisoned: {}", e),
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to load config: {}", e);
-                }
-            }
-        }
-    }
-
     /// Sets a simulated delay for lint_text (test only, global state).
     #[cfg(test)]
     pub fn set_global_test_delay(delay: std::time::Duration) {
@@ -331,381 +143,91 @@ impl Backend {
 #[tower_lsp::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        info!("TsuzuLint LSP server initializing...");
-
-        if let Some(path) = params.root_uri.and_then(|u| u.to_file_path().ok()) {
-            // Store workspace root
-            {
-                match self.state.workspace_root.write() {
-                    Ok(mut root) => {
-                        *root = Some(path);
-                    }
-                    Err(e) => {
-                        error!("Workspace root lock poisoned: {}", e);
-                        return Ok(InitializeResult::default());
-                    }
-                }
-            }
-
-            // Initial config load
-            self.reload_config();
-        }
-
-        Ok(InitializeResult {
-            capabilities: ServerCapabilities {
-                text_document_sync: Some(TextDocumentSyncCapability::Options(
-                    TextDocumentSyncOptions {
-                        open_close: Some(true),
-                        change: Some(TextDocumentSyncKind::FULL),
-                        save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
-                            include_text: Some(true),
-                        })),
-                        ..Default::default()
-                    },
-                )),
-                // Code action support for auto-fix
-                code_action_provider: Some(CodeActionProviderCapability::Options(
-                    CodeActionOptions {
-                        code_action_kinds: Some(vec![
-                            CodeActionKind::QUICKFIX,
-                            CodeActionKind::SOURCE_FIX_ALL,
-                        ]),
-                        resolve_provider: Some(false),
-                        work_done_progress_options: Default::default(),
-                    },
-                )),
-                // Document symbol support
-                document_symbol_provider: Some(OneOf::Left(true)),
-                ..Default::default()
-            },
-            server_info: Some(ServerInfo {
-                name: "tsuzulint-lsp".to_string(),
-                version: Some(env!("CARGO_PKG_VERSION").to_string()),
-            }),
-        })
+        handle_initialize(&self.state, &self.client, params).await
     }
 
     async fn initialized(&self, _: InitializedParams) {
-        self.client
-            .log_message(MessageType::INFO, "TsuzuLint LSP server initialized!")
-            .await;
+        handle_initialized(&self.client).await;
     }
 
     async fn shutdown(&self) -> Result<()> {
-        info!("TsuzuLint LSP server shutting down...");
-        Ok(())
+        handle_shutdown().await
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
-        debug!("Document opened: {}", params.text_document.uri);
+        let (uri, text, version) = handle_did_open(&self.state, params).await;
 
-        // Store document content
-        {
-            let mut docs = match self.state.documents.write() {
-                Ok(guard) => guard,
-                Err(e) => {
-                    error!("Documents lock poisoned: {}", e);
-                    return;
-                }
-            };
-            docs.insert(
-                params.text_document.uri.clone(),
-                DocumentData {
-                    text: params.text_document.text.clone(),
-                    version: params.text_document.version,
-                },
-            );
-        }
-
-        // Validate on open
-        self.validate_document(
-            &params.text_document.uri,
-            &params.text_document.text,
-            Some(params.text_document.version),
-        )
-        .await;
+        self.validate_document(uri, text, version).await;
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
-        debug!("Document changed: {}", params.text_document.uri);
-
-        // Get the full text (we use FULL sync)
-        if let Some(change) = params.content_changes.into_iter().next() {
-            let uri = params.text_document.uri.clone();
-            let version = params.text_document.version;
-            let text = change.text;
-
-            // Update stored content
-            {
-                let mut docs = match self.state.documents.write() {
-                    Ok(guard) => guard,
-                    Err(e) => {
-                        error!("Documents lock poisoned: {}", e);
-                        return;
-                    }
-                };
-                docs.insert(
-                    uri.clone(),
-                    DocumentData {
-                        text: text.clone(),
-                        version,
-                    },
-                );
-            }
-
-            // Debounce validation
-            // Clone self to move into the async block (Backend catches Arc<BackendState> internally)
+        if let Some((uri, text, version)) = handle_did_change(&self.state, params).await {
             let backend = self.clone();
 
-            tokio::spawn(async move {
-                tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-
-                // Check version
-                let should_validate = {
-                    let docs = match backend.state.documents.read() {
-                        Ok(g) => g,
-                        Err(e) => {
-                            error!("Documents lock poisoned: {}", e);
-                            return;
-                        }
-                    };
-                    if let Some(doc) = docs.get(&uri) {
-                        doc.version == version
-                    } else {
-                        false
-                    }
-                };
-
-                if should_validate {
-                    backend.validate_document(&uri, &text, Some(version)).await;
-                }
-            });
+            spawn_debounced_validation(
+                self.state.clone(),
+                uri.clone(),
+                text.clone(),
+                version,
+                move |u, t, v| {
+                    let backend = backend.clone();
+                    tokio::spawn(async move {
+                        backend.validate_document(u, t, v).await;
+                    });
+                },
+            );
         }
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
-        debug!("Document saved: {}", params.text_document.uri);
+        let (uri, text_opt) = handle_did_save(params).await;
 
-        if let Some(text) = params.text {
-            self.validate_document(&params.text_document.uri, &text, None)
-                .await;
+        if let Some(text) = text_opt {
+            self.validate_document(uri, text, None).await;
         }
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
-        debug!("Watched files changed: {:?}", params.changes);
-
-        // Check if any config files changed
-        let config_changed = params.changes.iter().any(|change| {
-            let path = change.uri.path();
-            LinterConfig::CONFIG_FILES
-                .iter()
-                .any(|name| path.ends_with(name))
-        });
-
-        if config_changed {
-            info!("Configuration file changed, reloading...");
-            self.reload_config();
-        }
+        handle_did_change_watched_files(&self.state, params).await;
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
-        debug!("Document closed: {}", params.text_document.uri);
+        let uri = handle_did_close(&self.state, params).await;
 
-        // Remove from cache
-        {
-            let mut docs = match self.state.documents.write() {
-                Ok(guard) => guard,
-                Err(e) => {
-                    error!("Documents lock poisoned: {}", e);
-                    return;
-                }
-            };
-            docs.remove(&params.text_document.uri);
-        }
-
-        // Clear diagnostics
-        self.client
-            .publish_diagnostics(params.text_document.uri, vec![], None)
-            .await;
+        self.client.publish_diagnostics(uri, vec![], None).await;
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
-        debug!("Code action request: {}", params.text_document.uri);
-
-        // Get document content
-        let uri = &params.text_document.uri;
+        let state = self.state.clone();
         let text = {
-            let docs = match self.state.documents.read() {
+            let docs = match state.documents.read() {
                 Ok(guard) => guard,
                 Err(e) => {
                     error!("Documents lock poisoned: {}", e);
                     return Ok(None);
                 }
             };
-            match docs.get(uri) {
+            match docs.get(&params.text_document.uri) {
                 Some(data) => data.text.clone(),
                 None => return Ok(None),
             }
         };
+        let path = params.text_document.uri.to_file_path().ok();
 
-        let path = match uri.to_file_path() {
-            Ok(p) => p,
-            Err(_) => return Ok(None),
-        };
+        let diagnostics = self.lint_text(&text, path.as_ref().unwrap()).await;
 
-        // Re-run linting to get diagnostics with fixes
-        // Note: In a real implementation, we should cache diagnostics map to avoid re-linting
-        let diagnostics = self.lint_text(&text, &path).await;
-
-        let mut actions = Vec::new();
-
-        // Calculate which action kinds are requested
-        // If `only` is None, all action kinds are allowed (per LSP spec)
-        let (wants_fix_all, wants_quickfix) = match &params.context.only {
-            Some(only) => (
-                only.contains(&CodeActionKind::SOURCE_FIX_ALL),
-                only.contains(&CodeActionKind::QUICKFIX),
-            ),
-            None => (true, true),
-        };
-
-        // Handle SourceFixAll
-        if wants_fix_all {
-            let mut changes = HashMap::new();
-            let mut edits = Vec::new();
-
-            // Apply all available fixes
-            // We need to be careful about overlapping ranges.
-            // Simple approach: Sort by position (descending) and apply.
-            // Ideally, we should use tsuzulint_core::fixer, but here we construct TextEdits.
-
-            let mut fixable_diags: Vec<_> =
-                diagnostics.iter().filter(|d| d.fix.is_some()).collect();
-
-            // Sort descending by start position to avoid offset shifting issues if applied sequentially
-            // But LSP TextEdits are applied simultaneously by the client, so standard order often doesn't matter
-            // IF ranges don't overlap. If they overlap, it's a conflict.
-            // We assume rule-generated fixes don't usually overlap for different rules, OR we take one.
-
-            fixable_diags.sort_by(|a, b| b.span.start.cmp(&a.span.start));
-
-            for diag in fixable_diags {
-                if let Some(ref fix) = diag.fix
-                    && let Some(range) =
-                        self.offset_to_range(fix.span.start as usize, fix.span.end as usize, &text)
-                {
-                    edits.push(TextEdit {
-                        range,
-                        new_text: fix.text.clone(),
-                    });
-                }
-            }
-
-            if !edits.is_empty() {
-                changes.insert(uri.clone(), edits);
-
-                let action = CodeAction {
-                    title: "Fix all TsuzuLint issues".to_string(),
-                    kind: Some(CodeActionKind::SOURCE_FIX_ALL),
-                    edit: Some(WorkspaceEdit {
-                        changes: Some(changes),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                };
-                actions.push(CodeActionOrCommand::CodeAction(action));
-            }
-        }
-
-        // Generate QUICKFIX actions for diagnostics in the requested range
-        if !wants_quickfix {
-            return Ok(Some(actions));
-        }
-
-        for diag in &diagnostics {
-            if let Some(ref fix) = diag.fix
-                && let Some(range) =
-                    self.offset_to_range(fix.span.start as usize, fix.span.end as usize, &text)
-                && self.positions_le(range.start, params.range.end)
-                && self.positions_le(params.range.start, range.end)
-            {
-                let action = CodeAction {
-                    title: format!("Fix: {}", diag.message),
-                    kind: Some(CodeActionKind::QUICKFIX),
-                    diagnostics: None,
-                    edit: Some(WorkspaceEdit {
-                        changes: Some(HashMap::from([(
-                            uri.clone(),
-                            vec![TextEdit {
-                                range,
-                                new_text: fix.text.clone(),
-                            }],
-                        )])),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                };
-                actions.push(CodeActionOrCommand::CodeAction(action));
-            }
-        }
-
-        Ok(Some(actions))
+        handle_code_action(&self.state, &diagnostics, params).await
     }
 
     async fn document_symbol(
         &self,
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
-        debug!("Document symbol request: {}", params.text_document.uri);
-
-        let uri = &params.text_document.uri;
-        let text = {
-            let docs = match self.state.documents.read() {
-                Ok(guard) => guard,
-                Err(e) => {
-                    error!("Documents lock poisoned: {}", e);
-                    return Ok(None);
-                }
-            };
-            match docs.get(uri) {
-                Some(data) => data.text.clone(),
-                None => return Ok(None),
-            }
-        };
-
-        // We need to parse the document to get symbols
-        let path = match uri.to_file_path() {
-            Ok(p) => p,
-            Err(_) => std::path::PathBuf::from("untitled"),
-        };
-
-        // Select parser
-        let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-        let parser: Box<dyn Parser> = if extension == "md" || extension == "markdown" {
-            Box::new(MarkdownParser::new())
-        } else {
-            // For plain text, maybe no symbols? Or just return None
-            Box::new(PlainTextParser::new())
-        };
-
-        let arena = AstArena::new();
-        let ast = match parser.parse(&arena, &text) {
-            Ok(ast) => ast,
-            Err(e) => {
-                error!("Failed to parse document for symbols: {}", e);
-                return Ok(None);
-            }
-        };
-
-        let symbols = self.extract_symbols(&ast, &text);
-        Ok(Some(DocumentSymbolResponse::Nested(symbols)))
+        handle_document_symbol(&self.state, params).await
     }
 }
 
 /// Starts the LSP server.
-///
-/// This function does not return unless an error occurs or the server shuts down.
 pub async fn run() {
     info!("TsuzuLint LSP server starting...");
 
@@ -721,13 +243,9 @@ mod tests {
     use super::*;
     use tokio::sync::Mutex;
 
-    // Define a global Mutex to serialize tests that manipulate TEST_LINT_DELAY_MS
     static TEST_MUTEX: Mutex<()> = Mutex::const_new(());
 
-    // Include the common test module content directly
     include!("../tests/common_mod.rs");
-
-    use tower_lsp::lsp_types::Position;
 
     struct DelayGuard;
     impl Drop for DelayGuard {
@@ -738,7 +256,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_delay_guard_resets_delay() {
-        // Acquire lock to prevent race conditions with other tests using TEST_LINT_DELAY_MS
         let _lock = TEST_MUTEX.lock().await;
 
         Backend::set_global_test_delay(std::time::Duration::from_millis(50));
@@ -749,116 +266,20 @@ mod tests {
         assert_eq!(TEST_LINT_DELAY_MS.load(Ordering::Relaxed), 0);
     }
 
-    #[test]
-    fn test_offset_to_position_basic_ascii() {
-        let text = "Hello World";
-        assert_eq!(
-            Backend::offset_to_position(0, text),
-            Some(Position::new(0, 0))
-        );
-        assert_eq!(
-            Backend::offset_to_position(5, text),
-            Some(Position::new(0, 5))
-        );
-        assert_eq!(
-            Backend::offset_to_position(10, text),
-            Some(Position::new(0, 10))
-        );
-        assert_eq!(
-            Backend::offset_to_position(11, text),
-            Some(Position::new(0, 11))
-        );
-        assert_eq!(Backend::offset_to_position(12, text), None);
-    }
-
-    #[test]
-    fn test_offset_to_position_multiline() {
-        let text = "Line 1\nLine 2\nLine 3";
-        assert_eq!(
-            Backend::offset_to_position(7, text),
-            Some(Position::new(1, 0))
-        );
-        assert_eq!(
-            Backend::offset_to_position(20, text),
-            Some(Position::new(2, 6))
-        );
-    }
-
-    #[test]
-    fn test_offset_to_position_unicode_multibyte() {
-        // 'あ' is 3 bytes in UTF-8, 1 code unit in UTF-16
-        let text = "あいう";
-        assert_eq!(
-            Backend::offset_to_position(0, text),
-            Some(Position::new(0, 0))
-        );
-        assert_eq!(
-            Backend::offset_to_position(3, text),
-            Some(Position::new(0, 1))
-        );
-        assert_eq!(
-            Backend::offset_to_position(6, text),
-            Some(Position::new(0, 2))
-        );
-        assert_eq!(
-            Backend::offset_to_position(9, text),
-            Some(Position::new(0, 3))
-        );
-    }
-
-    #[test]
-    fn test_offset_to_position_supplementary_plane_chars() {
-        // '🎉' is 4 bytes in UTF-8, 2 code units in UTF-16
-        let text = "a🎉b";
-        assert_eq!(
-            Backend::offset_to_position(0, text),
-            Some(Position::new(0, 0))
-        ); // 'a'
-        assert_eq!(
-            Backend::offset_to_position(1, text),
-            Some(Position::new(0, 1))
-        ); // '🎉'
-        assert_eq!(
-            Backend::offset_to_position(5, text),
-            Some(Position::new(0, 3))
-        ); // 'b'
-    }
-
-    #[test]
-    fn test_offset_to_position_empty_string() {
-        assert_eq!(
-            Backend::offset_to_position(0, ""),
-            Some(Position::new(0, 0))
-        );
-        assert_eq!(Backend::offset_to_position(1, ""), None);
-    }
-
-    /// Tests that lint_text does not block the async runtime.
-    ///
-    /// Strategy:
-    /// 1. Inject a 100ms delay into lint_text
-    /// 2. Open 3 documents in parallel via LSP protocol
-    /// 3. If blocking: total time ~300ms (sequential execution)
-    /// 4. If non-blocking: total time ~100ms + overhead (parallel execution)
     #[tokio::test]
     async fn test_lint_text_does_not_block_runtime() {
         use std::time::{Duration, Instant};
 
-        // Acquire lock to prevent race conditions with other tests using TEST_LINT_DELAY_MS
         let _lock = TEST_MUTEX.lock().await;
-
         let _guard = DelayGuard;
 
-        // Set test delay (100ms per lint operation)
         Backend::set_global_test_delay(Duration::from_millis(100));
 
-        // Create LSP server pipes
         let (client_read, server_write) = tokio::io::duplex(4096);
         let (server_read, client_write) = tokio::io::duplex(4096);
 
         let (service, socket) = LspService::new(Backend::new);
 
-        // Start server in background
         let _server_handle = tokio::spawn(async move {
             tower_lsp::Server::new(server_read, server_write, socket)
                 .serve(service)
@@ -868,7 +289,6 @@ mod tests {
         let mut reader = tokio::io::BufReader::new(client_read);
         let mut writer = client_write;
 
-        // Channel to collect responses
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         tokio::spawn(async move {
             while let Some(msg) = recv_msg(&mut reader).await {
@@ -878,12 +298,10 @@ mod tests {
             }
         });
 
-        // Setup
         let temp_dir = tempfile::tempdir().unwrap();
         let root_path = temp_dir.path();
         let root_uri = Url::from_file_path(root_path).unwrap();
 
-        // Initialize
         let init_req = format!(
             r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"rootUri":"{}","capabilities":{{}}}}}}"#,
             root_uri
@@ -891,14 +309,11 @@ mod tests {
         send_msg(&mut writer, &init_req).await;
         let _resp = rx.recv().await.unwrap();
 
-        // Initialized
         let initialized_notif = r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#;
         send_msg(&mut writer, initialized_notif).await;
 
-        // Measure time to open 3 documents in parallel
         let start = Instant::now();
 
-        // Send 3 didOpen requests rapidly (they should be processed in parallel if non-blocking)
         for i in 0..3 {
             let file_path = temp_dir.path().join(format!("test{}.md", i));
             let file_uri = Url::from_file_path(file_path).unwrap();
@@ -909,7 +324,6 @@ mod tests {
             send_msg(&mut writer, &did_open).await;
         }
 
-        // Wait for all 3 publishDiagnostics responses
         let mut diagnostics_count = 0;
         let timeout = tokio::time::sleep(Duration::from_secs(5));
         tokio::pin!(timeout);
@@ -934,18 +348,13 @@ mod tests {
 
         let elapsed = start.elapsed();
 
-        // Verify all diagnostics received
         assert_eq!(diagnostics_count, 3, "Expected 3 diagnostics responses");
 
-        // Verify timing:
-        // - If blocking: 3 × 100ms = 300ms minimum
-        // - If non-blocking: ~100ms + overhead (should be < 300ms)
         println!("Elapsed time for 3 parallel lints: {:?}", elapsed);
 
         assert!(
             elapsed < Duration::from_millis(300),
-            "Runtime was blocked! Expected < 300ms, got {:?}. \
-             This indicates lint_text is blocking the async runtime.",
+            "Runtime was blocked! Expected < 300ms, got {:?}",
             elapsed
         );
     }

--- a/crates/tsuzulint_lsp/src/state.rs
+++ b/crates/tsuzulint_lsp/src/state.rs
@@ -1,0 +1,53 @@
+//! LSP Backend state management.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use tower_lsp::lsp_types::Url;
+
+use tsuzulint_core::Linter;
+
+/// Document content and version cache.
+pub(crate) struct DocumentData {
+    pub text: String,
+    pub version: i32,
+}
+
+/// Shared backend state.
+pub(crate) struct BackendState {
+    /// Document contents cache.
+    pub documents: RwLock<HashMap<Url, DocumentData>>,
+    /// Linter instance (may be None if initialization failed).
+    pub linter: RwLock<Option<Linter>>,
+    /// Workspace root path.
+    pub workspace_root: RwLock<Option<std::path::PathBuf>>,
+}
+
+impl BackendState {
+    /// Creates a new empty state.
+    pub fn new() -> Self {
+        Self {
+            documents: RwLock::new(HashMap::new()),
+            linter: RwLock::new(None),
+            workspace_root: RwLock::new(None),
+        }
+    }
+
+    /// Creates a new state with a pre-initialized linter.
+    pub fn with_linter(linter: Option<Linter>) -> Self {
+        Self {
+            documents: RwLock::new(HashMap::new()),
+            linter: RwLock::new(linter),
+            workspace_root: RwLock::new(None),
+        }
+    }
+}
+
+impl Default for BackendState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Type alias for shared state.
+pub type SharedState = Arc<BackendState>;


### PR DESCRIPTION
## Summary

Split `lib.rs` (772+ lines) that handled 10 concerns into focused modules.

### Before
- `lib.rs`: ~950 lines handling 10 distinct concerns

### After
- `lib.rs`: 361 lines (thin entry point with Backend and run())

### New Module Structure

| File | Lines | Purpose |
|------|-------|---------|
| `lib.rs` | 361 | Thin entry point with `Backend` and `run()` |
| `state.rs` | 53 | `BackendState`, `DocumentData` structs |
| `conversion.rs` | 127 | LSP type conversions |
| `config.rs` | 48 | Configuration reload logic |
| `debounce.rs` | 50 | Debounce utilities |
| `handler/mod.rs` | 13 | Handler re-exports |
| `handler/initialize.rs` | 73 | Initialize/shutdown handlers |
| `handler/documents.rs` | 95 | Document lifecycle handlers |
| `handler/files.rs` | 27 | Watched files handler |
| `handler/code_action.rs` | 126 | Code action handler |
| `handler/symbols.rs` | 128 | Document symbol handler |

### Verification
- ✅ All 9 tests pass
- ✅ `make lint` passes
- ✅ Code formatted

## Motivation

The original file handled:
1. LSP Protocol implementations
2. Document management
3. Linting integration
4. Diagnostic conversion
5. Position utilities
6. Configuration management
7. Symbol extraction
8. Code actions
9. Debouncing
10. State management

This refactoring improves separation of concerns and testability.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * LSPサーバーの初期化とシャットダウン処理を実装
  * コード修正アクションの追加（クイックフィックスと一括修正）
  * ドキュメントシンボルナビゲーション機能を追加
  * ファイル監視時の設定ファイル自動リロード機能を追加

* **改善**
  * ドキュメント検証のデバウンス処理により、パフォーマンスを向上
  * ドキュメントライフサイクル管理を最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->