### PR TITLE
perf(plugin): use Arc<Vec<u8>> for RuleSource::Bytes to reduce clone overhead

### DIFF
--- a/crates/tsuzulint_plugin/src/executor_extism.rs
+++ b/crates/tsuzulint_plugin/src/executor_extism.rs
@@ -28,14 +28,14 @@ const DEFAULT_FUEL_LIMIT: u64 = 1_000_000_000;
 /// Source of the rule (WASM bytes or file path).
 #[derive(Clone)]
 enum RuleSource {
-    Bytes(Arc<Vec<u8>>),
+    Bytes(Arc<[u8]>),
     File(PathBuf),
 }
 
 impl RuleSource {
     fn to_wasm(&self) -> Wasm {
         match self {
-            RuleSource::Bytes(bytes) => Wasm::data((**bytes).clone()),
+            RuleSource::Bytes(bytes) => Wasm::data(bytes.to_vec()),
             RuleSource::File(path) => Wasm::file(path),
         }
     }
@@ -205,7 +205,7 @@ impl Default for ExtismExecutor {
 impl RuleExecutor for ExtismExecutor {
     fn load(&mut self, wasm_bytes: &[u8]) -> Result<LoadResult, PluginError> {
         info!("Loading WASM rule ({} bytes)", wasm_bytes.len());
-        self.load_rule(RuleSource::Bytes(Arc::new(wasm_bytes.to_vec())))
+        self.load_rule(RuleSource::Bytes(Arc::from(wasm_bytes)))
     }
 
     fn load_file(&mut self, path: &Path) -> Result<LoadResult, PluginError> {


### PR DESCRIPTION
## Summary
- Change `RuleSource::Bytes` from `Vec<u8>` to `Arc<Vec<u8>>` to avoid full WASM binary clones when calling `configure()`

## Context
The `configure()` method recreates plugins on each configuration change. Previously, `rule.source.clone()` would clone the entire WASM binary. Now with `Arc`, it's a cheap reference count increment.

Closes #152
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 内部のメモリ管理を最適化し、WASMバイナリ読み込み時の効率と安全性を向上しました。公開APIや既存の動作に変更はなく、パフォーマンスやメモリ使用量の改善が期待できます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->