### PR TITLE
🦀 Ferris: Split ExtismExecutor plugin creation and manifest fetching

### DIFF
--- a/crates/tsuzulint_plugin/src/executor_extism.rs
+++ b/crates/tsuzulint_plugin/src/executor_extism.rs
@@ -463,7 +463,7 @@ mod tests {
 
         // NOTE: Writing pure WAT to test Extism config is complex because it involves
         // managing Extism's memory model (alloc, length, load/store).
-        // Instead, we will rely on the fact that `configure` calls `create_plugin` which sets
+        // Instead, we will rely on the fact that `configure` calls `build_plugin` which sets
         // the manifest config. The Extism library guarantees this works.
         // We will just verify that `configure` doesn't error and that the rule persists.
 


### PR DESCRIPTION
💡 Improvement: Refactored `ExtismExecutor::create_plugin` into `build_plugin` and `fetch_manifest`.
🦀 Why: This separation allows the `configure` method to skip fetching and parsing the rule manifest (a potentially expensive WASM call and JSON deserialization) since the manifest is not needed when only updating configuration. This adheres to "Zero-cost abstractions" by avoiding unnecessary work.
🔍 Verification: Ran `cargo test -p tsuzulint_plugin` and `cargo test -p tsuzulint_core`, ensuring no regressions.

---
*PR created automatically by Jules for task [11988729832822577912](https://jules.google.com/task/11988729832822577912) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * プラグイン構築フローを見直し、プラグイン本体の生成とルールマニフェストの取得を分離しました。内部処理を簡潔化し保守性を向上しています。
* **Tests**
  * 関連するテスト・コメントを更新し、新しい構成に合わせて整備しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->