### PR TITLE
Scholar: Optimize LSP debounce memory usage

### DIFF
--- a/crates/tsuzulint_lsp/src/debounce.rs
+++ b/crates/tsuzulint_lsp/src/debounce.rs
@@ -14,12 +14,8 @@ pub const DEFAULT_DEBOUNCE_MS: u64 = 300;
 ///
 /// This function waits for the debounce period, then checks if the document
 /// version is still the same before retrieving the text and triggering validation.
-pub fn spawn_debounced_validation<F>(
-    state: SharedState,
-    uri: Url,
-    version: i32,
-    validate_fn: F,
-) where
+pub fn spawn_debounced_validation<F>(state: SharedState, uri: Url, version: i32, validate_fn: F)
+where
     F: FnOnce(Url, String, Option<i32>) + Send + 'static,
 {
     tokio::spawn(async move {
@@ -41,10 +37,8 @@ fn get_text_if_version(state: &BackendState, uri: &Url, version: i32) -> Option<
         }
     };
 
-    if let Some(doc) = docs.get(uri) {
-        if doc.version == version {
-            return Some(doc.text.clone());
-        }
+    if let Some(doc) = docs.get(uri).filter(|d| d.version == version) {
+        return Some(doc.text.clone());
     }
     None
 }

--- a/crates/tsuzulint_lsp/src/handler/documents.rs
+++ b/crates/tsuzulint_lsp/src/handler/documents.rs
@@ -59,13 +59,7 @@ pub fn handle_did_change(
                 return None;
             }
         };
-        docs.insert(
-            uri.clone(),
-            DocumentData {
-                text,
-                version,
-            },
-        );
+        docs.insert(uri.clone(), DocumentData { text, version });
     }
 
     Some((uri, version))

--- a/crates/tsuzulint_lsp/src/lib.rs
+++ b/crates/tsuzulint_lsp/src/lib.rs
@@ -164,17 +164,12 @@ impl LanguageServer for Backend {
         if let Some((uri, version)) = handle_did_change(&self.state, params) {
             let backend = self.clone();
 
-            spawn_debounced_validation(
-                self.state.clone(),
-                uri.clone(),
-                version,
-                move |u, t, v| {
-                    let backend = backend.clone();
-                    tokio::spawn(async move {
-                        backend.validate_document(u, t, v).await;
-                    });
-                },
-            );
+            spawn_debounced_validation(self.state.clone(), uri.clone(), version, move |u, t, v| {
+                let backend = backend.clone();
+                tokio::spawn(async move {
+                    backend.validate_document(u, t, v).await;
+                });
+            });
         }
     }
 


### PR DESCRIPTION
Optimized the LSP `didChange` handler to prevent unnecessary cloning of the document text for every keystroke. The debounce logic now checks the version before retrieving the text from the state, ensuring that only the final text for a debounced event is processed and allocated. This improves performance and reduces memory usage for large documents during rapid edits.

Also documented an attempted optimization for Extism configuration updates, which was blocked by API limitations in Extism v1.13.0 regarding raw memory access.

---
*PR created automatically by Jules for task [16716290811184902265](https://jules.google.com/task/16716290811184902265) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクター**
  * バリデーション処理を再構成し、変更イベントでは URI とバージョンのみを扱うように簡素化しました。
  * バリデーション時に最新のテキストをバージョン照合の上で取得する流れに移行し、処理の重複と同期の取り扱いを改善しました。
* **バグ修正**
  * ドキュメントロックの異常時に安全に処理を中断するようになり、安定性が向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->