### PR TITLE
🧪 [testing improvement] Test Watched Files Change Handler

### DIFF
--- a/crates/tsuzulint_lsp/src/handler/files.rs
+++ b/crates/tsuzulint_lsp/src/handler/files.rs
@@ -67,7 +67,9 @@ mod tests {
     async fn test_handle_did_change_watched_files_no_config_change() {
         let state = BackendState::new();
         let temp = tempdir().unwrap();
+        let config_path = temp.path().join(".tsuzulint.json");
         let other_path = temp.path().join("other.txt");
+        fs::write(&config_path, "{}").unwrap();
         fs::write(&other_path, "hello").unwrap();
 
         {


### PR DESCRIPTION
I added unit tests for the `handle_did_change_watched_files` function in `crates/tsuzulint_lsp/src/handler/files.rs`. These tests ensure that the LSP server correctly detects when a configuration file (like `.tsuzulint.json`) has changed and triggers a reload of the linter configuration.

Tested scenarios:
- **Config Change**: Changing `.tsuzulint.json` triggers `reload_config`.
- **No Config Change**: Changing `other.txt` does not trigger `reload_config`.
- **Mixed Changes**: A list of changes containing both config and non-config files triggers `reload_config`.

I also addressed code review feedback by ensuring all necessary types and the `BackendState` struct are correctly imported in the `tests` module.

---
*PR created automatically by Jules for task [13774541537446174158](https://jules.google.com/task/13774541537446174158) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * ファイル監視処理に対するテストスイートを追加しました。設定ファイルの変更検出が動作することを検証するテスト、設定ファイル以外の変更時に挙動が変わらないことを確認するテスト、設定ファイルと通常ファイルの同時変更への対応を検証するテストを含みます。これらは本番コードの変更を伴わないテスト追加です。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->