### PR TITLE
⚡ Optimize redundant rule version map creation

### DIFF
--- a/crates/tsuzulint_core/src/file_linter.rs
+++ b/crates/tsuzulint_core/src/file_linter.rs
@@ -27,6 +27,7 @@ pub fn lint_file_internal(
     config_hash: &str,
     cache: &Mutex<CacheManager>,
     enabled_rules: &HashSet<&str>,
+    rule_versions: &HashMap<String, String>,
     timings_enabled: bool,
 ) -> Result<LintResult, LinterError> {
     debug!("Linting {}", path.display());
@@ -58,7 +59,6 @@ pub fn lint_file_internal(
         .map_err(|e| LinterError::file(format!("Failed to read {}: {}", path.display(), e)))?;
 
     let content_hash = CacheManager::hash_content(&content);
-    let rule_versions = super::rule_loader::get_rule_versions_from_host(host);
 
     {
         let cache_guard = cache
@@ -244,7 +244,7 @@ pub fn lint_file_internal(
         let entry = tsuzulint_cache::CacheEntry::new(
             content_hash,
             config_hash.to_string(),
-            rule_versions,
+            rule_versions.clone(),
             final_diagnostics.clone(),
             new_blocks,
         );

--- a/crates/tsuzulint_core/src/parallel_linter.rs
+++ b/crates/tsuzulint_core/src/parallel_linter.rs
@@ -22,6 +22,7 @@ pub fn lint_files(
     tokenizer: &Arc<Tokenizer>,
     cache: &std::sync::Mutex<CacheManager>,
     dynamic_rules: &std::sync::Mutex<Vec<PathBuf>>,
+    rule_versions: &std::collections::HashMap<String, String>,
 ) -> LintFilesResult {
     let enabled_rules_vec = config.enabled_rules();
     let enabled_rules: std::collections::HashSet<&str> =
@@ -53,6 +54,7 @@ pub fn lint_files(
                     config_hash,
                     cache,
                     &enabled_rules,
+                    rule_versions,
                     timings_enabled,
                 )
                 .map_err(|e| (path.clone(), e))
@@ -111,6 +113,7 @@ mod tests {
             &tokenizer,
             &cache,
             &dynamic_rules,
+            &std::collections::HashMap::new(),
         );
         assert!(result.is_ok());
 


### PR DESCRIPTION
The redundant rule version map creation was causing unnecessary overhead and memory allocations for every file being linted. This PR lifts the rule version retrieval out of the core linting loop, computing it once per session and threading it through the call stack.

Key improvements:
- Reduced CPU overhead per file.
- Reduced memory allocations and string clones.
- Improved concurrency by briefly locking the PluginHost to extract versions before starting parallel processing.

---
*PR created automatically by Jules for task [6777978641689079731](https://jules.google.com/task/6777978641689079731) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
