### PR TITLE
feat(rule): add `max-ten` rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -211,9 +211,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -2062,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2149,13 +2149,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.1",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -2420,9 +2421,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memfd"
@@ -2678,9 +2679,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parking_lot"
@@ -2756,18 +2757,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2776,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2791,6 +2792,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "postcard"
@@ -3186,9 +3193,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -3289,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relative-path"
@@ -3540,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3665,9 +3672,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
@@ -3678,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3961,9 +3968,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4269,9 +4276,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.8+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -4695,9 +4702,9 @@ checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4928,9 +4935,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4941,9 +4948,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.63"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4955,9 +4962,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4965,9 +4972,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4978,18 +4985,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6fc7a6f61926fa909ee570d4ca194e264545ebbbb4ffd63ac07ba921bff447"
+checksum = "6311c867385cc7d5602463b31825d454d0837a3aba7cdb5e56d5201792a3f7fe"
 dependencies = [
  "async-trait",
  "cast",
@@ -5009,9 +5016,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f745a117245c232859f203d6c8d52c72d4cfc42de7e668c147ca6b3e45f1157e"
+checksum = "67008cdde4769831958536b0f11b3bdd0380bde882be17fff9c2f34bb4549abd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5020,9 +5027,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f88e7ae201cc7c291da857532eb1c8712e89494e76ec3967b9805221388e938"
+checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
 
 [[package]]
 name = "wasm-encoder"
@@ -5480,9 +5487,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6106,18 +6113,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6186,9 +6193,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/rules/Cargo.lock
+++ b/rules/Cargo.lock
@@ -527,6 +527,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tsuzulint-rule-max-ten"
+version = "0.1.0"
+dependencies = [
+ "extism-pdk",
+ "pretty_assertions",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "tsuzulint-rule-pdk",
+]
+
+[[package]]
 name = "tsuzulint-rule-no-doubled-joshi"
 version = "0.1.0"
 dependencies = [

--- a/rules/Cargo.toml
+++ b/rules/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 resolver = "2"
-members = ["rules-pdk", "no-todo", "sentence-length", "no-doubled-joshi"]
+members = [
+    "rules-pdk",
+    "no-todo",
+    "sentence-length",
+    "no-doubled-joshi",
+    "max-ten",
+]
 
 [workspace.package]
 version = "0.1.0"

--- a/rules/max-ten/Cargo.toml
+++ b/rules/max-ten/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "tsuzulint-rule-max-ten"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+tsuzulint-rule-pdk = { path = "../rules-pdk" }
+extism-pdk = "1.3"
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+pretty_assertions = "1.4"
+rmp-serde = "1.3"
+serde_json = "1.0"

--- a/rules/max-ten/src/lib.rs
+++ b/rules/max-ten/src/lib.rs
@@ -1,0 +1,776 @@
+//! max-ten rule: Limit the number of Japanese commas (読点) in a single sentence.
+//!
+//! # Configuration
+//!
+//! | Option | Type | Default | Description |
+//! |--------|------|---------|-------------|
+//! | max | number | 3 | Maximum number of commas allowed in a sentence |
+//! | strict | boolean | false | If false, commas sandwiched between nouns are ignored |
+//! | touten | string | "、" | The comma character to count |
+//! | kuten | string | "。" | The period character |
+
+use extism_pdk::*;
+use serde::Deserialize;
+use tsuzulint_rule_pdk::{
+    Capability, Diagnostic, KnownLanguage, LintRequest, LintResponse, RuleManifest, Span, Token,
+    is_node_type,
+};
+
+const RULE_ID: &str = "max-ten";
+const VERSION: &str = "1.0.0";
+
+const DEFAULT_MAX_TEN: usize = 3;
+const DEFAULT_TOUTEN: &str = "、";
+const DEFAULT_KUTEN: &str = "。";
+
+#[derive(Debug, serde::Serialize, Deserialize)]
+struct Config {
+    #[serde(default = "default_max")]
+    max: usize,
+    #[serde(default)]
+    strict: bool,
+    #[serde(default = "default_touten")]
+    touten: String,
+    #[serde(default = "default_kuten")]
+    kuten: String,
+}
+
+fn default_max() -> usize {
+    DEFAULT_MAX_TEN
+}
+
+fn default_touten() -> String {
+    DEFAULT_TOUTEN.to_string()
+}
+
+fn default_kuten() -> String {
+    DEFAULT_KUTEN.to_string()
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            max: DEFAULT_MAX_TEN,
+            strict: false,
+            touten: DEFAULT_TOUTEN.to_string(),
+            kuten: DEFAULT_KUTEN.to_string(),
+        }
+    }
+}
+
+#[plugin_fn]
+pub fn get_manifest() -> FnResult<RuleManifest> {
+    Ok(RuleManifest::new(RULE_ID, VERSION)
+        .with_description("Limit the number of Japanese commas (読点) in a single sentence")
+        .with_fixable(false)
+        .with_node_types(vec!["Str".to_string()])
+        .with_languages(vec![KnownLanguage::Ja])
+        .with_capabilities(vec![Capability::Morphology]))
+}
+
+#[plugin_fn]
+pub fn lint(request: LintRequest) -> FnResult<LintResponse> {
+    do_lint(request)
+}
+
+fn do_lint(request: LintRequest) -> FnResult<LintResponse> {
+    let mut diagnostics = Vec::new();
+
+    if !is_node_type(&request.node, "Str") {
+        return Ok(LintResponse { diagnostics });
+    }
+
+    let config: Config = request.get_config().unwrap_or_default();
+    let tokens = request.get_tokens();
+
+    let mut separator_characters = vec!["?", "!", "？", "！"];
+    separator_characters.push(&config.kuten);
+
+    let mut current_ten_count = 0;
+    let mut last_touten_span = None;
+
+    for (index, token) in tokens.iter().enumerate() {
+        let surface = token.surface.as_str();
+
+        if surface == config.touten {
+            let is_sandwiched = is_sandwiched_meishi(tokens, index);
+            if !config.strict && is_sandwiched {
+                continue;
+            }
+            current_ten_count += 1;
+            last_touten_span = Some(token.span);
+        }
+
+        if separator_characters.contains(&surface) {
+            current_ten_count = 0;
+        }
+
+        if current_ten_count > config.max {
+            if let Some(span) = last_touten_span {
+                diagnostics.push(Diagnostic::new(
+                    RULE_ID,
+                    format!(
+                        "一つの文で\"{}\"を{}つ以上使用しています",
+                        config.touten,
+                        config.max + 1
+                    ),
+                    Span::new(span.start, span.end),
+                ));
+            }
+            current_ten_count = 0;
+        }
+    }
+
+    Ok(LintResponse { diagnostics })
+}
+
+fn is_sandwiched_meishi(tokens: &[Token], index: usize) -> bool {
+    let before = find_sibling_meaning_token(tokens, index, -1);
+    let after = find_sibling_meaning_token(tokens, index, 1);
+
+    if let (Some(b), Some(a)) = (before, after) {
+        b.is_noun() && a.is_noun()
+    } else {
+        false
+    }
+}
+
+fn find_sibling_meaning_token(
+    tokens: &[Token],
+    current_index: usize,
+    direction: isize,
+) -> Option<&Token> {
+    let mut idx = current_index as isize + direction;
+    while idx >= 0 && (idx as usize) < tokens.len() {
+        let sibling = &tokens[idx as usize];
+        if is_kakko(sibling) {
+            idx += direction;
+            continue;
+        }
+        return Some(sibling);
+    }
+    None
+}
+
+fn is_kakko(token: &Token) -> bool {
+    if token.major_pos() == Some("記号") {
+        if let Some(detail) = token.pos_detail(1) {
+            if detail.starts_with("括弧") {
+                return true;
+            }
+        }
+    }
+    if token.surface == "(" || token.surface == ")" {
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use tsuzulint_rule_pdk::{AstNode, TextSpan};
+
+    fn create_token(surface: &str, pos: Vec<&str>, start: u32, end: u32) -> Token {
+        Token::new(
+            surface,
+            pos.iter().map(|s| s.to_string()).collect(),
+            TextSpan::new(start, end),
+        )
+    }
+
+    fn create_request_with_config<T: serde::Serialize>(
+        text: &str,
+        config: &T,
+        tokens: Vec<Token>,
+    ) -> LintRequest {
+        let mut request = LintRequest::single(
+            AstNode::new("Str", Some([0, text.len() as u32])),
+            text.to_string(),
+        );
+        request.config = Some(rmp_serde::to_vec_named(config).unwrap());
+        // Configure text context mock with tokens for helpers
+        request.helpers = Some(tsuzulint_rule_pdk::LintHelpers {
+            text_context: Some(tsuzulint_rule_pdk::TextContext {
+                tokens,
+                sentences: vec![],
+            }),
+            ..Default::default()
+        });
+        request
+    }
+
+    struct TestCase {
+        text: String,
+        config: Option<serde_json::Value>,
+        tokens: Vec<Token>,
+        expected_errors: Vec<ExpectedError>,
+    }
+
+    struct ExpectedError {
+        message: String,
+    }
+
+    fn run_test_cases(valid: Vec<TestCase>, invalid: Vec<TestCase>) {
+        for (i, case) in valid.into_iter().enumerate() {
+            let request = if let Some(config) = case.config {
+                create_request_with_config(&case.text, &config, case.tokens)
+            } else {
+                create_request_with_config(&case.text, &Config::default(), case.tokens)
+            };
+            let response = do_lint(request).unwrap();
+            assert_eq!(
+                response.diagnostics.len(),
+                0,
+                "Expected valid case {} to have 0 errors, found {}",
+                i,
+                response.diagnostics.len()
+            );
+        }
+
+        for (i, case) in invalid.into_iter().enumerate() {
+            let request = if let Some(config) = case.config {
+                create_request_with_config(&case.text, &config, case.tokens)
+            } else {
+                create_request_with_config(&case.text, &Config::default(), case.tokens)
+            };
+            let response = do_lint(request).unwrap();
+            assert_eq!(
+                response.diagnostics.len(),
+                case.expected_errors.len(),
+                "Expected invalid case {} to have {} errors, found {}",
+                i,
+                case.expected_errors.len(),
+                response.diagnostics.len()
+            );
+            for (diag, expected) in response.diagnostics.iter().zip(case.expected_errors.iter()) {
+                assert_eq!(
+                    diag.message, expected.message,
+                    "Invalid case {} message mismatch\nDiag span: {:?}",
+                    i, diag.span
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_max_ten() {
+        let valid = vec![
+            TestCase {
+                text: "名詞、名詞、名詞、名詞、名詞の場合は例外".to_string(),
+                config: None,
+                tokens: vec![
+                    create_token("名詞", vec!["名詞", "一般"], 0, 6),
+                    create_token("、", vec!["記号", "読点"], 6, 9),
+                    create_token("名詞", vec!["名詞", "一般"], 9, 15),
+                    create_token("、", vec!["記号", "読点"], 15, 18),
+                    create_token("名詞", vec!["名詞", "一般"], 18, 24),
+                    create_token("、", vec!["記号", "読点"], 24, 27),
+                    create_token("名詞", vec!["名詞", "一般"], 27, 33),
+                    create_token("、", vec!["記号", "読点"], 33, 36),
+                    create_token("名詞", vec!["名詞", "一般"], 36, 42),
+                    create_token("の", vec!["助詞", "連体化"], 42, 45),
+                    create_token("場合", vec!["名詞", "一般"], 45, 51),
+                    create_token("は", vec!["助詞", "係助詞"], 51, 54),
+                    create_token("例外", vec!["名詞", "一般"], 54, 60),
+                ],
+                expected_errors: vec![],
+            },
+            TestCase {
+                text: "ビスケットの主な材料は(1)小麦粉、(2)牛乳、(3)ショートニング、(4)バター、(5)砂糖である。".to_string(),
+                config: None,
+                tokens: vec![
+                    create_token("ビスケット", vec!["名詞", "一般"], 0, 15),
+                    create_token("(", vec!["記号", "一般"], 33, 34),
+                    create_token("1", vec!["名詞", "数"], 34, 35),
+                    create_token(")", vec!["記号", "一般"], 35, 36),
+                    create_token("小麦粉", vec!["名詞", "一般"], 36, 45),
+                    create_token("、", vec!["記号", "読点"], 45, 48),
+                    create_token("(", vec!["記号", "一般"], 48, 49),
+                    create_token("2", vec!["名詞", "数"], 49, 50),
+                    create_token(")", vec!["記号", "一般"], 50, 51),
+                    create_token("牛乳", vec!["名詞", "一般"], 51, 57),
+                    create_token("、", vec!["記号", "読点"], 57, 60),
+                    create_token("(", vec!["記号", "一般"], 60, 61),
+                    create_token("3", vec!["名詞", "数"], 61, 62),
+                    create_token(")", vec!["記号", "一般"], 62, 63),
+                    create_token("ショートニング", vec!["名詞", "一般"], 63, 84),
+                    create_token("、", vec!["記号", "読点"], 84, 87),
+                    create_token("(", vec!["記号", "一般"], 87, 88),
+                    create_token("4", vec!["名詞", "数"], 88, 89),
+                    create_token(")", vec!["記号", "一般"], 89, 90),
+                    create_token("バター", vec!["名詞", "一般"], 90, 99),
+                    create_token("、", vec!["記号", "読点"], 99, 102),
+                    create_token("(", vec!["記号", "一般"], 102, 103),
+                    create_token("5", vec!["名詞", "数"], 103, 104),
+                    create_token(")", vec!["記号", "一般"], 104, 105),
+                    create_token("砂糖", vec!["名詞", "一般"], 105, 111),
+                ],
+                expected_errors: vec![],
+            },
+            TestCase {
+                text: "これは、これは、これは、これは、オプションでカウントされないのでOK".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "touten": "，",
+                    "kuten": "．"
+                })).unwrap(),
+                tokens: vec![
+                    create_token("これ", vec!["代名詞", "一般"], 0, 6),
+                    create_token("は", vec!["助詞", "係助詞"], 6, 9),
+                    create_token("、", vec!["記号", "読点"], 9, 12),
+                    create_token("これ", vec!["代名詞", "一般"], 12, 18),
+                    create_token("は", vec!["助詞", "係助詞"], 18, 21),
+                    create_token("、", vec!["記号", "読点"], 21, 24),
+                    create_token("これ", vec!["代名詞", "一般"], 24, 30),
+                    create_token("は", vec!["助詞", "係助詞"], 30, 33),
+                    create_token("、", vec!["記号", "読点"], 33, 36),
+                    create_token("これ", vec!["代名詞", "一般"], 36, 42),
+                    create_token("は", vec!["助詞", "係助詞"], 42, 45),
+                    create_token("、", vec!["記号", "読点"], 45, 48),
+                ],
+                expected_errors: vec![],
+            },
+            TestCase {
+                text: "テキスト１、テキスト２、テキスト３、テキスト４、テキスト５".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "max": 5
+                })).unwrap(),
+                tokens: vec![
+                    create_token("テキスト", vec!["名詞", "一般"], 0, 12),
+                    create_token("１", vec!["名詞", "数"], 12, 15),
+                    create_token("、", vec!["記号", "読点"], 15, 18),
+                    create_token("テキスト", vec!["名詞", "一般"], 18, 30),
+                    create_token("２", vec!["名詞", "数"], 30, 33),
+                    create_token("、", vec!["記号", "読点"], 33, 36),
+                    create_token("テキスト", vec!["名詞", "一般"], 36, 48),
+                    create_token("３", vec!["名詞", "数"], 48, 51),
+                    create_token("、", vec!["記号", "読点"], 51, 54),
+                    create_token("テキスト", vec!["名詞", "一般"], 54, 66),
+                    create_token("４", vec!["名詞", "数"], 66, 69),
+                    create_token("、", vec!["記号", "読点"], 69, 72),
+                    create_token("テキスト", vec!["名詞", "一般"], 72, 84),
+                    create_token("５", vec!["名詞", "数"], 84, 87),
+                ],
+                expected_errors: vec![],
+            },
+            TestCase {
+                text: "「紅ちゃんは、たたえなくなっていいって、思う？ もっと大事なものがあったら、スパイになれなくてもいいって、思う？」".to_string(),
+                config: None,
+                tokens: vec![
+                    create_token("「", vec!["記号", "括弧開"], 0, 3),
+                    create_token("紅", vec!["名詞", "固有名詞"], 3, 6),
+                    create_token("ちゃん", vec!["名詞", "接尾"], 6, 15),
+                    create_token("は", vec!["助詞", "係助詞"], 15, 18),
+                    create_token("、", vec!["記号", "読点"], 18, 21),
+                    create_token("たたえ", vec!["動詞", "自立"], 21, 30),
+                    create_token("なく", vec!["助動詞"], 30, 36),
+                    create_token("なっ", vec!["動詞", "非自立"], 36, 42),
+                    create_token("て", vec!["助詞", "接続助詞"], 42, 45),
+                    create_token("いい", vec!["形容詞", "自立"], 45, 51),
+                    create_token("って", vec!["助詞", "格助詞"], 51, 57),
+                    create_token("、", vec!["記号", "読点"], 57, 60),
+                    create_token("思う", vec!["動詞", "自立"], 60, 66),
+                    create_token("？", vec!["記号", "一般"], 66, 69),
+                    create_token(" ", vec!["記号", "空白"], 69, 70),
+                    create_token("もっと", vec!["副詞", "一般"], 70, 79),
+                    create_token("大事", vec!["名詞", "形容動詞語幹"], 79, 85),
+                    create_token("な", vec!["助動詞"], 85, 88),
+                    create_token("もの", vec!["名詞", "非自立"], 88, 94),
+                    create_token("が", vec!["助詞", "格助詞"], 94, 97),
+                    create_token("あっ", vec!["動詞", "自立"], 97, 103),
+                    create_token("たら", vec!["助動詞"], 103, 109),
+                    create_token("、", vec!["記号", "読点"], 109, 112),
+                    create_token("スパイ", vec!["名詞", "一般"], 112, 121),
+                    create_token("に", vec!["助詞", "格助詞"], 121, 124),
+                    create_token("なれ", vec!["動詞", "自立"], 124, 130),
+                    create_token("なく", vec!["助動詞"], 130, 136),
+                    create_token("て", vec!["助詞", "接続助詞"], 136, 139),
+                    create_token("も", vec!["助詞", "係助詞"], 139, 142),
+                    create_token("いい", vec!["形容詞", "自立"], 142, 148),
+                    create_token("って", vec!["助詞", "格助詞"], 148, 154),
+                    create_token("、", vec!["記号", "読点"], 154, 157),
+                    create_token("思う", vec!["動詞", "自立"], 157, 163),
+                    create_token("？", vec!["記号", "一般"], 163, 166),
+                    create_token("」", vec!["記号", "括弧閉"], 166, 169),
+                ],
+                expected_errors: vec![],
+            },
+        ];
+        let invalid = vec![
+            TestCase {
+                text: "これは、これは、これは、これは、これはだめ。".to_string(),
+                config: None,
+                tokens: vec![
+                    create_token("これ", vec!["代名詞", "一般"], 0, 6),
+                    create_token("は", vec!["助詞", "係助詞"], 6, 9),
+                    create_token("、", vec!["記号", "読点"], 9, 12),
+                    create_token("これ", vec!["代名詞", "一般"], 12, 18),
+                    create_token("は", vec!["助詞", "係助詞"], 18, 21),
+                    create_token("、", vec!["記号", "読点"], 21, 24),
+                    create_token("これ", vec!["代名詞", "一般"], 24, 30),
+                    create_token("は", vec!["助詞", "係助詞"], 30, 33),
+                    create_token("、", vec!["記号", "読点"], 33, 36),
+                    create_token("これ", vec!["代名詞", "一般"], 36, 42),
+                    create_token("は", vec!["助詞", "係助詞"], 42, 45),
+                    create_token("、", vec!["記号", "読点"], 45, 48),
+                    create_token("これ", vec!["代名詞", "一般"], 48, 54),
+                    create_token("は", vec!["助詞", "係助詞"], 54, 57),
+                    create_token("だめ", vec!["名詞", "一般"], 57, 63),
+                    create_token("。", vec!["記号", "句点"], 63, 66),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"、\"を4つ以上使用しています".to_string(),
+                }],
+            },
+            TestCase {
+                text: "これは，これは，これは，これは，これは。".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "touten": "，",
+                    "kuten": "．"
+                }))
+                .unwrap(),
+                tokens: vec![
+                    create_token("これ", vec!["代名詞", "一般"], 0, 6),
+                    create_token("は", vec!["助詞", "係助詞"], 6, 9),
+                    create_token("，", vec!["記号", "読点"], 9, 12),
+                    create_token("これ", vec!["代名詞", "一般"], 12, 18),
+                    create_token("は", vec!["助詞", "係助詞"], 18, 21),
+                    create_token("，", vec!["記号", "読点"], 21, 24),
+                    create_token("これ", vec!["代名詞", "一般"], 24, 30),
+                    create_token("は", vec!["助詞", "係助詞"], 30, 33),
+                    create_token("，", vec!["記号", "読点"], 33, 36),
+                    create_token("これ", vec!["代名詞", "一般"], 36, 42),
+                    create_token("は", vec!["助詞", "係助詞"], 42, 45),
+                    create_token("，", vec!["記号", "読点"], 45, 48),
+                    create_token("これ", vec!["代名詞", "一般"], 48, 54),
+                    create_token("は", vec!["助詞", "係助詞"], 54, 57),
+                    create_token("。", vec!["記号", "句点"], 57, 60),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"，\"を4つ以上使用しています".to_string(),
+                }],
+            },
+            TestCase {
+                text: "テキスト１、テキスト２、テキスト３、テキスト４、テキスト５".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "max": 3,
+                    "strict": true
+                }))
+                .unwrap(),
+                tokens: vec![
+                    create_token("テキスト", vec!["名詞", "一般"], 0, 12),
+                    create_token("１", vec!["名詞", "数"], 12, 15),
+                    create_token("、", vec!["記号", "読点"], 15, 18),
+                    create_token("テキスト", vec!["名詞", "一般"], 18, 30),
+                    create_token("２", vec!["名詞", "数"], 30, 33),
+                    create_token("、", vec!["記号", "読点"], 33, 36),
+                    create_token("テキスト", vec!["名詞", "一般"], 36, 48),
+                    create_token("３", vec!["名詞", "数"], 48, 51),
+                    create_token("、", vec!["記号", "読点"], 51, 54),
+                    create_token("テキスト", vec!["名詞", "一般"], 54, 66),
+                    create_token("４", vec!["名詞", "数"], 66, 69),
+                    create_token("、", vec!["記号", "読点"], 69, 72),
+                    create_token("テキスト", vec!["名詞", "一般"], 72, 84),
+                    create_token("５", vec!["名詞", "数"], 84, 87),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"、\"を4つ以上使用しています".to_string(),
+                }],
+            },
+            TestCase {
+                text: "これは，これは，これは。これは，これは，これは，どうですか?".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "touten": "，",
+                    "kuten": "．"
+                }))
+                .unwrap(),
+                tokens: vec![
+                    create_token("これ", vec!["代名詞", "一般"], 0, 6),
+                    create_token("は", vec!["助詞", "係助詞"], 6, 9),
+                    create_token("，", vec!["記号", "読点"], 9, 12),
+                    create_token("これ", vec!["代名詞", "一般"], 12, 18),
+                    create_token("は", vec!["助詞", "係助詞"], 18, 21),
+                    create_token("，", vec!["記号", "読点"], 21, 24),
+                    create_token("これ", vec!["代名詞", "一般"], 24, 30),
+                    create_token("は", vec!["助詞", "係助詞"], 30, 33),
+                    create_token("。", vec!["記号", "句点"], 33, 36),
+                    create_token("これ", vec!["代名詞", "一般"], 36, 42),
+                    create_token("は", vec!["助詞", "係助詞"], 42, 45),
+                    create_token("，", vec!["記号", "読点"], 45, 48),
+                    create_token("これ", vec!["代名詞", "一般"], 48, 54),
+                    create_token("は", vec!["助詞", "係助詞"], 54, 57),
+                    create_token("，", vec!["記号", "読点"], 57, 60),
+                    create_token("これ", vec!["代名詞", "一般"], 60, 66),
+                    create_token("は", vec!["助詞", "係助詞"], 66, 69),
+                    create_token("，", vec!["記号", "読点"], 69, 72),
+                    create_token("どう", vec!["副詞", "一般"], 72, 78),
+                    create_token("です", vec!["助動詞"], 78, 84),
+                    create_token("か", vec!["助詞", "終助詞"], 84, 87),
+                    create_token("?", vec!["記号", "一般"], 87, 88),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"，\"を4つ以上使用しています".to_string(),
+                }],
+            },
+            TestCase {
+                text: "テスト文章において、テスト文章において、テスト文章において、テスト文章において、テスト文章において、テスト文章において、です".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "max": 5
+                }))
+                .unwrap(),
+                tokens: vec![
+                    create_token("テスト", vec!["名詞", "一般"], 0, 3),
+                    create_token("文章", vec!["名詞", "一般"], 3, 5),
+                    create_token("において", vec!["助詞", "格助詞"], 5, 9),
+                    create_token("、", vec!["記号", "読点"], 9, 10),
+                    create_token("テスト", vec!["名詞", "一般"], 10, 13),
+                    create_token("文章", vec!["名詞", "一般"], 13, 15),
+                    create_token("において", vec!["助詞", "格助詞"], 15, 19),
+                    create_token("、", vec!["記号", "読点"], 19, 20),
+                    create_token("テスト", vec!["名詞", "一般"], 20, 23),
+                    create_token("文章", vec!["名詞", "一般"], 23, 25),
+                    create_token("において", vec!["助詞", "格助詞"], 25, 29),
+                    create_token("、", vec!["記号", "読点"], 29, 30),
+                    create_token("テスト", vec!["名詞", "一般"], 30, 33),
+                    create_token("文章", vec!["名詞", "一般"], 33, 35),
+                    create_token("において", vec!["助詞", "格助詞"], 35, 39),
+                    create_token("、", vec!["記号", "読点"], 39, 40),
+                    create_token("テスト", vec!["名詞", "一般"], 40, 43),
+                    create_token("文章", vec!["名詞", "一般"], 43, 45),
+                    create_token("において", vec!["助詞", "格助詞"], 45, 49),
+                    create_token("、", vec!["記号", "読点"], 49, 50),
+                    create_token("テスト", vec!["名詞", "一般"], 50, 53),
+                    create_token("文章", vec!["名詞", "一般"], 53, 55),
+                    create_token("において", vec!["助詞", "格助詞"], 55, 59),
+                    create_token("、", vec!["記号", "読点"], 59, 60),
+                    create_token("です", vec!["助動詞"], 60, 62),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"、\"を6つ以上使用しています".to_string(),
+                }],
+            },
+            TestCase {
+                text: "これは、長文の例ですが、columnがちゃんと計算、されてるはずです。".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "max": 2
+                }))
+                .unwrap(),
+                tokens: vec![
+                    create_token("これ", vec!["代名詞", "一般"], 0, 2),
+                    create_token("は", vec!["助詞", "係助詞"], 2, 3),
+                    create_token("、", vec!["記号", "読点"], 3, 4),
+                    create_token("長文", vec!["名詞", "一般"], 4, 6),
+                    create_token("の", vec!["助詞", "連体化"], 6, 7),
+                    create_token("例", vec!["名詞", "一般"], 7, 8),
+                    create_token("です", vec!["助動詞"], 8, 10),
+                    create_token("が", vec!["助詞", "接続助詞"], 10, 11),
+                    create_token("、", vec!["記号", "読点"], 11, 12),
+                    create_token("column", vec!["名詞", "一般"], 12, 18),
+                    create_token("が", vec!["助詞", "格助詞"], 18, 19),
+                    create_token("ちゃんと", vec!["副詞", "一般"], 19, 23),
+                    create_token("計算", vec!["名詞", "サ変接続"], 23, 25),
+                    create_token("、", vec!["記号", "読点"], 25, 26),
+                    create_token("さ", vec!["動詞", "自立"], 26, 27),
+                    create_token("れ", vec!["動詞", "接尾"], 27, 28),
+                    create_token("てる", vec!["動詞", "非自立"], 28, 30),
+                    create_token("はず", vec!["名詞", "非自立"], 30, 32),
+                    create_token("です", vec!["助動詞"], 32, 34),
+                    create_token("。", vec!["記号", "句点"], 34, 35),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"、\"を3つ以上使用しています".to_string(),
+                }],
+            },
+            TestCase {
+                text: "間に、Str以外の`code`Nodeが、あっても、OKと、聞いています。".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "max": 3
+                }))
+                .unwrap(),
+                tokens: vec![
+                    create_token("間", vec!["名詞", "一般"], 0, 1),
+                    create_token("に", vec!["助詞", "格助詞"], 1, 2),
+                    create_token("、", vec!["記号", "読点"], 2, 3),
+                    create_token("Str", vec!["名詞", "一般"], 3, 6),
+                    create_token("以外", vec!["名詞", "一般"], 6, 8),
+                    create_token("の", vec!["助詞", "連体化"], 8, 9),
+                    create_token("`", vec!["記号", "一般"], 9, 10),
+                    create_token("code", vec!["名詞", "一般"], 10, 14),
+                    create_token("`", vec!["記号", "一般"], 14, 15),
+                    create_token("Node", vec!["名詞", "一般"], 15, 19),
+                    create_token("が", vec!["助詞", "格助詞"], 19, 20),
+                    create_token("、", vec!["記号", "読点"], 20, 21),
+                    create_token("あっ", vec!["動詞", "自立"], 21, 23),
+                    create_token("て", vec!["助詞", "接続助詞"], 23, 24),
+                    create_token("も", vec!["助詞", "係助詞"], 24, 25),
+                    create_token("、", vec!["記号", "読点"], 25, 26),
+                    create_token("OK", vec!["名詞", "一般"], 26, 28),
+                    create_token("と", vec!["助詞", "格助詞"], 28, 29),
+                    create_token("、", vec!["記号", "読点"], 29, 30),
+                    create_token("聞い", vec!["動詞", "自立"], 30, 32),
+                    create_token("て", vec!["助詞", "接続助詞"], 32, 33),
+                    create_token("い", vec!["動詞", "非自立"], 33, 34),
+                    create_token("ます", vec!["助動詞"], 34, 36),
+                    create_token("。", vec!["記号", "句点"], 36, 37),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"、\"を4つ以上使用しています".to_string(),
+                }],
+            },
+            TestCase {
+                text: "複数のセンテンスがある場合。これでも、columnが、ちゃんと計算、されているはず、そのためのテキストです。".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "max": 3
+                }))
+                .unwrap(),
+                tokens: vec![
+                    create_token("複数", vec!["名詞", "一般"], 0, 2),
+                    create_token("の", vec!["助詞", "連体化"], 2, 3),
+                    create_token("センテンス", vec!["名詞", "一般"], 3, 8),
+                    create_token("が", vec!["助詞", "格助詞"], 8, 9),
+                    create_token("ある", vec!["動詞", "自立"], 9, 11),
+                    create_token("場合", vec!["名詞", "一般"], 11, 13),
+                    create_token("。", vec!["記号", "句点"], 13, 14),
+                    create_token("これ", vec!["代名詞", "一般"], 14, 16),
+                    create_token("でも", vec!["助詞", "副助詞"], 16, 18),
+                    create_token("、", vec!["記号", "読点"], 18, 19),
+                    create_token("column", vec!["名詞", "一般"], 19, 25),
+                    create_token("が", vec!["助詞", "格助詞"], 25, 26),
+                    create_token("、", vec!["記号", "読点"], 26, 27),
+                    create_token("ちゃんと", vec!["副詞", "一般"], 27, 31),
+                    create_token("計算", vec!["名詞", "サ変接続"], 31, 33),
+                    create_token("、", vec!["記号", "読点"], 33, 34),
+                    create_token("さ", vec!["動詞", "自立"], 34, 35),
+                    create_token("れ", vec!["動詞", "接尾"], 35, 36),
+                    create_token("て", vec!["助詞", "接続助詞"], 36, 37),
+                    create_token("いる", vec!["動詞", "非自立"], 37, 39),
+                    create_token("はず", vec!["名詞", "非自立"], 39, 41),
+                    create_token("、", vec!["記号", "読点"], 41, 42),
+                    create_token("その", vec!["連体詞"], 42, 44),
+                    create_token("ため", vec!["名詞", "非自立"], 44, 46),
+                    create_token("の", vec!["助詞", "連体化"], 46, 47),
+                    create_token("テキスト", vec!["名詞", "一般"], 47, 51),
+                    create_token("です", vec!["助動詞"], 51, 53),
+                    create_token("。", vec!["記号", "句点"], 53, 54),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"、\"を4つ以上使用しています".to_string(),
+                }],
+            },
+            TestCase {
+                text: "複数のセンテンスがあって、改行されている場合でも\n大丈夫です。これでも、lineとcolumnが、ちゃんと計算、されているはず、そのためのテキストです。".to_string(),
+                config: serde_json::from_value(serde_json::json!({
+                    "max": 3
+                }))
+                .unwrap(),
+                tokens: vec![
+                    create_token("複数", vec!["名詞", "一般"], 0, 2),
+                    create_token("の", vec!["助詞", "連体化"], 2, 3),
+                    create_token("センテンス", vec!["名詞", "一般"], 3, 8),
+                    create_token("が", vec!["助詞", "格助詞"], 8, 9),
+                    create_token("あっ", vec!["動詞", "自立"], 9, 11),
+                    create_token("て", vec!["助詞", "接続助詞"], 11, 12),
+                    create_token("、", vec!["記号", "読点"], 12, 13),
+                    create_token("改行", vec!["名詞", "サ変接続"], 13, 15),
+                    create_token("さ", vec!["動詞", "自立"], 15, 16),
+                    create_token("れ", vec!["動詞", "接尾"], 16, 17),
+                    create_token("て", vec!["助詞", "接続助詞"], 17, 18),
+                    create_token("いる", vec!["動詞", "非自立"], 18, 20),
+                    create_token("場合", vec!["名詞", "非自立"], 20, 22),
+                    create_token("でも", vec!["助詞", "副助詞"], 22, 24),
+                    create_token("\n", vec!["記号", "空白"], 24, 25),
+                    create_token("大丈夫", vec!["名詞", "形容動詞語幹"], 25, 28),
+                    create_token("です", vec!["助動詞"], 28, 30),
+                    create_token("。", vec!["記号", "句点"], 30, 31),
+                    create_token("これ", vec!["代名詞", "一般"], 31, 33),
+                    create_token("でも", vec!["助詞", "副助詞"], 33, 35),
+                    create_token("、", vec!["記号", "読点"], 35, 36),
+                    create_token("line", vec!["名詞", "一般"], 36, 40),
+                    create_token("と", vec!["助詞", "並立助詞"], 40, 41),
+                    create_token("column", vec!["名詞", "一般"], 41, 47),
+                    create_token("が", vec!["助詞", "格助詞"], 47, 48),
+                    create_token("、", vec!["記号", "読点"], 48, 49),
+                    create_token("ちゃんと", vec!["副詞", "一般"], 49, 53),
+                    create_token("計算", vec!["名詞", "サ変接続"], 53, 55),
+                    create_token("、", vec!["記号", "読点"], 55, 56),
+                    create_token("さ", vec!["動詞", "自立"], 56, 57),
+                    create_token("れ", vec!["動詞", "接尾"], 57, 58),
+                    create_token("て", vec!["助詞", "接続助詞"], 58, 59),
+                    create_token("いる", vec!["動詞", "非自立"], 59, 61),
+                    create_token("はず", vec!["名詞", "非自立"], 61, 63),
+                    create_token("、", vec!["記号", "読点"], 63, 64),
+                    create_token("その", vec!["連体詞"], 64, 66),
+                    create_token("ため", vec!["名詞", "非自立"], 66, 68),
+                    create_token("の", vec!["助詞", "連体化"], 68, 69),
+                    create_token("テキスト", vec!["名詞", "一般"], 69, 73),
+                    create_token("です", vec!["助動詞"], 73, 75),
+                    create_token("。", vec!["記号", "句点"], 75, 76),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"、\"を4つ以上使用しています".to_string(),
+                }],
+            },
+            TestCase {
+                text: "このパラグラフはOKです。\n            \n変数の名前は、名前のルールが決まっていて、そのルールは複雑で、たくさんのルールがあるので、箇条書きしましょう。\n\n3つめのパラグラフはもOKです。\n\n".to_string(),
+                config: None,
+                tokens: vec![
+                    create_token("この", vec!["連体詞"], 0, 2),
+                    create_token("パラグラフ", vec!["名詞", "一般"], 2, 7),
+                    create_token("は", vec!["助詞", "係助詞"], 7, 8),
+                    create_token("OK", vec!["名詞", "一般"], 8, 10),
+                    create_token("です", vec!["助動詞"], 10, 12),
+                    create_token("。", vec!["記号", "句点"], 12, 13),
+                    create_token("\n            \n", vec!["記号", "空白"], 13, 27),
+                    create_token("変数", vec!["名詞", "一般"], 27, 29),
+                    create_token("の", vec!["助詞", "連体化"], 29, 30),
+                    create_token("名前", vec!["名詞", "一般"], 30, 32),
+                    create_token("は", vec!["助詞", "係助詞"], 32, 33),
+                    create_token("、", vec!["記号", "読点"], 33, 34),
+                    create_token("名前", vec!["名詞", "一般"], 34, 36),
+                    create_token("の", vec!["助詞", "連体化"], 36, 37),
+                    create_token("ルール", vec!["名詞", "一般"], 37, 40),
+                    create_token("が", vec!["助詞", "格助詞"], 40, 41),
+                    create_token("決まっ", vec!["動詞", "自立"], 41, 44),
+                    create_token("て", vec!["助詞", "接続助詞"], 44, 45),
+                    create_token("い", vec!["動詞", "非自立"], 45, 46),
+                    create_token("て", vec!["助詞", "接続助詞"], 46, 47),
+                    create_token("、", vec!["記号", "読点"], 47, 48),
+                    create_token("その", vec!["連体詞"], 48, 50),
+                    create_token("ルール", vec!["名詞", "一般"], 50, 53),
+                    create_token("は", vec!["助詞", "係助詞"], 53, 54),
+                    create_token("複雑", vec!["名詞", "形容動詞語幹"], 54, 56),
+                    create_token("で", vec!["助動詞"], 56, 57),
+                    create_token("、", vec!["記号", "読点"], 57, 58),
+                    create_token("たくさん", vec!["名詞", "副詞可能"], 58, 62),
+                    create_token("の", vec!["助詞", "連体化"], 62, 63),
+                    create_token("ルール", vec!["名詞", "一般"], 63, 66),
+                    create_token("が", vec!["助詞", "格助詞"], 66, 67),
+                    create_token("ある", vec!["動詞", "自立"], 67, 69),
+                    create_token("ので", vec!["助詞", "接続助詞"], 69, 71),
+                    create_token("、", vec!["記号", "読点"], 71, 72),
+                    create_token("箇条書き", vec!["名詞", "一般"], 72, 76),
+                    create_token("し", vec!["動詞", "自立"], 76, 77),
+                    create_token("ましょう", vec!["助動詞"], 77, 81),
+                    create_token("。", vec!["記号", "句点"], 81, 82),
+                    create_token("\n\n", vec!["記号", "空白"], 82, 84),
+                    create_token("3", vec!["名詞", "数"], 84, 85),
+                    create_token("つ", vec!["名詞", "接尾"], 85, 86),
+                    create_token("め", vec!["名詞", "接尾"], 86, 87),
+                    create_token("の", vec!["助詞", "連体化"], 87, 88),
+                    create_token("パラグラフ", vec!["名詞", "一般"], 88, 93),
+                    create_token("は", vec!["助詞", "係助詞"], 93, 94),
+                    create_token("も", vec!["助詞", "係助詞"], 94, 95),
+                    create_token("OK", vec!["名詞", "一般"], 95, 97),
+                    create_token("です", vec!["助動詞"], 97, 99),
+                    create_token("。", vec!["記号", "句点"], 99, 100),
+                    create_token("\n\n", vec!["記号", "空白"], 100, 102),
+                ],
+                expected_errors: vec![ExpectedError {
+                    message: "一つの文で\"、\"を4つ以上使用しています".to_string(),
+                }],
+            },
+        ];
+        run_test_cases(valid, invalid);
+    }
+}

--- a/rules/max-ten/tsuzulint-rule.json
+++ b/rules/max-ten/tsuzulint-rule.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://raw.githubusercontent.com/simorgh3196/tsuzulint/main/schemas/v1/rule.json",
+  "rule": {
+    "name": "max-ten",
+    "version": "0.1.0",
+    "description": "Limit the number of Japanese commas (読点) in a single sentence",
+    "repository": "https://github.com/simorgh3196/tsuzulint",
+    "license": "MIT",
+    "keywords": [
+      "sentence",
+      "style",
+      "max-ten",
+      "comma"
+    ],
+    "fixable": false,
+    "node_types": [
+      "Str"
+    ],
+    "isolation_level": "block"
+  },
+  "wasm": [
+    {
+      "path": "../target/wasm32-wasip1/release/tsuzulint_rule_max_ten.wasm",
+      "hash": "ce8244e62435076ef8c725398a4af432145a26b18216c863dbac2f390ef0d348"
+    }
+  ],
+  "options": {
+    "type": "object",
+    "properties": {
+      "max": {
+        "type": "integer",
+        "default": 3,
+        "description": "Maximum number of commas allowed in a sentence"
+      },
+      "strict": {
+        "type": "boolean",
+        "default": false,
+        "description": "If false, commas sandwiched between nouns are ignored"
+      },
+      "touten": {
+        "type": "string",
+        "default": "、",
+        "description": "The comma character to count"
+      },
+      "kuten": {
+        "type": "string",
+        "default": "。",
+        "description": "The period character"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implement the \`max-ten\` rule to limit the number of Japanese commas (読点) in a single sentence.

Based on textlint-rule-max-ten, this rule brings TDD-verified logic to count commas within a sentence, optionally ignoring those sandwiched between nouns (\`strict\` option). It supports customizable limits (\`max\`) and punctuation marks (\`touten\`, \`kuten\`).

All original test cases have been successfully ported as Rust unit tests, and validation has passed for full \`make all\` integration.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* 日本語テキストの句点（読点）の最大数を制限する新しいルール「max-ten」が追加されました。
* カスタマイズ可能な設定により、最大句点数、句点文字、句読点文字、および厳密モードを調整できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->