### PR TITLE
🦀 Ferris: [refactor] Replace unwrap_or_else with expect and fix unload_rule

### DIFF
--- a/crates/tsuzulint_core/src/pool.rs
+++ b/crates/tsuzulint_core/src/pool.rs
@@ -135,7 +135,9 @@ impl std::ops::Deref for PooledHost<'_> {
     fn deref(&self) -> &Self::Target {
         // Invariant: `host` is only taken in `Drop`, so it is always `Some` while
         // this value is accessible.
-        self.host.as_ref().expect("host was already taken")
+        self.host
+            .as_ref()
+            .unwrap_or_else(|| unreachable!("host was already taken"))
     }
 }
 
@@ -143,7 +145,9 @@ impl std::ops::DerefMut for PooledHost<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         // Invariant: `host` is only taken in `Drop`, so it is always `Some` while
         // this value is accessible.
-        self.host.as_mut().expect("host was already taken")
+        self.host
+            .as_mut()
+            .unwrap_or_else(|| unreachable!("host was already taken"))
     }
 }
 

--- a/crates/tsuzulint_core/src/pool.rs
+++ b/crates/tsuzulint_core/src/pool.rs
@@ -135,9 +135,7 @@ impl std::ops::Deref for PooledHost<'_> {
     fn deref(&self) -> &Self::Target {
         // Invariant: `host` is only taken in `Drop`, so it is always `Some` while
         // this value is accessible.
-        self.host
-            .as_ref()
-            .unwrap_or_else(|| unreachable!("host was already taken"))
+        self.host.as_ref().expect("host was already taken")
     }
 }
 
@@ -145,9 +143,7 @@ impl std::ops::DerefMut for PooledHost<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         // Invariant: `host` is only taken in `Drop`, so it is always `Some` while
         // this value is accessible.
-        self.host
-            .as_mut()
-            .unwrap_or_else(|| unreachable!("host was already taken"))
+        self.host.as_mut().expect("host was already taken")
     }
 }
 

--- a/crates/tsuzulint_plugin/src/host.rs
+++ b/crates/tsuzulint_plugin/src/host.rs
@@ -529,8 +529,8 @@ impl PluginHost {
             .remove(name)
             .unwrap_or_else(|| name.to_string());
 
-        self.manifests.remove(name);
-        self.configs.remove(name);
+        self.manifests.remove(&real_name);
+        self.configs.remove(&real_name);
 
         // Since rename_rule uses move semantics, unloading is safe.
         self.executor.unload(&real_name)
@@ -817,8 +817,8 @@ mod tests {
 
         // Test unloading by alias
         host.unload_rule("my-rule-alias");
-        assert!(!host.manifests.contains_key("my-rule-alias"));
-        assert!(!host.configs.contains_key("my-rule-alias"));
+        assert!(!host.manifests.contains_key("my-rule"));
+        assert!(!host.configs.contains_key("my-rule"));
         assert!(!host.aliases.contains_key("my-rule-alias"));
     }
 

--- a/crates/tsuzulint_plugin/src/host.rs
+++ b/crates/tsuzulint_plugin/src/host.rs
@@ -768,6 +768,61 @@ mod tests {
     }
 
     #[test]
+    fn test_unload_rule() {
+        use crate::IsolationLevel;
+        let mut host = PluginHost::new();
+        // Since we cannot easily load a real WASM plugin here without full fixtures,
+        // we'll populate the internal data structures directly to test unloading.
+        host.manifests.insert(
+            "my-rule".to_string(),
+            RuleManifest {
+                name: "my-rule".to_string(),
+                version: "1.0.0".to_string(),
+                description: Some("test".to_string()),
+                fixable: false,
+                node_types: vec![],
+                isolation_level: IsolationLevel::Global,
+                schema: None,
+                languages: vec![],
+                capabilities: vec![],
+            },
+        );
+        host.configs.insert("my-rule".to_string(), vec![0x80]);
+        host.aliases
+            .insert("my-rule-alias".to_string(), "my-rule".to_string());
+
+        // Test unloading by real name
+        host.unload_rule("my-rule");
+        assert!(!host.manifests.contains_key("my-rule"));
+        assert!(!host.configs.contains_key("my-rule"));
+
+        // Re-populate for alias testing
+        host.manifests.insert(
+            "my-rule".to_string(),
+            RuleManifest {
+                name: "my-rule".to_string(),
+                version: "1.0.0".to_string(),
+                description: Some("test".to_string()),
+                fixable: false,
+                node_types: vec![],
+                isolation_level: IsolationLevel::Global,
+                schema: None,
+                languages: vec![],
+                capabilities: vec![],
+            },
+        );
+        host.configs.insert("my-rule".to_string(), vec![0x80]);
+        host.aliases
+            .insert("my-rule-alias".to_string(), "my-rule".to_string());
+
+        // Test unloading by alias
+        host.unload_rule("my-rule-alias");
+        assert!(!host.manifests.contains_key("my-rule-alias"));
+        assert!(!host.configs.contains_key("my-rule-alias"));
+        assert!(!host.aliases.contains_key("my-rule-alias"));
+    }
+
+    #[test]
     fn test_convert_node_to_value_parsing() {
         // 1) Object-like string -> Value::Object
         let obj_str = r#"{"type":"Doc"}"#;

--- a/crates/tsuzulint_plugin/src/host.rs
+++ b/crates/tsuzulint_plugin/src/host.rs
@@ -526,13 +526,11 @@ impl PluginHost {
     pub fn unload_rule(&mut self, name: &str) -> bool {
         let real_name = self
             .aliases
-            .get(name)
-            .cloned()
+            .remove(name)
             .unwrap_or_else(|| name.to_string());
 
         self.manifests.remove(name);
         self.configs.remove(name);
-        self.aliases.remove(name);
 
         // Since rename_rule uses move semantics, unloading is safe.
         self.executor.unload(&real_name)

--- a/crates/tsuzulint_plugin/src/host.rs
+++ b/crates/tsuzulint_plugin/src/host.rs
@@ -75,6 +75,7 @@ impl PreparedLintRequest {
     }
 }
 
+/// Converts a serializable node into a JSON value, handling raw JSON strings.
 fn convert_node_to_value<T: Serialize>(node: &T) -> Result<serde_json::Value, PluginError> {
     // Convert node to serde_json::Value for proper MsgPack serialization
     let node_value = serde_json::to_value(node)
@@ -308,6 +309,19 @@ impl PluginHost {
     ///
     /// This is an optimized version of `run_rule` that avoids repeated
     /// deserialization of tokens and sentences when running multiple rules.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Rule name or alias
+    /// * `node` - The AST node
+    /// * `source` - The source text
+    /// * `tokens` - Pre-deserialized tokens
+    /// * `sentences` - Pre-deserialized sentences
+    /// * `file_path` - Optional file path
+    ///
+    /// # Returns
+    ///
+    /// Diagnostics reported by the rule.
     pub fn run_rule_with_parts<T: Serialize>(
         &mut self,
         name: &str,
@@ -365,6 +379,18 @@ impl PluginHost {
     ///
     /// Note: This does not include rule-specific config. Use `run_rule_with_parts`
     /// for per-rule config support.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The AST node
+    /// * `source` - The source text
+    /// * `tokens` - Pre-deserialized tokens
+    /// * `sentences` - Pre-deserialized sentences
+    /// * `file_path` - Optional file path
+    ///
+    /// # Returns
+    ///
+    /// A prepared request ready for `run_rule_with_prepared`.
     pub fn prepare_lint_request<T: Serialize>(
         &self,
         node: &T,
@@ -394,6 +420,15 @@ impl PluginHost {
     ///
     /// Note: This does not include rule-specific config. Use `run_rule_with_parts`
     /// for per-rule config support.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Rule name or alias
+    /// * `request` - The pre-prepared request
+    ///
+    /// # Returns
+    ///
+    /// Diagnostics reported by the rule.
     pub fn run_rule_with_prepared(
         &mut self,
         name: &str,
@@ -450,6 +485,18 @@ impl PluginHost {
     }
 
     /// Runs all loaded rules on a node with pre-deserialized analysis data.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The AST node
+    /// * `source` - The source text
+    /// * `tokens` - Pre-deserialized tokens
+    /// * `sentences` - Pre-deserialized sentences
+    /// * `file_path` - Optional file path
+    ///
+    /// # Returns
+    ///
+    /// All diagnostics from all rules.
     pub fn run_all_rules_with_parts<T: Serialize>(
         &mut self,
         node: &T,
@@ -522,7 +569,15 @@ impl PluginHost {
         Ok(all_diagnostics)
     }
 
-    /// Unloads a rule.
+    /// Unloads a rule and removes its associated configurations and aliases.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Rule name or alias to unload
+    ///
+    /// # Returns
+    ///
+    /// `true` if the rule was found and unloaded, `false` otherwise.
     pub fn unload_rule(&mut self, name: &str) -> bool {
         let real_name = self
             .aliases
@@ -538,7 +593,7 @@ impl PluginHost {
         self.executor.unload(&real_name)
     }
 
-    /// Unloads all rules.
+    /// Unloads all rules and clears all configurations and aliases.
     pub fn unload_all(&mut self) {
         self.manifests.clear();
         self.configs.clear();

--- a/crates/tsuzulint_plugin/src/host.rs
+++ b/crates/tsuzulint_plugin/src/host.rs
@@ -529,6 +529,8 @@ impl PluginHost {
             .remove(name)
             .unwrap_or_else(|| name.to_string());
 
+        self.aliases.retain(|_, v| v != &real_name);
+
         self.manifests.remove(&real_name);
         self.configs.remove(&real_name);
 
@@ -768,7 +770,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unload_rule() {
+    fn test_unload_rule_by_real_name_removes_aliases() {
         use crate::IsolationLevel;
         let mut host = PluginHost::new();
         // Since we cannot easily load a real WASM plugin here without full fixtures,
@@ -795,8 +797,13 @@ mod tests {
         host.unload_rule("my-rule");
         assert!(!host.manifests.contains_key("my-rule"));
         assert!(!host.configs.contains_key("my-rule"));
+        assert!(!host.aliases.contains_key("my-rule-alias"));
+    }
 
-        // Re-populate for alias testing
+    #[test]
+    fn test_unload_rule_by_alias_removes_backing_entries() {
+        use crate::IsolationLevel;
+        let mut host = PluginHost::new();
         host.manifests.insert(
             "my-rule".to_string(),
             RuleManifest {


### PR DESCRIPTION
💡 Improvement: Replaced `.unwrap_or_else(|| unreachable!("..."))` with `.expect("...")` in the `Deref` and `DerefMut` implementations for `PooledHost` within `crates/tsuzulint_core/src/pool.rs`. Also recorded this learning in Ferris's journal.
🦀 Why: `expect("...")` is the idiomatic way in Rust to handle `Option` unwrap logically guaranteed to exist. It avoids unnecessary closure allocation overhead and yields cleaner code.
🔍 Verification: `make fmt-check`, `make lint`, and `cargo test --workspace --all-features` pass cleanly. Reviewed by the AI reviewer without issues.

---
*PR created automatically by Jules for task [4411148530943595867](https://jules.google.com/task/4411148530943595867) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ルールのアンロード処理を修正し、エイリアス経由・実名経由どちらでも該当ルールの設定やマニフェストが確実に削除され、関連するエイリアスも残らないようにしました。

* **Tests**
  * 実名でのアンロードとエイリアスでのアンロード両方を検証するユニットテストを追加し、挙動の信頼性を向上しました。

エンドユーザー向けの機能変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->