### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU / OOM vulnerability in file fix

### DIFF
--- a/crates/tsuzulint_core/src/file_linter.rs
+++ b/crates/tsuzulint_core/src/file_linter.rs
@@ -1,7 +1,6 @@
 //! Single file linting logic.
 
 use std::collections::{HashMap, HashSet};
-use std::io::Read;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -17,6 +16,9 @@ use crate::diagnostic_dist::distribute_diagnostics;
 use crate::error::LinterError;
 use crate::ignore_range::extract_ignore_ranges;
 use crate::result::LintResult;
+use crate::safe_io::{
+    check_file_metadata, clear_nonblocking, handle_io_err, open_nonblocking, read_to_string_bounded,
+};
 
 pub const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
 
@@ -49,65 +51,22 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
     // Open with O_NONBLOCK so that opening a FIFO (or other special file)
     // does not block. This eliminates the TOCTOU window between a metadata
     // check and the actual open call.
-    let file = open_nonblocking(path)
-        .map_err(|e| LinterError::file(format!("Failed to open {}: {}", path.display(), e)))?;
+    let mut file = handle_io_err(open_nonblocking(path), path, "Failed to open")?;
 
     // Verify the opened fd refers to a regular file (TOCTOU-safe, uses fstat).
-    let metadata = file.metadata().map_err(|e| {
-        LinterError::file(format!(
-            "Failed to read metadata for {}: {}",
-            path.display(),
-            e
-        ))
-    })?;
+    let metadata = handle_io_err(file.metadata(), path, "Failed to read metadata for")?;
+    check_file_metadata(&metadata, MAX_FILE_SIZE, path)?;
 
-    if !metadata.is_file() {
-        return Err(LinterError::file(format!(
-            "Not a regular file: {}",
-            path.display()
-        )));
-    }
-
-    if metadata.len() > MAX_FILE_SIZE {
-        return Err(LinterError::file(format!(
-            "File size exceeds limit of {} bytes: {}",
-            MAX_FILE_SIZE,
-            path.display()
-        )));
-    }
-
-    // Initialize string with known file size to minimize reallocations and optimize performance
-    let mut content = String::with_capacity(metadata.len() as usize);
     // Clear O_NONBLOCK so that subsequent reads block normally.
-    clear_nonblocking(&file).map_err(|e| {
-        LinterError::file(format!(
-            "Failed to clear O_NONBLOCK on {}: {}",
-            path.display(),
-            e
-        ))
-    })?;
-    file.take(MAX_FILE_SIZE + 1)
-        .read_to_string(&mut content)
-        .map_err(|e| {
-            // EAGAIN / EWOULDBLOCK can theoretically appear if O_NONBLOCK was not
-            // successfully cleared; surface a clear error in that case.
-            #[cfg(unix)]
-            if e.raw_os_error() == Some(libc::EAGAIN) {
-                return LinterError::file(format!(
-                    "Failed to read {} (EAGAIN: O_NONBLOCK still set)",
-                    path.display()
-                ));
-            }
-            LinterError::file(format!("Failed to read {}: {}", path.display(), e))
-        })?;
+    handle_io_err(
+        clear_nonblocking(&file),
+        path,
+        "Failed to clear O_NONBLOCK on",
+    )?;
 
-    if content.len() as u64 > MAX_FILE_SIZE {
-        return Err(LinterError::file(format!(
-            "File size exceeds limit of {} bytes: {}",
-            MAX_FILE_SIZE,
-            path.display()
-        )));
-    }
+    // Bounded read: caps content at MAX_FILE_SIZE even when metadata.len()
+    // underreports the file size (e.g. pseudo-files under /proc, /dev/zero).
+    let content = read_to_string_bounded(&mut file, MAX_FILE_SIZE, path)?;
 
     let content_hash = CacheManager::hash_content(&content);
 
@@ -398,43 +357,6 @@ fn select_parser(extension: &str) -> FileParser {
     } else {
         FileParser::Text(PlainTextParser::new())
     }
-}
-
-/// Opens a file with `O_NONBLOCK` on Unix to avoid blocking on FIFOs or other
-/// special files.  After a successful open the caller must clear `O_NONBLOCK`
-/// before performing blocking reads (use [`clear_nonblocking`]).
-///
-/// On non-Unix platforms this is a plain `fs::File::open`.
-fn open_nonblocking(path: &Path) -> std::io::Result<std::fs::File> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_NONBLOCK)
-            .open(path)
-    }
-    #[cfg(not(unix))]
-    {
-        std::fs::File::open(path)
-    }
-}
-
-/// Clears the `O_NONBLOCK` flag on an open file descriptor so that subsequent
-/// reads block normally.  This is a no-op on non-Unix platforms.
-#[cfg(unix)]
-fn clear_nonblocking(file: &std::fs::File) -> std::io::Result<()> {
-    use std::os::unix::io::AsFd;
-    let fd = file.as_fd();
-    let flags = rustix::fs::fcntl_getfl(fd)?;
-    let new_flags = flags - rustix::fs::OFlags::NONBLOCK;
-    rustix::fs::fcntl_setfl(fd, new_flags)?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn clear_nonblocking(_file: &std::fs::File) -> std::io::Result<()> {
-    Ok(())
 }
 
 fn to_raw_value<T: serde::Serialize>(

--- a/crates/tsuzulint_core/src/fixer.rs
+++ b/crates/tsuzulint_core/src/fixer.rs
@@ -8,6 +8,10 @@ use tracing::{debug, warn};
 use tsuzulint_plugin::{Diagnostic, Fix};
 
 use crate::LinterError;
+use crate::file_linter::MAX_FILE_SIZE;
+use crate::safe_io::{
+    check_file_metadata, clear_nonblocking, handle_io_err, open_nonblocking, read_to_string_bounded,
+};
 
 /// Result of applying fixes to a file.
 #[derive(Debug)]
@@ -133,15 +137,50 @@ pub(crate) fn filter_overlapping_fixes(mut fixes: Vec<&Fix>) -> Vec<&Fix> {
     result
 }
 
+/// Reads `path` safely: rejects non-regular files (incl. FIFOs that would
+/// otherwise block), caps the read at `max_size` bytes to prevent
+/// memory-exhaustion via pseudo-files (e.g. `/dev/zero`), and uses
+/// `O_NONBLOCK` on Unix to close the TOCTOU window around the open itself.
+fn read_file_bounded(path: &Path, max_size: u64) -> Result<String, LinterError> {
+    // O_NONBLOCK open: never blocks on FIFOs or TTYs, and gives us an fd we
+    // can fstat (instead of racing a lstat/open pair).
+    let mut file = handle_io_err(open_nonblocking(path), path, "Failed to open")?;
+
+    // fstat-based metadata on the opened fd; no TOCTOU window vs. a separate
+    // lstat on `path`.  This replaces the previous
+    // `file.metadata().unwrap_or_else(|_| unreachable!())` which could panic
+    // on platforms where `fstat` can still fail after a successful open.
+    let metadata = handle_io_err(file.metadata(), path, "Failed to read metadata for")?;
+    check_file_metadata(&metadata, max_size, path)?;
+
+    // Clear O_NONBLOCK so the subsequent read can block as usual.
+    handle_io_err(
+        clear_nonblocking(&file),
+        path,
+        "Failed to clear O_NONBLOCK on",
+    )?;
+
+    // Bounded read: `/proc/version`, `/dev/zero`, and similar pseudo-files
+    // may report `metadata.len() == 0` while producing arbitrarily many
+    // bytes, so we must cap at the content level too.
+    read_to_string_bounded(&mut file, max_size, path)
+}
+
+fn apply_fixes_to_file_inner(
+    path: &Path,
+    diagnostics: &[Diagnostic],
+    max_size: u64,
+) -> Result<FixerResult, LinterError> {
+    let content = read_file_bounded(path, max_size)?;
+    Ok(apply_fixes_to_content(&content, diagnostics))
+}
+
 /// Applies fixes to a file and writes the result.
 pub fn apply_fixes_to_file(
     path: &Path,
     diagnostics: &[Diagnostic],
 ) -> Result<FixerResult, LinterError> {
-    let content = fs::read_to_string(path)
-        .map_err(|e| LinterError::file(format!("Failed to read {}: {}", path.display(), e)))?;
-
-    let result = apply_fixes_to_content(&content, diagnostics);
+    let result = apply_fixes_to_file_inner(path, diagnostics, MAX_FILE_SIZE)?;
 
     if result.modified {
         fs::write(path, &result.fixed_content)
@@ -498,15 +537,191 @@ mod tests {
 
         let diagnostics = vec![make_diagnostic_with_fix(0, 5, "Hi")];
 
-        // This should fail to read the file
+        // This should fail to open the file
         let result = apply_fixes_to_file(&path, &diagnostics);
 
         match result {
             Err(LinterError::File(msg)) => {
-                assert!(msg.contains("Failed to read"));
+                assert!(
+                    msg.contains("Failed to open"),
+                    "Unexpected error message: {}",
+                    msg
+                );
             }
             Ok(_) => panic!("Expected LinterError::File, got Ok"),
             Err(e) => panic!("Expected LinterError::File, got {:?}", e),
         }
+    }
+
+    #[test]
+    fn apply_fixes_to_file_rejects_directory() {
+        // Directories are not regular files and must be rejected.
+        let dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let diagnostics: Vec<Diagnostic> = vec![];
+        let result = apply_fixes_to_file(dir.path(), &diagnostics);
+
+        match result {
+            Err(LinterError::File(msg)) => {
+                assert!(
+                    msg.contains("Not a regular file")
+                        || msg.contains("Failed to open")
+                        || msg.contains("Access is denied")
+                        || msg.contains("Permission denied"),
+                    "Unexpected error message: {}",
+                    msg
+                );
+            }
+            Err(e) => panic!("Expected LinterError::File, got {:?}", e),
+            Ok(_) => panic!("Expected error for directory input, got Ok"),
+        }
+    }
+
+    #[test]
+    fn apply_fixes_to_file_inner_rejects_oversized_metadata() {
+        // Simulate a file whose metadata-reported size already exceeds the
+        // limit; we must reject before ever issuing a read.
+        use tempfile::NamedTempFile;
+        let file = NamedTempFile::new().expect("Failed to create temp file");
+        file.as_file().set_len(100).expect("Failed to set len");
+        let path = file.into_temp_path();
+
+        let res = apply_fixes_to_file_inner(&path, &[], 10);
+        let msg = res.unwrap_err().to_string();
+        assert!(msg.contains("exceeds limit"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn apply_fixes_to_file_inner_rejects_oversized_content() {
+        // Write more bytes than max_size — metadata check passes (size is
+        // within limit), but the bounded read should then reject because the
+        // +1 byte makes total > max_size.
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"123456").unwrap();
+        let path = file.into_temp_path();
+
+        let res = apply_fixes_to_file_inner(&path, &[], 3);
+        let msg = res.unwrap_err().to_string();
+        assert!(msg.contains("exceeds limit"), "unexpected: {msg}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn apply_fixes_to_file_inner_proc_file_is_bounded() {
+        // /proc/version reports metadata.len() == 0 but produces many bytes
+        // when read.  With max_size = 5, metadata check passes, then the
+        // bounded read must reject the oversized content — this is the
+        // OOM-guard we rely on for /dev/zero-style pseudo-files.
+        let path = Path::new("/proc/version");
+        if path.exists() {
+            let res = apply_fixes_to_file_inner(path, &[], 5);
+            assert!(res.is_err());
+            assert!(res.unwrap_err().to_string().contains("exceeds limit"));
+        }
+    }
+
+    /// Opening a FIFO must not hang the `--fix` path.  With `O_NONBLOCK` the
+    /// open returns immediately, and `check_file_metadata` then rejects the
+    /// FIFO because it is not a regular file — all bounded by a real
+    /// wall-clock deadline to catch regressions.
+    #[test]
+    #[cfg(unix)]
+    fn apply_fixes_to_file_fifo_does_not_block() {
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let fifo = dir.path().join("fifo");
+        let c_path = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
+        // SAFETY: c_path is a valid nul-terminated string.
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+        if rc != 0 {
+            eprintln!("mkfifo not supported; skipping");
+            return;
+        }
+
+        let (tx, rx) = mpsc::channel();
+        let fifo_path = fifo.clone();
+        let handle = thread::spawn(move || {
+            let res = apply_fixes_to_file(&fifo_path, &[]);
+            let _ = tx.send(res);
+        });
+
+        // If the FIFO still blocks we'd hang here; 5s is generous but
+        // finite, so a regression surfaces as a test timeout rather than a
+        // hang.
+        let res = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("apply_fixes_to_file blocked on FIFO");
+        let _ = handle.join();
+
+        match res {
+            Err(LinterError::File(msg)) => {
+                assert!(
+                    msg.contains("Not a regular file") || msg.contains("Failed to open"),
+                    "unexpected error: {msg}"
+                );
+            }
+            Err(e) => panic!("Expected LinterError::File, got {e:?}"),
+            Ok(_) => panic!("FIFO should not be accepted as a fixable file"),
+        }
+    }
+
+    /// `/dev/zero` is a regular stream of NUL bytes.  Without the bounded
+    /// read, `fs::read_to_string` would allocate unbounded memory and OOM.
+    /// With the bounded read we get a clean `exceeds limit` error.
+    #[test]
+    #[cfg(unix)]
+    fn apply_fixes_to_file_dev_zero_is_bounded() {
+        let path = Path::new("/dev/zero");
+        if !path.exists() {
+            return;
+        }
+        let res = apply_fixes_to_file_inner(path, &[], 1024);
+        match res {
+            Err(LinterError::File(msg)) => {
+                // Either "Not a regular file" (if metadata reports it as a
+                // char device) or "exceeds limit" (if metadata passes but
+                // the read overflows).  Both are safe outcomes; what we
+                // must *not* see is an unbounded allocation.
+                assert!(
+                    msg.contains("Not a regular file")
+                        || msg.contains("exceeds limit")
+                        || msg.contains("Failed to read"),
+                    "unexpected error for /dev/zero: {msg}"
+                );
+            }
+            Err(e) => panic!("Expected LinterError::File, got {e:?}"),
+            Ok(_) => panic!("/dev/zero must not be accepted as a fixable file"),
+        }
+    }
+
+    /// Symlink-swap TOCTOU race: even if an attacker swaps the symlink
+    /// target between metadata and open, the fix path reads from the fd we
+    /// opened ourselves (via `open_nonblocking` + `file.metadata`), not by
+    /// reopening the path.  This test just exercises the symlink-followed
+    /// path to make sure a regular-file symlink is still accepted.
+    #[test]
+    #[cfg(unix)]
+    fn apply_fixes_to_file_follows_symlink_to_regular_file() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.txt");
+        std::fs::File::create(&real)
+            .unwrap()
+            .write_all(b"Hello World")
+            .unwrap();
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let diagnostics = vec![make_diagnostic_with_fix(6, 11, "Rust")];
+        let result = apply_fixes_to_file(&link, &diagnostics).expect("symlink fix must succeed");
+        assert!(result.modified);
+        assert_eq!(result.fixed_content, "Hello Rust");
+
+        // The real file on disk is updated (the symlink was followed).
+        let on_disk = std::fs::read_to_string(&real).unwrap();
+        assert_eq!(on_disk, "Hello Rust");
     }
 }

--- a/crates/tsuzulint_core/src/lib.rs
+++ b/crates/tsuzulint_core/src/lib.rs
@@ -41,6 +41,7 @@ pub mod resolver;
 mod result;
 mod rule_loader;
 pub mod rule_manifest;
+mod safe_io;
 pub mod walker;
 
 pub use config::{

--- a/crates/tsuzulint_core/src/safe_io.rs
+++ b/crates/tsuzulint_core/src/safe_io.rs
@@ -1,0 +1,273 @@
+//! Safe file I/O helpers shared between the linter and the fixer.
+//!
+//! This module centralises the checks that must be performed when opening and
+//! reading user-provided files:
+//!
+//! - [`open_nonblocking`] opens a file with `O_NONBLOCK` on Unix so that a
+//!   FIFO / named pipe does not block the process indefinitely.  After the
+//!   caller has validated the file kind with [`check_file_metadata`], the
+//!   flag must be cleared via [`clear_nonblocking`] before performing a
+//!   blocking read.
+//! - [`check_file_metadata`] rejects non-regular files and files whose
+//!   reported size exceeds a configurable limit.
+//! - [`check_limit`] is the size-bound check that is also used again after
+//!   reading, because some pseudo-files (e.g. `/proc/version`, `/dev/zero`)
+//!   report a size of 0 while producing arbitrarily many bytes.
+//! - [`read_to_string_bounded`] reads a file into a `String` with a hard cap,
+//!   returning a descriptive [`LinterError`] on failure.
+//! - [`handle_io_err`] converts a `std::io::Result` into a
+//!   `Result<_, LinterError>` with a consistent error message format.
+//!
+//! Keeping these helpers in a single module avoids subtle divergence between
+//! the linter and the fixer paths (both of which must harden against the
+//! same class of TOCTOU / resource-exhaustion attacks).
+
+use std::fs;
+use std::io::Read;
+use std::path::Path;
+
+use crate::error::LinterError;
+
+/// Opens a file with `O_NONBLOCK` on Unix so that opening a FIFO (or other
+/// special file) does not block.  This also closes the TOCTOU window between
+/// a pre-open metadata check and the actual open call — the caller should
+/// subsequently validate the opened file with [`check_file_metadata`] (which
+/// uses `fstat` semantics via `File::metadata`).
+///
+/// Before performing blocking reads, the caller **must** clear `O_NONBLOCK`
+/// via [`clear_nonblocking`] to avoid spurious `EAGAIN` errors.
+///
+/// On non-Unix platforms this is a plain `fs::File::open`.
+pub(crate) fn open_nonblocking(path: &Path) -> std::io::Result<fs::File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(path)
+    }
+    #[cfg(not(unix))]
+    {
+        fs::File::open(path)
+    }
+}
+
+/// Clears the `O_NONBLOCK` flag on an open file descriptor so that subsequent
+/// reads block normally.  This is a no-op on non-Unix platforms.
+#[cfg(unix)]
+pub(crate) fn clear_nonblocking(file: &fs::File) -> std::io::Result<()> {
+    use std::os::unix::io::AsFd;
+    let fd = file.as_fd();
+    let flags = rustix::fs::fcntl_getfl(fd)?;
+    let new_flags = flags - rustix::fs::OFlags::NONBLOCK;
+    rustix::fs::fcntl_setfl(fd, new_flags)?;
+    Ok(())
+}
+
+/// Non-Unix no-op.
+#[cfg(not(unix))]
+pub(crate) fn clear_nonblocking(_file: &fs::File) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Converts a `std::io::Result` into a `Result<_, LinterError>` with a
+/// consistent `"<msg> <path>: <err>"` message format.
+pub(crate) fn handle_io_err<T>(
+    res: std::io::Result<T>,
+    path: &Path,
+    msg: &str,
+) -> Result<T, LinterError> {
+    res.map_err(|e| LinterError::file(format!("{} {}: {}", msg, path.display(), e)))
+}
+
+/// Checks that `size` does not exceed `limit`, producing a descriptive
+/// `LinterError` otherwise.
+pub(crate) fn check_limit(size: u64, limit: u64, path: &Path) -> Result<(), LinterError> {
+    if size > limit {
+        Err(LinterError::file(format!(
+            "File size exceeds limit of {} bytes: {}",
+            limit,
+            path.display()
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+/// Verifies that `metadata` describes a regular file (rejects directories,
+/// sockets, FIFOs on platforms that surface them as non-regular, etc.) and
+/// that its reported size is within `max_size`.
+///
+/// Note: some pseudo-files report size 0 while yielding many bytes when read;
+/// callers must therefore **also** check the content length after reading via
+/// [`check_limit`].
+pub(crate) fn check_file_metadata(
+    metadata: &fs::Metadata,
+    max_size: u64,
+    path: &Path,
+) -> Result<(), LinterError> {
+    if !metadata.is_file() {
+        return Err(LinterError::file(format!(
+            "Not a regular file: {}",
+            path.display()
+        )));
+    }
+    check_limit(metadata.len(), max_size, path)
+}
+
+/// Reads up to `max_size + 1` bytes from `file` into a freshly allocated
+/// `String` and rejects the result if the decoded content exceeds `max_size`
+/// bytes.  The caller is responsible for clearing `O_NONBLOCK` (via
+/// [`clear_nonblocking`]) before calling this function; if `O_NONBLOCK` is
+/// still set on Unix, the returned error explicitly names the condition so
+/// that operators can diagnose it.
+///
+/// The `+ 1` trick lets us distinguish "file was exactly `max_size` bytes"
+/// from "file was larger than the limit" after the read completes.
+pub(crate) fn read_to_string_bounded(
+    file: &mut fs::File,
+    max_size: u64,
+    path: &Path,
+) -> Result<String, LinterError> {
+    let capacity_hint = file
+        .metadata()
+        .map(|m| m.len() as usize)
+        .unwrap_or(0)
+        .min(max_size as usize);
+    let mut content = String::with_capacity(capacity_hint);
+    file.take(max_size + 1)
+        .read_to_string(&mut content)
+        .map_err(|e| {
+            // EAGAIN / EWOULDBLOCK can theoretically appear if O_NONBLOCK was
+            // not successfully cleared; surface a clear error in that case.
+            #[cfg(unix)]
+            if e.raw_os_error() == Some(libc::EAGAIN) {
+                return LinterError::file(format!(
+                    "Failed to read {} (EAGAIN: O_NONBLOCK still set)",
+                    path.display()
+                ));
+            }
+            LinterError::file(format!("Failed to read {}: {}", path.display(), e))
+        })?;
+
+    check_limit(content.len() as u64, max_size, path)?;
+    Ok(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn handle_io_err_maps_err() {
+        let err = std::io::Error::new(std::io::ErrorKind::NotFound, "missing");
+        let res: Result<(), _> = handle_io_err(Err(err), Path::new("a.txt"), "Failed to open");
+        let msg = res.unwrap_err().to_string();
+        assert!(msg.contains("Failed to open"), "unexpected: {msg}");
+        assert!(msg.contains("a.txt"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn handle_io_err_passes_ok() {
+        let ok: Result<u32, _> = handle_io_err(Ok(42), Path::new("a.txt"), "Failed");
+        assert_eq!(ok.unwrap(), 42);
+    }
+
+    #[test]
+    fn check_limit_rejects_oversize() {
+        assert!(check_limit(10, 5, Path::new("a.txt")).is_err());
+    }
+
+    #[test]
+    fn check_limit_accepts_equal() {
+        assert!(check_limit(5, 5, Path::new("a.txt")).is_ok());
+    }
+
+    #[test]
+    fn check_file_metadata_rejects_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = std::fs::metadata(dir.path()).unwrap();
+        let err = check_file_metadata(&meta, 100, dir.path()).unwrap_err();
+        assert!(err.to_string().contains("Not a regular file"));
+    }
+
+    #[test]
+    fn check_file_metadata_accepts_small_file() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let meta = std::fs::metadata(file.path()).unwrap();
+        assert!(check_file_metadata(&meta, 100, file.path()).is_ok());
+    }
+
+    #[test]
+    fn read_to_string_bounded_reads_content() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hello").unwrap();
+        let path = tmp.path().to_path_buf();
+        let mut file = fs::File::open(&path).unwrap();
+        let s = read_to_string_bounded(&mut file, 100, &path).unwrap();
+        assert_eq!(s, "hello");
+    }
+
+    #[test]
+    fn read_to_string_bounded_rejects_oversize() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"123456789").unwrap();
+        let path = tmp.path().to_path_buf();
+        let mut file = fs::File::open(&path).unwrap();
+        let err = read_to_string_bounded(&mut file, 4, &path).unwrap_err();
+        assert!(err.to_string().contains("exceeds limit"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn open_nonblocking_opens_regular_file() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hi").unwrap();
+        let file = open_nonblocking(tmp.path()).unwrap();
+        assert!(file.metadata().unwrap().is_file());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn clear_nonblocking_clears_flag() {
+        use std::os::unix::io::AsFd;
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let file = open_nonblocking(tmp.path()).unwrap();
+        let flags_before = rustix::fs::fcntl_getfl(file.as_fd()).unwrap();
+        assert!(flags_before.contains(rustix::fs::OFlags::NONBLOCK));
+        clear_nonblocking(&file).unwrap();
+        let flags_after = rustix::fs::fcntl_getfl(file.as_fd()).unwrap();
+        assert!(!flags_after.contains(rustix::fs::OFlags::NONBLOCK));
+    }
+
+    /// FIFO opens succeed immediately with `O_NONBLOCK` (no writer attached)
+    /// and subsequent reads return EOF rather than blocking.  The linter
+    /// rejects the FIFO at [`check_file_metadata`] because it is not a
+    /// regular file.
+    #[test]
+    #[cfg(unix)]
+    fn open_nonblocking_does_not_block_on_fifo() {
+        use std::os::unix::fs::FileTypeExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("pipe");
+
+        // Create the FIFO via libc; skip the test on platforms where mkfifo
+        // is unavailable (e.g. exotic targets).
+        let c_path = std::ffi::CString::new(fifo.to_str().unwrap()).unwrap();
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o644) };
+        if rc != 0 {
+            eprintln!("mkfifo failed; skipping");
+            return;
+        }
+
+        let file = open_nonblocking(&fifo).expect("O_NONBLOCK open of FIFO must not block");
+        let meta = file.metadata().unwrap();
+        assert!(meta.file_type().is_fifo());
+        assert!(!meta.is_file());
+
+        let err = check_file_metadata(&meta, 100, &fifo).unwrap_err();
+        assert!(err.to_string().contains("Not a regular file"));
+    }
+}


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: `std::fs::read_to_string` was used, which exposes the system to a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the file can grow significantly between checks, or Denial of Service via Out-Of-Memory (OOM) via reading giant streams like `/dev/zero` or huge artifacts. 
🎯 **Impact**: Out-of-memory or unbounded data read vulnerability that can bring down the application.
🔧 **Fix**: Substituted `std::fs::read_to_string` with a bounded file reader using `file.take()` logic leveraging `MAX_FILE_SIZE`.
✅ **Verification**: Run `cargo test -p tsuzulint_core -- fixer`. Tests run successfully.

---
*PR created automatically by Jules for task [1448630165237341829](https://jules.google.com/task/1448630165237341829) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **修正**
  * ファイル読み取り前のバリデーションを強化：通常ファイルかの確認とファイルサイズ上限を厳格化
  * 存在しない／開けないファイルに対して早期に明確なエラーメッセージを返すよう改善
  * 読み取り時に上限バウンドを導入し、上限超過を確実に検出

* **テスト**
  * ディレクトリ指定、メタデータでの上限超過、FIFOを含む境界ケースの単体テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->