### PR TITLE
🛡️ Sentinel: [HIGH] Fix OOM/TOCTOU in WASM resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,6 +2541,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4634,6 +4646,7 @@ dependencies = [
  "extism-manifest",
  "futures-util",
  "miette",
+ "nix",
  "proptest",
  "reqwest 0.12.28",
  "serde",

--- a/crates/tsuzulint_registry/Cargo.toml
+++ b/crates/tsuzulint_registry/Cargo.toml
@@ -25,6 +25,9 @@ dirs = "6.0.0"
 url = "2.5.8"
 # semver.workspace = true
 
+[target.'cfg(unix)'.dev-dependencies]
+nix = { version = "0.31.2", features = ["fs"] }
+
 [dev-dependencies]
 wiremock.workspace = true
 proptest = "1.10"

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -24,7 +24,11 @@ fn read_wasm_file(path: &Path) -> Result<Vec<u8>, std::io::Error> {
     if metadata.len() > MAX_WASM_SIZE {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("WASM file too large: {} bytes exceeds maximum of {} bytes", metadata.len(), MAX_WASM_SIZE)
+            format!(
+                "WASM file too large: {} bytes exceeds maximum of {} bytes",
+                metadata.len(),
+                MAX_WASM_SIZE
+            ),
         ));
     }
 
@@ -36,7 +40,10 @@ fn read_wasm_file(path: &Path) -> Result<Vec<u8>, std::io::Error> {
     if buffer.len() as u64 > MAX_WASM_SIZE {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("WASM file too large: exceeds maximum of {} bytes", MAX_WASM_SIZE)
+            format!(
+                "WASM file too large: exceeds maximum of {} bytes",
+                MAX_WASM_SIZE
+            ),
         ));
     }
 
@@ -760,6 +767,60 @@ mod tests {
 
         let wasm_bytes = read_wasm_file(&resolved2.wasm_path).unwrap();
         assert_eq!(wasm_bytes, wasm_content);
+    }
+
+    #[test]
+    fn test_read_wasm_file_metadata_too_large() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("too_large.wasm");
+        let file = std::fs::File::create(&path).unwrap();
+
+        // Mock a file larger than 50MB using set_len
+        file.set_len(50 * 1024 * 1024 + 1).unwrap();
+
+        let result = read_wasm_file(&path);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds maximum of 52428800 bytes")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_wasm_file_content_too_large() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fifo_too_large.wasm");
+
+        nix::unistd::mkfifo(&path, nix::sys::stat::Mode::S_IRWXU).unwrap();
+
+        let path_clone = path.clone();
+        std::thread::spawn(move || {
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&path_clone)
+                .unwrap();
+            let chunk = vec![0u8; 1024 * 1024];
+            for _ in 0..50 {
+                file.write_all(&chunk).unwrap();
+            }
+            file.write_all(&[0u8; 1]).unwrap();
+        });
+
+        let result = read_wasm_file(&path);
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds maximum of 52428800 bytes")
+        );
     }
 
     #[tokio::test]

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -12,6 +12,36 @@ use thiserror::Error;
 pub use crate::fetcher::PluginSource;
 pub use crate::spec::{ParseError, PluginSpec};
 use extism_manifest::Wasm;
+use std::io::Read;
+
+fn read_wasm_file(path: &Path) -> Result<Vec<u8>, std::io::Error> {
+    // 50 MB maximum WASM size (consistent with tsuzulint_plugin::MAX_WASM_SIZE)
+    const MAX_WASM_SIZE: u64 = 50 * 1024 * 1024;
+
+    let mut file = std::fs::File::open(path)?;
+    let metadata = file.metadata()?;
+
+    if metadata.len() > MAX_WASM_SIZE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("WASM file too large: {} bytes exceeds maximum of {} bytes", metadata.len(), MAX_WASM_SIZE)
+        ));
+    }
+
+    let mut buffer: Vec<u8> = Vec::with_capacity(metadata.len() as usize);
+    (&mut file)
+        .take(MAX_WASM_SIZE + 1)
+        .read_to_end(&mut buffer)?;
+
+    if buffer.len() as u64 > MAX_WASM_SIZE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("WASM file too large: exceeds maximum of {} bytes", MAX_WASM_SIZE)
+        ));
+    }
+
+    Ok(buffer)
+}
 
 #[derive(Debug, Error)]
 pub enum ResolveError {
@@ -164,7 +194,7 @@ impl PluginResolver {
         wasm_url = wasm_url.replace("{version}", &manifest.rule.version);
 
         if let Some(cached) = self.cache.get(source, version) {
-            match std::fs::read(&cached.wasm_path) {
+            match read_wasm_file(&cached.wasm_path) {
                 Ok(cached_bytes) => {
                     if HashVerifier::verify(&cached_bytes, &expected_hash).is_ok() {
                         return Ok(ResolvedPlugin {
@@ -233,7 +263,7 @@ impl PluginResolver {
 
         let wasm_path = validate_local_wasm_path(wasm_relative, parent)?;
 
-        let bytes = std::fs::read(&wasm_path).map_err(DownloadError::IoError)?;
+        let bytes = read_wasm_file(&wasm_path).map_err(DownloadError::IoError)?;
 
         let expected_hash = expected_hash.ok_or_else(|| {
             ResolveError::SerializationError(
@@ -319,7 +349,7 @@ mod tests {
 
         assert_eq!(resolved.alias, "test-rule");
         assert_eq!(resolved.manifest.rule.name, "test-rule");
-        assert_eq!(std::fs::read(&resolved.wasm_path).unwrap(), wasm_content);
+        assert_eq!(read_wasm_file(&resolved.wasm_path).unwrap(), wasm_content);
     }
 
     #[tokio::test]
@@ -372,7 +402,7 @@ mod tests {
 
         assert_eq!(resolved.alias, "test-alias");
         assert_eq!(resolved.manifest.rule.name, "test-rule");
-        assert_eq!(std::fs::read(&resolved.wasm_path).unwrap(), wasm_content);
+        assert_eq!(read_wasm_file(&resolved.wasm_path).unwrap(), wasm_content);
     }
 
     #[tokio::test]
@@ -728,7 +758,7 @@ mod tests {
             .await
             .expect("Second resolve failed");
 
-        let wasm_bytes = std::fs::read(&resolved2.wasm_path).unwrap();
+        let wasm_bytes = read_wasm_file(&resolved2.wasm_path).unwrap();
         assert_eq!(wasm_bytes, wasm_content);
     }
 
@@ -791,7 +821,7 @@ mod tests {
             .expect("Second resolve failed");
 
         assert!(resolved2.wasm_path.exists());
-        let wasm_bytes = std::fs::read(&resolved2.wasm_path).unwrap();
+        let wasm_bytes = read_wasm_file(&resolved2.wasm_path).unwrap();
         assert_eq!(wasm_bytes, wasm_content);
     }
 }


### PR DESCRIPTION
This PR replaces all instances of unbounded `std::fs::read` in `crates/tsuzulint_registry/src/resolver.rs` with a newly implemented `read_wasm_file` helper function. This addresses a potential Out-of-Memory (OOM) and Time-of-Check to Time-of-Use (TOCTOU) vulnerability where extremely large or maliciously modified WASM plugins could be read fully into memory without size constraints. 

The implementation respects the 50MB `MAX_WASM_SIZE` used elsewhere in the codebase, reading the file securely by leveraging `File::open` and `Read::take`.

---
*PR created automatically by Jules for task [4140887106822237458](https://jules.google.com/task/4140887106822237458) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * WASM ファイル読み込み時に 50MB のサイズ制限を追加しました。キャッシュおよびローカル読み込みでメタデータと読み込み後の両方を確認し、制限超過のファイルは拒否されます。
* **テスト**
  * サイズ制限の動作を検証する単体テストを追加しました（制限超過のケースを含む）。
* **雑務**
  * Unix 環境向けの開発依存を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->