### PR TITLE
🛡️ Sentinel: [HIGH] Fix OOM and TOCTOU vulnerability in `resolver.rs` local WASM file reads

### DIFF
--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -6,12 +6,41 @@ use crate::error::FetchError;
 use crate::fetcher::ManifestFetcher;
 use crate::manifest::{ExternalRuleManifest, HashVerifier, IntegrityError};
 use crate::security::validate_local_wasm_path;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 pub use crate::fetcher::PluginSource;
 pub use crate::spec::{ParseError, PluginSpec};
 use extism_manifest::Wasm;
+
+const MAX_WASM_SIZE: u64 = 50 * 1024 * 1024;
+
+fn read_wasm(path: &Path) -> std::io::Result<Vec<u8>> {
+    let mut file = std::fs::File::open(path)?;
+    let metadata = file.metadata()?;
+
+    if metadata.len() > MAX_WASM_SIZE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "WASM file too large",
+        ));
+    }
+
+    let mut buffer = Vec::with_capacity(metadata.len() as usize);
+    let bytes_read = (&mut file)
+        .take(MAX_WASM_SIZE + 1)
+        .read_to_end(&mut buffer)?;
+
+    if bytes_read as u64 > MAX_WASM_SIZE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "WASM file exceeded max size during read",
+        ));
+    }
+
+    Ok(buffer)
+}
 
 #[derive(Debug, Error)]
 pub enum ResolveError {
@@ -164,7 +193,7 @@ impl PluginResolver {
         wasm_url = wasm_url.replace("{version}", &manifest.rule.version);
 
         if let Some(cached) = self.cache.get(source, version) {
-            match std::fs::read(&cached.wasm_path) {
+            match read_wasm(&cached.wasm_path) {
                 Ok(cached_bytes) => {
                     if HashVerifier::verify(&cached_bytes, &expected_hash).is_ok() {
                         return Ok(ResolvedPlugin {
@@ -233,7 +262,7 @@ impl PluginResolver {
 
         let wasm_path = validate_local_wasm_path(wasm_relative, parent)?;
 
-        let bytes = std::fs::read(&wasm_path).map_err(DownloadError::IoError)?;
+        let bytes = read_wasm(&wasm_path).map_err(DownloadError::IoError)?;
 
         let expected_hash = expected_hash.ok_or_else(|| {
             ResolveError::SerializationError(

--- a/crates/tsuzulint_registry/tests/resolver_security.rs
+++ b/crates/tsuzulint_registry/tests/resolver_security.rs
@@ -35,3 +35,59 @@ async fn test_resolve_local_exceeds_max_wasm_size() {
     let err_str = result.unwrap_err().to_string();
     assert!(err_str.contains("WASM file too large") || err_str.contains("too large"));
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_resolve_local_fifo_exceeds_max_wasm_size() {
+    let resolver = PluginResolver::new().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+
+    let wasm_path = dir.path().join("fifo.wasm");
+    let status = std::process::Command::new("mkfifo")
+        .arg(&wasm_path)
+        .status();
+
+    if status.is_err() || !status.unwrap().success() {
+        return;
+    }
+
+    let manifest_path = dir.path().join("tsuzulint-rule.json");
+    let manifest = json!({
+        "rule": { "name": "oversized-rule", "version": "1.0.0" },
+        "wasm": [{
+            "path": "fifo.wasm",
+            "hash": "0000000000000000000000000000000000000000000000000000000000000000"
+        }]
+    });
+    std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+
+    let spec = PluginSpec {
+        source: PluginSource::Path(manifest_path.clone()),
+        alias: None,
+    };
+
+    let wasm_path_clone = wasm_path.clone();
+    let handle = std::thread::spawn(move || {
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&wasm_path_clone)
+        {
+            use std::io::Write;
+            let chunk = vec![0u8; 1024 * 1024]; // 1MB chunk
+            for _ in 0..51 {
+                let _ = file.write_all(&chunk);
+            }
+        }
+    });
+
+    let result = resolver.resolve(&spec).await;
+
+    assert!(result.is_err());
+    let err_str = result.unwrap_err().to_string();
+    assert!(
+        err_str.contains("exceeded max size during read")
+            || err_str.contains("WASM file exceeded max size during read")
+    );
+
+    handle.join().unwrap();
+}

--- a/crates/tsuzulint_registry/tests/resolver_security.rs
+++ b/crates/tsuzulint_registry/tests/resolver_security.rs
@@ -1,0 +1,37 @@
+use serde_json::json;
+use tempfile::NamedTempFile;
+use tsuzulint_registry::{PluginResolver, PluginSource, PluginSpec};
+
+const MAX_WASM_SIZE: u64 = 50 * 1024 * 1024;
+
+#[tokio::test]
+async fn test_resolve_local_exceeds_max_wasm_size() {
+    let resolver = PluginResolver::new().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+
+    // Create oversized WASM
+    let wasm_file = NamedTempFile::new_in(&dir).unwrap();
+    wasm_file.as_file().set_len(MAX_WASM_SIZE + 1024).unwrap();
+
+    // Create valid manifest pointing to oversized WASM
+    let manifest_path = dir.path().join("tsuzulint-rule.json");
+    let manifest = json!({
+        "rule": { "name": "oversized-rule", "version": "1.0.0" },
+        "wasm": [{
+            "path": wasm_file.path().file_name().unwrap().to_str().unwrap(),
+            "hash": "0000000000000000000000000000000000000000000000000000000000000000"
+        }]
+    });
+    std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+
+    let spec = PluginSpec {
+        source: PluginSource::Path(manifest_path.clone()),
+        alias: None,
+    };
+
+    let result = resolver.resolve(&spec).await;
+
+    assert!(result.is_err());
+    let err_str = result.unwrap_err().to_string();
+    assert!(err_str.contains("WASM file too large") || err_str.contains("too large"));
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unbounded file reads leading to potential Out-of-Memory (OOM) attacks, and Time-of-Check to Time-of-Use (TOCTOU) issues when loading local WASM plugins from the registry. Using `std::fs::read` reads the entire file directly into memory without size checks.
🎯 **Impact:** An attacker could cause the application to crash or allocate excessive memory by providing an extremely large WASM file or modifying a file after a metadata check but before the read.
🔧 **Fix:** Replaced `std::fs::read` in `PluginResolver` logic with a newly implemented `read_wasm` helper function. This helper opens the file descriptor first, validates that the initial metadata size is under the 50MB limit, and uses `.take(MAX_WASM_SIZE + 1)` during the actual read to ensure memory bounds are strictly enforced regardless of subsequent file modifications.
✅ **Verification:** Verified that `cargo test -p tsuzulint_registry` runs successfully and `clippy` tests pass locally.

---
*PR created automatically by Jules for task [13391938465668864166](https://jules.google.com/task/13391938465668864166) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * WASM ファイルの読み込みに 50 MiB のサイズ上限を導入し、過大なファイルの処理を防止
  * ファイル読み込み時のエラー処理とログ出力を強化し、読み込み失敗が適切に伝播されるように改善

* **テスト**
  * ローカルの大容量 WASM ファイルを扱った失敗ケースを検証する統合テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->