### PR TITLE
🛡️ Sentinel: [HIGH] Fix OOM/TOCTOU vulnerability in file reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4633,6 +4633,7 @@ dependencies = [
  "dirs",
  "extism-manifest",
  "futures-util",
+ "libc",
  "miette",
  "proptest",
  "reqwest 0.12.28",

--- a/crates/tsuzulint_registry/Cargo.toml
+++ b/crates/tsuzulint_registry/Cargo.toml
@@ -29,3 +29,6 @@ url = "2.5.8"
 wiremock.workspace = true
 proptest = "1.10"
 tempfile.workspace = true
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -352,7 +352,68 @@ mod tests {
 
         assert_eq!(resolved.alias, "test-rule");
         assert_eq!(resolved.manifest.rule.name, "test-rule");
-        assert_eq!(read_file_securely(&resolved.wasm_path).unwrap(), wasm_content);
+        assert_eq!(
+            read_file_securely(&resolved.wasm_path).unwrap(),
+            wasm_content
+        );
+    }
+
+    #[test]
+    fn test_read_file_securely_metadata_too_large() {
+        let dir = tempdir().unwrap();
+        let wasm_path = dir.path().join("rule.wasm");
+        let file = std::fs::File::create(&wasm_path).unwrap();
+        file.set_len(crate::downloader::DEFAULT_MAX_SIZE + 1)
+            .unwrap();
+
+        let result = read_file_securely(&wasm_path);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("File size exceeds")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_file_securely_content_too_large() {
+        let dir = tempdir().unwrap();
+        let fifo_path = dir.path().join("rule.wasm");
+
+        let c_path = std::ffi::CString::new(fifo_path.to_str().unwrap()).unwrap();
+        unsafe {
+            let _ = libc::mkfifo(c_path.as_ptr(), 0o644);
+        }
+
+        let handle = std::thread::spawn(move || {
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&fifo_path)
+                .unwrap();
+            let chunk = vec![0u8; 1024 * 1024];
+            let limit = crate::downloader::DEFAULT_MAX_SIZE as usize + 1024;
+            let mut written = 0;
+            while written < limit {
+                use std::io::Write;
+                if file.write_all(&chunk).is_err() {
+                    break;
+                }
+                written += chunk.len();
+            }
+        });
+
+        let result = read_file_securely(&dir.path().join("rule.wasm"));
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("File size exceeds")
+        );
+
+        let _ = handle.join();
     }
 
     #[tokio::test]
@@ -405,7 +466,10 @@ mod tests {
 
         assert_eq!(resolved.alias, "test-alias");
         assert_eq!(resolved.manifest.rule.name, "test-rule");
-        assert_eq!(read_file_securely(&resolved.wasm_path).unwrap(), wasm_content);
+        assert_eq!(
+            read_file_securely(&resolved.wasm_path).unwrap(),
+            wasm_content
+        );
     }
 
     #[tokio::test]

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -41,6 +41,39 @@ pub struct ResolvedPlugin {
     pub alias: String,
 }
 
+/// Securely reads a file into memory with a size limit to prevent OOM vulnerabilities.
+fn read_file_securely(path: &Path) -> std::io::Result<Vec<u8>> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path)?;
+    let metadata = file.metadata()?;
+
+    if metadata.len() > crate::downloader::DEFAULT_MAX_SIZE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "File size exceeds maximum allowed size of {} bytes",
+                crate::downloader::DEFAULT_MAX_SIZE
+            ),
+        ));
+    }
+
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    let bytes_read = (&mut file)
+        .take(crate::downloader::DEFAULT_MAX_SIZE + 1)
+        .read_to_end(&mut bytes)?;
+
+    if bytes_read as u64 > crate::downloader::DEFAULT_MAX_SIZE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "File size exceeds maximum allowed size of {} bytes",
+                crate::downloader::DEFAULT_MAX_SIZE
+            ),
+        ));
+    }
+    Ok(bytes)
+}
+
 pub struct PluginResolver {
     fetcher: ManifestFetcher,
     cache: PluginCache,
@@ -164,7 +197,7 @@ impl PluginResolver {
         wasm_url = wasm_url.replace("{version}", &manifest.rule.version);
 
         if let Some(cached) = self.cache.get(source, version) {
-            match std::fs::read(&cached.wasm_path) {
+            match read_file_securely(&cached.wasm_path) {
                 Ok(cached_bytes) => {
                     if HashVerifier::verify(&cached_bytes, &expected_hash).is_ok() {
                         return Ok(ResolvedPlugin {
@@ -233,7 +266,7 @@ impl PluginResolver {
 
         let wasm_path = validate_local_wasm_path(wasm_relative, parent)?;
 
-        let bytes = std::fs::read(&wasm_path).map_err(DownloadError::IoError)?;
+        let bytes = read_file_securely(&wasm_path).map_err(DownloadError::IoError)?;
 
         let expected_hash = expected_hash.ok_or_else(|| {
             ResolveError::SerializationError(
@@ -319,7 +352,7 @@ mod tests {
 
         assert_eq!(resolved.alias, "test-rule");
         assert_eq!(resolved.manifest.rule.name, "test-rule");
-        assert_eq!(std::fs::read(&resolved.wasm_path).unwrap(), wasm_content);
+        assert_eq!(read_file_securely(&resolved.wasm_path).unwrap(), wasm_content);
     }
 
     #[tokio::test]
@@ -372,7 +405,7 @@ mod tests {
 
         assert_eq!(resolved.alias, "test-alias");
         assert_eq!(resolved.manifest.rule.name, "test-rule");
-        assert_eq!(std::fs::read(&resolved.wasm_path).unwrap(), wasm_content);
+        assert_eq!(read_file_securely(&resolved.wasm_path).unwrap(), wasm_content);
     }
 
     #[tokio::test]
@@ -728,7 +761,7 @@ mod tests {
             .await
             .expect("Second resolve failed");
 
-        let wasm_bytes = std::fs::read(&resolved2.wasm_path).unwrap();
+        let wasm_bytes = read_file_securely(&resolved2.wasm_path).unwrap();
         assert_eq!(wasm_bytes, wasm_content);
     }
 
@@ -791,7 +824,7 @@ mod tests {
             .expect("Second resolve failed");
 
         assert!(resolved2.wasm_path.exists());
-        let wasm_bytes = std::fs::read(&resolved2.wasm_path).unwrap();
+        let wasm_bytes = read_file_securely(&resolved2.wasm_path).unwrap();
         assert_eq!(wasm_bytes, wasm_content);
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix OOM/TOCTOU vulnerability in file reading

🚨 **Severity:** HIGH
💡 **Vulnerability:** Unbounded file reading via `std::fs::read` in `crates/tsuzulint_registry/src/resolver.rs`. Reading large or malicious WASM files directly into memory without size checks exposes the registry to Out-of-Memory (OOM) Denial-of-Service (DoS) attacks. Furthermore, using metadata size checks followed by `std::fs::read` introduces a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where the file could be replaced and grown between the check and the read.
🎯 **Impact:** Maliciously crafted local plugins or symlinks pointing to excessively large files could exhaust system memory, crashing the linter or CI environment.
🔧 **Fix:** Replaced standard `std::fs::read` invocations with a custom `read_file_securely` helper function. This function uses `File::open`, strictly checks the file `metadata()?.len()`, and securely bounds the file read using `Read::take(DEFAULT_MAX_SIZE + 1)` and `read_to_end`, thereby safely returning an error if the limits are breached and preventing memory exhaustion.
✅ **Verification:** Ran `cargo test --workspace --all-features` and confirmed that all unit and integration tests covering manifest parsing, resolution caching, and plugin loading pass successfully. No performance regressions or linting warnings (`cargo clippy`) observed.

---
*PR created automatically by Jules for task [13181536476539503611](https://jules.google.com/task/13181536476539503611) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファイル読み込みに最大サイズの制限を追加し、上限を超えるファイルはエラーとして拒否されるようになりました（安定性・安全性向上）。

* **テスト**
  * ファイル読み込み関連のユニットテストを強化・更新しました（境界ケースの検証を追加）。

* **雑務**
  * 開発時のUnix向け依存設定を追加しました（開発環境の補助）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->