### PR TITLE
⚡ Bolt: [performance improvement] bypass String allocations during block extraction

### DIFF
--- a/crates/tsuzulint_cache/src/manager.rs
+++ b/crates/tsuzulint_cache/src/manager.rs
@@ -62,7 +62,12 @@ impl CacheManager {
 
     /// Computes the BLAKE3 hash of content.
     pub fn hash_content(content: &str) -> BlockHash {
-        blake3::hash(content.as_bytes()).into()
+        Self::hash_bytes(content.as_bytes())
+    }
+
+    /// Computes the BLAKE3 hash of raw bytes.
+    pub fn hash_bytes(bytes: &[u8]) -> BlockHash {
+        blake3::hash(bytes).into()
     }
 
     /// Gets a cached entry for a file.

--- a/crates/tsuzulint_core/src/block_extractor.rs
+++ b/crates/tsuzulint_core/src/block_extractor.rs
@@ -18,13 +18,7 @@ pub fn extract_blocks(ast: &TxtNode, content: &str) -> Vec<BlockCacheEntry> {
         let content_bytes = content.as_bytes();
 
         if start <= content_bytes.len() && end <= content_bytes.len() && start <= end {
-            let hash = if let Some(slice) = content.get(start..end) {
-                CacheManager::hash_content(slice)
-            } else {
-                let bytes = &content_bytes[start..end];
-                let block_content = String::from_utf8_lossy(bytes);
-                CacheManager::hash_content(&block_content)
-            };
+            let hash = CacheManager::hash_bytes(&content_bytes[start..end]);
 
             blocks.push(BlockCacheEntry {
                 hash,


### PR DESCRIPTION
💡 **What**: Refactored `CacheManager` to directly expose `hash_bytes(&[u8])` and updated the `block_extractor` to use it directly instead of converting bounded text slices to Strings or `utf8_lossy` replacements.

🎯 **Why**: When extracting text blocks from AST nodes (which may be unaligned with UTF-8 char bounds), `extract_blocks` previously tried to pull a `&str` and fell back to allocating a new String via `String::from_utf8_lossy` if it failed. Since BLAKE3 operates purely on byte streams anyway, it is mathematically more robust and highly performant to bypass string bounds checking and allocations altogether.

📊 **Impact**: Reduces block extraction overhead. Eliminates potential runtime allocation of `String::from_utf8_lossy` in fallback scenarios, improving linter speed when iterating large files.

🔬 **Measurement**: Verify by running `cargo test -p tsuzulint_core` and tracking block extraction timings for large documents.

---
*PR created automatically by Jules for task [8581470625187605275](https://jules.google.com/task/8581470625187605275) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * キャッシュ処理内のハッシング機能を効率化し、より統一されたアプローチに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->