### PR TITLE
🦀 Ferris: [refactor] Simplify PluginSource cloning in prepare_source

### DIFF
--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -112,21 +112,7 @@ impl PluginResolver {
 
     fn prepare_source(&self, source: &PluginSource) -> (PluginSource, Option<PathBuf>) {
         match source {
-            PluginSource::GitHub {
-                owner,
-                repo,
-                version,
-                server_url,
-            } => (
-                PluginSource::GitHub {
-                    owner: owner.clone(),
-                    repo: repo.clone(),
-                    version: version.clone(),
-                    server_url: server_url.clone(),
-                },
-                None,
-            ),
-            PluginSource::Url(url) => (PluginSource::Url(url.clone()), None),
+            PluginSource::GitHub { .. } | PluginSource::Url(_) => (source.clone(), None),
             PluginSource::Path(path) => {
                 let p = if path.is_dir() {
                     path.join("tsuzulint-rule.json")


### PR DESCRIPTION
💡 **Improvement:** Replaced verbose field-by-field cloning of `PluginSource::GitHub` and `PluginSource::Url` variants with a simple `source.clone()` call inside `prepare_source`.

🦀 **Why:** Since the `PluginSource` enum derives the `Clone` trait, destructuring it to clone individual fields only to reconstruct the exact same variant is unnecessarily verbose and unidiomatic. Using `.clone()` directly on the enum is idiomatic and keeps the code lean.

🔍 **Verification:**
- Ran `cargo clippy --workspace --all-targets -- -D warnings` (passed)
- Ran `make test` via `cargo test --workspace` (passed)
- Ran `make fmt-check` (passed)

---
*PR created automatically by Jules for task [1214179789298460256](https://jules.google.com/task/1214179789298460256) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **最適化**
  * 内部プラグインリゾルバーの処理を効率化し、ソース管理のロジックを簡潔にしました。エンドユーザーへの機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->