### PR TITLE
⚡ Bolt: [performance improvement] Use with_capacity when reading files to minimize reallocations

### DIFF
--- a/crates/tsuzulint_core/src/file_linter.rs
+++ b/crates/tsuzulint_core/src/file_linter.rs
@@ -61,7 +61,8 @@ pub fn lint_file_internal(
         )));
     }
 
-    let mut content = String::new();
+    // Initialize string with known file size to minimize reallocations and optimize performance
+    let mut content = String::with_capacity(metadata.len() as usize);
     // Clear O_NONBLOCK so that subsequent reads block normally.
     clear_nonblocking(&file).map_err(|e| {
         LinterError::file(format!(


### PR DESCRIPTION
💡 What: Replaced `String::new()` with `String::with_capacity(metadata.len() as usize)` when reading file contents in `lint_file_internal`.
🎯 Why: When reading a file into a `String` (or `Vec<u8>`), if the string is initialized with `String::new()`, it has a capacity of zero and must continuously reallocate and copy memory as the contents are streamed in. Since we already queried the file metadata, we know the exact size needed, so we can pre-allocate it to completely eliminate intermediate allocations.
📊 Impact: This significantly optimizes the hot path for reading large documents, reducing memory churn and overhead.
🔬 Measurement: Verify by running the test suite (`make lint` and `cargo test -p tsuzulint_core`), and benchmark linting performance on large source repositories.

---
*PR created automatically by Jules for task [10837903377333769225](https://jules.google.com/task/10837903377333769225) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * ファイルのリント処理中のメモリ割り当て効率が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->