### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unsafe fcntl usage in file_linter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4549,6 +4549,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "rstest",
+ "rustix 0.38.44",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/tsuzulint_core/Cargo.toml
+++ b/crates/tsuzulint_core/Cargo.toml
@@ -33,6 +33,7 @@ jsonschema.workspace = true
 tsuzulint_manifest.workspace = true
 dirs = "6.0"
 parking_lot = { workspace = true }
+rustix = "0.38"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/tsuzulint_core/src/file_linter.rs
+++ b/crates/tsuzulint_core/src/file_linter.rs
@@ -404,18 +404,11 @@ fn open_nonblocking(path: &Path) -> std::io::Result<std::fs::File> {
 /// reads block normally.  This is a no-op on non-Unix platforms.
 #[cfg(unix)]
 fn clear_nonblocking(file: &std::fs::File) -> std::io::Result<()> {
-    use std::os::unix::io::AsRawFd as _;
-    let fd = file.as_raw_fd();
-    // SAFETY: `fd` is a valid, open file descriptor owned by `file`.
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-    if flags == -1 {
-        return Err(std::io::Error::last_os_error());
-    }
-    let new_flags = flags & !libc::O_NONBLOCK;
-    // SAFETY: same fd, setting valid flags.
-    if unsafe { libc::fcntl(fd, libc::F_SETFL, new_flags) } == -1 {
-        return Err(std::io::Error::last_os_error());
-    }
+    use std::os::unix::io::AsFd;
+    let fd = file.as_fd();
+    let flags = rustix::fs::fcntl_getfl(fd)?;
+    let new_flags = flags - rustix::fs::OFlags::NONBLOCK;
+    rustix::fs::fcntl_setfl(fd, new_flags)?;
     Ok(())
 }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The codebase relied on an `unsafe` FFI block directly interfacing with `libc::fcntl` to get and clear the `O_NONBLOCK` file flag in `tsuzulint_core/src/file_linter.rs`. This was an unnecessary use of `unsafe` that circumvented standard Rust memory and safety guarantees for system calls.
🎯 Impact: While the current usage was bounded, unmanaged `unsafe` blocks directly operating on raw file descriptors can lead to security vulnerabilities such as memory corruption or logic errors if misused in the future.
🔧 Fix: Removed the `libc::fcntl` bindings entirely and implemented a safe, idiomatic abstraction utilizing `rustix::fs::fcntl_getfl` and `rustix::fs::fcntl_setfl` using the safe `AsFd` model, thus eliminating the `unsafe` block.
✅ Verification: Ran `cargo test --workspace` to ensure no functionality regressions and `cargo clippy` to guarantee lint compliance.

---
*PR created automatically by Jules for task [10383479274092303882](https://jules.google.com/task/10383479274092303882) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 内部依存関係を更新し、ファイル操作の処理をリファクタリングしました。これにより、コードの保守性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->