### PR TITLE
🦀 Ferris: Refactor prepare_source to idiomatically clone PluginSource

### DIFF
--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -112,21 +112,6 @@ impl PluginResolver {
 
     fn prepare_source(&self, source: &PluginSource) -> (PluginSource, Option<PathBuf>) {
         match source {
-            PluginSource::GitHub {
-                owner,
-                repo,
-                version,
-                server_url,
-            } => (
-                PluginSource::GitHub {
-                    owner: owner.clone(),
-                    repo: repo.clone(),
-                    version: version.clone(),
-                    server_url: server_url.clone(),
-                },
-                None,
-            ),
-            PluginSource::Url(url) => (PluginSource::Url(url.clone()), None),
             PluginSource::Path(path) => {
                 let p = if path.is_dir() {
                     path.join("tsuzulint-rule.json")
@@ -135,6 +120,7 @@ impl PluginResolver {
                 };
                 (PluginSource::Path(p.clone()), Some(p))
             }
+            _ => (source.clone(), None),
         }
     }
 


### PR DESCRIPTION
💡 Improvement: Simplified `prepare_source` by using a catch-all match arm to directly clone the `PluginSource` enum instance rather than manually destructuring and cloning individual fields for the `GitHub` and `Url` variants.
🦀 Why: Relying on the derived `Clone` trait for enums instead of manually unpacking and repackaging fields is more idiomatic, concise, and maintainable. It reduces boilerplate and the risk of missing fields if the enum changes.
🔍 Verification: Checked via `make test` to ensure all registry resolution tests pass, and `make lint`/`make fmt-check` to confirm the change adheres to style guidelines.

---
*PR created automatically by Jules for task [11009264602552806794](https://jules.google.com/task/11009264602552806794) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * プラグインリゾルバーの内部ロジックを簡素化しました。特定のプラグインソースの処理フローを統合し、コードの効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->