### PR TITLE
⚡ Bolt: [performance improvement] Eliminate string allocations in block extraction

### DIFF
--- a/crates/tsuzulint_cache/src/manager.rs
+++ b/crates/tsuzulint_cache/src/manager.rs
@@ -61,8 +61,8 @@ impl CacheManager {
     }
 
     /// Computes the BLAKE3 hash of content.
-    pub fn hash_content(content: &str) -> BlockHash {
-        blake3::hash(content.as_bytes()).into()
+    pub fn hash_content<T: AsRef<[u8]>>(content: T) -> BlockHash {
+        blake3::hash(content.as_ref()).into()
     }
 
     /// Gets a cached entry for a file.

--- a/crates/tsuzulint_core/src/block_extractor.rs
+++ b/crates/tsuzulint_core/src/block_extractor.rs
@@ -18,13 +18,7 @@ pub fn extract_blocks(ast: &TxtNode, content: &str) -> Vec<BlockCacheEntry> {
         let content_bytes = content.as_bytes();
 
         if start <= content_bytes.len() && end <= content_bytes.len() && start <= end {
-            let hash = if let Some(slice) = content.get(start..end) {
-                CacheManager::hash_content(slice)
-            } else {
-                let bytes = &content_bytes[start..end];
-                let block_content = String::from_utf8_lossy(bytes);
-                CacheManager::hash_content(&block_content)
-            };
+            let hash = CacheManager::hash_content(&content_bytes[start..end]);
 
             blocks.push(BlockCacheEntry {
                 hash,


### PR DESCRIPTION
💡 **What**: Changed `CacheManager::hash_content` to use `AsRef<[u8]>` rather than `&str`, avoiding the fallback `String::from_utf8_lossy` heap allocation in `block_extractor.rs`.

🎯 **Why**: When extracting AST node blocks, an intermediate heap string was unnecessarily allocated via `String::from_utf8_lossy` on cache boundaries if character ranges misaligned. 

📊 **Impact**: Faster cache computation bounds processing by preventing heap memory allocations entirely.

🔬 **Measurement**: `cargo test -p tsuzulint_core -- block_extractor::tests` passes alongside `cargo test -p tsuzulint_cache`. Heap profilers will show less allocs inside `extract_blocks`.

---
*PR created automatically by Jules for task [13768878471506679926](https://jules.google.com/task/13768878471506679926) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * キャッシュおよびブロック抽出機能の内部処理を最適化しました。

このリリースに含まれるのは、内部インフラストラクチャの改善であり、エンドユーザーの機能に対する直接的な変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->