### PR TITLE
🛡️ Sentinel: [HIGH] Fix local WASM DoS via unbounded reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,6 +2541,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4634,6 +4646,7 @@ dependencies = [
  "extism-manifest",
  "futures-util",
  "miette",
+ "nix",
  "proptest",
  "reqwest 0.12.28",
  "serde",

--- a/crates/tsuzulint_registry/Cargo.toml
+++ b/crates/tsuzulint_registry/Cargo.toml
@@ -29,3 +29,6 @@ url = "2.5.8"
 wiremock.workspace = true
 proptest = "1.10"
 tempfile.workspace = true
+
+[target."cfg(unix)".dev-dependencies]
+nix = { version = "0.31.2", features = ["fs"] }

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -233,7 +233,29 @@ impl PluginResolver {
 
         let wasm_path = validate_local_wasm_path(wasm_relative, parent)?;
 
-        let bytes = std::fs::read(&wasm_path).map_err(DownloadError::IoError)?;
+        let mut file = std::fs::File::open(&wasm_path).map_err(DownloadError::IoError)?;
+
+        let metadata = file.metadata().map_err(DownloadError::IoError)?;
+        if metadata.len() > crate::downloader::DEFAULT_MAX_SIZE {
+            return Err(ResolveError::DownloadError(DownloadError::TooLarge {
+                size: metadata.len(),
+                max: crate::downloader::DEFAULT_MAX_SIZE,
+            }));
+        }
+
+        use std::io::Read;
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        (&mut file)
+            .take(crate::downloader::DEFAULT_MAX_SIZE + 1)
+            .read_to_end(&mut bytes)
+            .map_err(DownloadError::IoError)?;
+
+        if bytes.len() as u64 > crate::downloader::DEFAULT_MAX_SIZE {
+            return Err(ResolveError::DownloadError(DownloadError::TooLarge {
+                size: bytes.len() as u64,
+                max: crate::downloader::DEFAULT_MAX_SIZE,
+            }));
+        }
 
         let expected_hash = expected_hash.ok_or_else(|| {
             ResolveError::SerializationError(
@@ -730,6 +752,125 @@ mod tests {
 
         let wasm_bytes = std::fs::read(&resolved2.wasm_path).unwrap();
         assert_eq!(wasm_bytes, wasm_content);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_path_wasm_too_large() {
+        let dir = tempdir().unwrap();
+        let manifest_path = dir.path().join("tsuzulint-rule.json");
+        let wasm_path = dir.path().join("rule.wasm");
+
+        let file = std::fs::File::create(&wasm_path).unwrap();
+        file.set_len(crate::downloader::DEFAULT_MAX_SIZE + 1).unwrap();
+
+        let manifest = json!({
+            "rule": {
+                "name": "local-rule",
+                "version": "1.0.0",
+            },
+            "wasm": [{
+                "path": "rule.wasm",
+                "hash": "0".repeat(64)
+            }]
+        });
+
+        std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+
+        let fetcher = ManifestFetcher::new().allow_local(true);
+        let downloader = WasmDownloader::new()
+            .expect("Failed to create downloader")
+            .allow_local(true);
+
+        let cache_dir = tempdir().unwrap();
+        let resolver = PluginResolver::with_fetcher(fetcher)
+            .expect("Failed to create resolver")
+            .with_downloader(downloader)
+            .with_cache(PluginCache::with_dir(cache_dir.path()));
+
+        let spec = PluginSpec::parse(&json!({
+            "path": manifest_path.to_str().unwrap(),
+            "as": "test-alias"
+        }))
+        .unwrap();
+
+        let result = resolver.resolve(&spec).await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("File too large"),
+            "Expected error about WASM size, but got: {}",
+            err_msg
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_resolve_path_wasm_too_large_fifo() {
+        let dir = tempdir().unwrap();
+        let manifest_path = dir.path().join("tsuzulint-rule.json");
+        let wasm_path = dir.path().join("rule.wasm");
+
+        // Create a FIFO so metadata().len() is 0, but reading it produces data
+        nix::unistd::mkfifo(&wasm_path, nix::sys::stat::Mode::S_IRWXU).unwrap();
+
+        let manifest = json!({
+            "rule": {
+                "name": "local-rule",
+                "version": "1.0.0",
+            },
+            "wasm": [{
+                "path": "rule.wasm",
+                "hash": "0".repeat(64)
+            }]
+        });
+
+        std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+
+        let fetcher = ManifestFetcher::new().allow_local(true);
+        let downloader = WasmDownloader::new()
+            .expect("Failed to create downloader")
+            .allow_local(true);
+
+        let cache_dir = tempdir().unwrap();
+        let resolver = PluginResolver::with_fetcher(fetcher)
+            .expect("Failed to create resolver")
+            .with_downloader(downloader)
+            .with_cache(PluginCache::with_dir(cache_dir.path()));
+
+        let spec = PluginSpec::parse(&json!({
+            "path": manifest_path.to_str().unwrap(),
+            "as": "test-alias"
+        }))
+        .unwrap();
+
+        // Spawn a background thread to feed data to the FIFO
+        let wasm_path_clone = wasm_path.clone();
+        std::thread::spawn(move || {
+            use std::io::Write;
+            if let Ok(mut file) = std::fs::File::create(&wasm_path_clone) {
+                // Write slightly more than the limit to trigger the post-read check
+                let chunk = vec![0u8; 1024 * 1024]; // 1MB chunk
+                let limit = crate::downloader::DEFAULT_MAX_SIZE as usize + 1024;
+                let mut written = 0;
+                while written < limit {
+                    if file.write_all(&chunk).is_err() {
+                        break;
+                    }
+                    written += chunk.len();
+                }
+            }
+        });
+
+        let result = resolver.resolve(&spec).await;
+
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("File too large"),
+            "Expected error about WASM size limit from post-read check, got: {}",
+            err_msg
+        );
     }
 
     #[tokio::test]

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -761,7 +761,8 @@ mod tests {
         let wasm_path = dir.path().join("rule.wasm");
 
         let file = std::fs::File::create(&wasm_path).unwrap();
-        file.set_len(crate::downloader::DEFAULT_MAX_SIZE + 1).unwrap();
+        file.set_len(crate::downloader::DEFAULT_MAX_SIZE + 1)
+            .unwrap();
 
         let manifest = json!({
             "rule": {


### PR DESCRIPTION
This PR addresses a HIGH severity DoS vulnerability when resolving local WASM files.

🚨 **Severity:** HIGH
💡 **Vulnerability:** Unbounded file reading (`std::fs::read`) for local WASM plugins in `tsuzulint_registry/src/resolver.rs`.
🎯 **Impact:** Denial of Service (DoS) via OOM panic if a local rule or symlink points to a massive file or an endless device file (like a FIFO).
🔧 **Fix:** Replaced `std::fs::read` with a bounded read. The system now validates `metadata().len()` and enforces a strict read limit using `std::io::Read::take`.
✅ **Verification:** Unit tests have been added to simulate oversized files and FIFOs to ensure limits are strictly enforced. To verify manually, run `make test` or `cargo test --workspace`.

---
*PR created automatically by Jules for task [12118755652361436482](https://jules.google.com/task/12118755652361436482) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ローカルWASMファイルの読み込みでサイズ制限を厳格化し、読み込み前後の二段階検証を導入しました。特殊なファイル（例: FIFO）でも上限超過を確実に検出し、適切な「ファイルが大きすぎる」エラーを返すようになり、エラーハンドリングが改善されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->