### PR TITLE
🦀 Ferris: Replace `.to_string()` with `String::from` in iterators

### DIFF
--- a/crates/tsuzulint_core/src/context.rs
+++ b/crates/tsuzulint_core/src/context.rs
@@ -396,7 +396,7 @@ impl<'a> LintContext<'a> {
             }
             NodeType::Link | NodeType::Image => {
                 let url = node.url().unwrap_or("").to_string();
-                let title = node.title().map(|s| s.to_string());
+                let title = node.title().map(String::from);
                 structure.links.push(LinkInfo {
                     url,
                     title,
@@ -405,7 +405,7 @@ impl<'a> LintContext<'a> {
                 });
             }
             NodeType::CodeBlock => {
-                let lang = node.lang().map(|s| s.to_string());
+                let lang = node.lang().map(String::from);
                 structure.code_blocks.push(CodeBlockInfo {
                     lang,
                     span: node.span,

--- a/crates/tsuzulint_core/src/formatters/sarif.rs
+++ b/crates/tsuzulint_core/src/formatters/sarif.rs
@@ -114,7 +114,7 @@ impl ToolComponent {
         let rules_vec: Vec<_> = rules.into_values().collect();
         Self {
             name: TOOL_NAME.to_string(),
-            version: option_env!("CARGO_PKG_VERSION").map(|s| s.to_string()),
+            version: option_env!("CARGO_PKG_VERSION").map(String::from),
             rules: rules_vec,
         }
     }

--- a/crates/tsuzulint_plugin/src/host.rs
+++ b/crates/tsuzulint_plugin/src/host.rs
@@ -634,7 +634,7 @@ mod tests {
         assert_eq!(guest_request.source, source);
         assert_eq!(guest_request.tokens, tokens);
         assert_eq!(guest_request.sentences, sentences);
-        assert_eq!(guest_request.file_path, file_path.map(|s| s.to_string()));
+        assert_eq!(guest_request.file_path, file_path.map(String::from));
         assert_eq!(guest_request.node, node_data);
         assert_eq!(guest_request.helpers, None);
     }

--- a/crates/tsuzulint_text/src/tokenizer.rs
+++ b/crates/tsuzulint_text/src/tokenizer.rs
@@ -69,14 +69,14 @@ impl Tokenizer {
                 .iter()
                 .take(4)
                 .filter(|s| **s != "*")
-                .map(|s| s.to_string())
+                .map(|s| String::from(*s))
                 .collect();
 
             let detail: Vec<String> = details
                 .iter()
                 .skip(4)
                 .filter(|s| **s != "*")
-                .map(|s| s.to_string())
+                .map(|s| String::from(*s))
                 .collect();
 
             let span = lindera_token.byte_start..lindera_token.byte_end;


### PR DESCRIPTION
💡 Improvement: Replaced `.map(|s| s.to_string())` with `.map(String::from)` or `.map(|s| String::from(*s))` in iterators across `tokenizer.rs`, `context.rs`, `host.rs`, and `sarif.rs`.
🦀 Why: Idiomatic reason: Calling `.to_string()` inside iterators (e.g., when mapping `&str` or `&&str` to `String`) invokes the `Display` trait formatter, which incurs unnecessary overhead. It's more idiomatic and efficient to use `String::from` or `.to_owned()` for direct allocation.
🔍 Verification: `cargo clippy`, `make test`, and `make fmt-check` all pass with no warnings.

---
*PR created automatically by Jules for task [2916928276350250236](https://jules.google.com/task/2916928276350250236) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/303" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 内部の文字列変換処理を最適化しました。

* **Chores**
  * コード品質の向上に関する微細な調整を実施しました。

**ユーザー向けの変更：** このリリースに含まれるのは内部的な改善のみで、ユーザーが感じられる変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->