### PR TITLE
🦀 Ferris: Refactor `prepare_source` to use `clone()` on enum directly

### DIFF
--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -112,21 +112,7 @@ impl PluginResolver {
 
     fn prepare_source(&self, source: &PluginSource) -> (PluginSource, Option<PathBuf>) {
         match source {
-            PluginSource::GitHub {
-                owner,
-                repo,
-                version,
-                server_url,
-            } => (
-                PluginSource::GitHub {
-                    owner: owner.clone(),
-                    repo: repo.clone(),
-                    version: version.clone(),
-                    server_url: server_url.clone(),
-                },
-                None,
-            ),
-            PluginSource::Url(url) => (PluginSource::Url(url.clone()), None),
+            PluginSource::GitHub { .. } | PluginSource::Url(_) => (source.clone(), None),
             PluginSource::Path(path) => {
                 let p = if path.is_dir() {
                     path.join("tsuzulint-rule.json")


### PR DESCRIPTION
💡 **Improvement:** Replaced manual destructuring and cloning of the `PluginSource::GitHub` and `PluginSource::Url` variants inside `prepare_source` with a direct call to `source.clone()`.
🦀 **Why:** `PluginSource` derives `Clone`, making manual field-by-field cloning unnecessary. Calling `clone()` on the enum directly is concise, idiomatic, and reduces the chance of missing a field if the enum variants evolve in the future.
🔍 **Verification:** Verified that `cargo test` passes successfully and `cargo clippy` emits no warnings for the updated code.

---
*PR created automatically by Jules for task [2299689464988444078](https://jules.google.com/task/2299689464988444078) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * プラグイン解決処理の内部ロジックを最適化し、コード複雑性を削減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->