### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded read vulnerabilities

### DIFF
--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -6,6 +6,7 @@ use crate::error::FetchError;
 use crate::fetcher::ManifestFetcher;
 use crate::manifest::{ExternalRuleManifest, HashVerifier, IntegrityError};
 use crate::security::validate_local_wasm_path;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -39,6 +40,27 @@ pub struct ResolvedPlugin {
     pub manifest_path: PathBuf,
     pub manifest: ExternalRuleManifest,
     pub alias: String,
+}
+
+fn read_wasm_bounded(path: &Path) -> Result<Vec<u8>, DownloadError> {
+    let mut file = std::fs::File::open(path).map_err(DownloadError::IoError)?;
+    let metadata = file.metadata().map_err(DownloadError::IoError)?;
+
+    if metadata.len() > crate::downloader::DEFAULT_MAX_SIZE {
+        return Err(DownloadError::TooLarge { size: metadata.len(), max: crate::downloader::DEFAULT_MAX_SIZE });
+    }
+
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    (&mut file)
+        .take(crate::downloader::DEFAULT_MAX_SIZE + 1)
+        .read_to_end(&mut bytes)
+        .map_err(DownloadError::IoError)?;
+
+    if bytes.len() as u64 > crate::downloader::DEFAULT_MAX_SIZE {
+        return Err(DownloadError::TooLarge { size: bytes.len() as u64, max: crate::downloader::DEFAULT_MAX_SIZE });
+    }
+
+    Ok(bytes)
 }
 
 pub struct PluginResolver {
@@ -164,7 +186,7 @@ impl PluginResolver {
         wasm_url = wasm_url.replace("{version}", &manifest.rule.version);
 
         if let Some(cached) = self.cache.get(source, version) {
-            match std::fs::read(&cached.wasm_path) {
+            match read_wasm_bounded(&cached.wasm_path) {
                 Ok(cached_bytes) => {
                     if HashVerifier::verify(&cached_bytes, &expected_hash).is_ok() {
                         return Ok(ResolvedPlugin {
@@ -233,7 +255,7 @@ impl PluginResolver {
 
         let wasm_path = validate_local_wasm_path(wasm_relative, parent)?;
 
-        let bytes = std::fs::read(&wasm_path).map_err(DownloadError::IoError)?;
+        let bytes = read_wasm_bounded(&wasm_path)?;
 
         let expected_hash = expected_hash.ok_or_else(|| {
             ResolveError::SerializationError(
@@ -413,6 +435,44 @@ mod tests {
             wasm_path.canonicalize().unwrap()
         );
         assert_eq!(resolved.alias, "local-alias");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_path_wasm_too_large() {
+        let dir = tempdir().unwrap();
+        let manifest_path = dir.path().join("tsuzulint-rule.json");
+        let wasm_path = dir.path().join("rule.wasm");
+
+        let file = std::fs::File::create(&wasm_path).unwrap();
+        file.set_len(crate::downloader::DEFAULT_MAX_SIZE + 1).unwrap();
+
+        let manifest = json!({
+            "rule": {
+                "name": "local-rule",
+                "version": "1.0.0",
+            },
+            "wasm": [{
+                "path": "rule.wasm",
+                "hash": "0000000000000000000000000000000000000000000000000000000000000000"
+            }]
+        });
+        std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+
+        let cache_dir = tempdir().unwrap();
+        let resolver = PluginResolver::new()
+            .unwrap()
+            .with_cache(PluginCache::with_dir(cache_dir.path()));
+        let spec = PluginSpec::parse(&json!({
+            "path": manifest_path.to_str().unwrap(),
+            "as": "local-alias"
+        }))
+        .unwrap();
+
+        let result = resolver.resolve(&spec).await;
+        assert!(matches!(
+            result,
+            Err(ResolveError::DownloadError(DownloadError::TooLarge { .. }))
+        ));
     }
 
     #[tokio::test]

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -47,7 +47,10 @@ fn read_wasm_bounded(path: &Path) -> Result<Vec<u8>, DownloadError> {
     let metadata = file.metadata().map_err(DownloadError::IoError)?;
 
     if metadata.len() > crate::downloader::DEFAULT_MAX_SIZE {
-        return Err(DownloadError::TooLarge { size: metadata.len(), max: crate::downloader::DEFAULT_MAX_SIZE });
+        return Err(DownloadError::TooLarge {
+            size: metadata.len(),
+            max: crate::downloader::DEFAULT_MAX_SIZE,
+        });
     }
 
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
@@ -57,7 +60,10 @@ fn read_wasm_bounded(path: &Path) -> Result<Vec<u8>, DownloadError> {
         .map_err(DownloadError::IoError)?;
 
     if bytes.len() as u64 > crate::downloader::DEFAULT_MAX_SIZE {
-        return Err(DownloadError::TooLarge { size: bytes.len() as u64, max: crate::downloader::DEFAULT_MAX_SIZE });
+        return Err(DownloadError::TooLarge {
+            size: bytes.len() as u64,
+            max: crate::downloader::DEFAULT_MAX_SIZE,
+        });
     }
 
     Ok(bytes)
@@ -444,7 +450,8 @@ mod tests {
         let wasm_path = dir.path().join("rule.wasm");
 
         let file = std::fs::File::create(&wasm_path).unwrap();
-        file.set_len(crate::downloader::DEFAULT_MAX_SIZE + 1).unwrap();
+        file.set_len(crate::downloader::DEFAULT_MAX_SIZE + 1)
+            .unwrap();
 
         let manifest = json!({
             "rule": {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unbounded file reads were found in `tsuzulint_registry/src/resolver.rs` when resolving local Wasm files and when reading cached Wasm files. Using `std::fs::read` allocates memory dynamically up to the file's size, risking a Denial of Service (DoS) due to memory exhaustion (OOM) if a maliciously large file is provided.
🎯 **Impact:** An attacker could craft an oversized file that, when resolved locally or verified in the cache, would cause the process to allocate excessive memory, potentially crashing the application or the entire system.
🔧 **Fix:** Replaced `std::fs::read` with a custom `read_wasm_bounded` helper function. This function strictly bounds reads by validating the file's metadata and using `Read::take()` with `crate::downloader::DEFAULT_MAX_SIZE` (50MB) to ensure the memory footprint is strictly controlled.
✅ **Verification:** Verified by unit tests (specifically `test_resolve_path_wasm_too_large`) and `cargo test --workspace --all-features`.

---
*PR created automatically by Jules for task [5966450428420118691](https://jules.google.com/task/5966450428420118691) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * WASM ファイルのサイズ制限チェックを強化しました。キャッシュ済みファイルも含め、制限を超えるファイルは読み込み時に検出され、再取得やエラー処理の対象となります。ローカルの大容量ファイルは読み込みを中断して即座にエラーとなります。

* **Tests**
  * 制限超過の WASM ファイルに対するエラーハンドリングを追加で検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
