### PR TITLE
🦀 Ferris: [refactor] Replace unwrap_or_else with unwrap_or for Path

### DIFF
--- a/.jules/ferris.md
+++ b/.jules/ferris.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Avoid unnecessary map with to_string() when iterating over &&str]
+**Learning:** `ToString` is not specialized for double references (`&&str`). When iterating over `&&str`, replace `.map(|s| s.to_string())` with `.map(|s| String::from(*s))` to bypass the `Display` trait formatter and improve performance.
+**Action:** Replace `.map(|s| s.to_string())` with `.map(|s| String::from(*s))` when iterating over `&&str` collections like in `tsuzulint_text::tokenizer`.

--- a/crates/tsuzulint_core/src/rule_manifest.rs
+++ b/crates/tsuzulint_core/src/rule_manifest.rs
@@ -69,7 +69,7 @@ pub fn load_rule_manifest(manifest_path: &Path) -> Result<LoadRuleManifestResult
         ))
     })?;
 
-    let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+    let manifest_dir = manifest_path.parent().unwrap_or(Path::new("."));
 
     let mut resolved_wasm = None;
     for w in &manifest.wasm {


### PR DESCRIPTION
💡 Improvement: Replaced `unwrap_or_else(|| Path::new("."))` with `unwrap_or(Path::new("."))` when extracting parent directories from `Path`.
🦀 Why: `Path::new(".")` is a zero-cost operation that does not allocate memory. Using `unwrap_or_else(|| Path::new("."))` creates an unnecessary closure.
🔍 Verification: Ran `make test`, `make lint`, and `make fmt-check`. No behavior changes.

---
*PR created automatically by Jules for task [6909274799658581362](https://jules.google.com/task/6909274799658581362) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 内部開発ドキュメントを更新しました。

* **Refactor**
  * マニフェストディレクトリの計算ロジックを最適化しました。

---

**注記:** 本リリースは主に内部保守作業です。エンドユーザーに対する機能変更や新機能はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/308" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
