### PR TITLE
🦀 Ferris: [refactor/improvement]

### DIFF
--- a/crates/tsuzulint_core/src/rule_manifest.rs
+++ b/crates/tsuzulint_core/src/rule_manifest.rs
@@ -69,7 +69,7 @@ pub fn load_rule_manifest(manifest_path: &Path) -> Result<LoadRuleManifestResult
         ))
     })?;
 
-    let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+    let manifest_dir = manifest_path.parent().unwrap_or(Path::new("."));
 
     let mut resolved_wasm = None;
     for w in &manifest.wasm {


### PR DESCRIPTION
💡 **Improvement**: Replaced `unwrap_or_else(|| Path::new("."))` with `unwrap_or(Path::new("."))` in `crates/tsuzulint_core/src/rule_manifest.rs`.

🦀 **Why**: `Path::new` is a `const fn` and has zero allocation overhead. Using `unwrap_or` avoids the unnecessary closure creation required by `unwrap_or_else`, making the code more idiomatic and aligning with standard Clippy lint rules (e.g. `unnecessary_lazy_evaluations`).

🔍 **Verification**: Ran `make lint`, `make fmt-check`, and `make test`. All checks passed.

---
*PR created automatically by Jules for task [8878027958775700792](https://jules.google.com/task/8878027958775700792) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 内部パスの解決ロジックを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->