### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in IPv6 handling

### DIFF
--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -32,13 +32,13 @@ pub fn check_ip(ip: std::net::IpAddr) -> Result<(), SecurityError> {
             }
         }
         std::net::IpAddr::V6(ipv6) => {
-            // Check for IPv6-mapped IPv4 addresses (e.g., ::ffff:127.0.0.1)
-            // These must be checked as IPv4 to prevent SSRF bypass
-            if let Some(ipv4) = ipv6.to_ipv4_mapped() {
-                return check_ip(std::net::IpAddr::V4(ipv4));
-            }
             if ipv6.is_loopback() || ipv6.is_unspecified() {
                 return Err(SecurityError::LoopbackDenied(ipv6.to_string()));
+            }
+            // Check for IPv6-mapped and IPv4-compatible IPv4 addresses (e.g., ::ffff:127.0.0.1, ::127.0.0.1)
+            // These must be checked as IPv4 to prevent SSRF bypass
+            if let Some(ipv4) = ipv6.to_ipv4() {
+                return check_ip(std::net::IpAddr::V4(ipv4));
             }
             // Unique local (fc00::/7)
             if (ipv6.segments()[0] & 0xfe00) == 0xfc00 || ipv6.is_unicast_link_local() {

--- a/crates/tsuzulint_registry/tests/test_ssrf_bypass.rs
+++ b/crates/tsuzulint_registry/tests/test_ssrf_bypass.rs
@@ -1,0 +1,6 @@
+#[test]
+fn test_ssrf_bypass() {
+    let ipv4_compatible: std::net::IpAddr = "::127.0.0.1".parse().unwrap();
+    let result = tsuzulint_registry::security::check_ip(ipv4_compatible);
+    assert!(result.is_err(), "Vulnerable to SSRF bypass!");
+}


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** SSRF bypass in IP evaluation. The logic checked for IPv4-mapped addresses (`::ffff:127.0.0.1`) but missed IPv4-compatible addresses (`::127.0.0.1`).
🎯 **Impact:** An attacker could craft a specific IPv4-compatible IPv6 address to target internal loopback/private services by bypassing the standard blocked lists.
🔧 **Fix:** Changed `to_ipv4_mapped()` to `to_ipv4()`. Moved the native `ipv6.is_loopback()` and `ipv6.is_unspecified()` checks to execute before the IPv4 conversion. Added `test_ssrf_bypass` to prevent regressions.
✅ **Verification:** Run `cargo test -p tsuzulint_registry --test test_ssrf_bypass` and verify it passes.

---
*PR created automatically by Jules for task [10026075849223735454](https://jules.google.com/task/10026075849223735454) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/314" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * SSRF（Server-Side Request Forgery）バイパス攻撃の検出精度を向上させました。IPv6アドレスからのIPv4抽出範囲を拡大し、より多くの偽装パターンに対応しました。

* **Tests**
  * SSRF バイパス検出に関する新しいテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->