### PR TITLE
🦀 Ferris: [refactor] idiomatic enum cloning and lazy evaluation

### DIFF
--- a/.jules/ferris.md
+++ b/.jules/ferris.md
@@ -1,0 +1,3 @@
+## 2025-04-10 - Idiomatic Enum Cloning and Lazy Evaluation
+**Learning:** When an enum derives `Clone` (like `PluginSource`), you can clone the entire instance directly instead of manually destructuring and cloning individual fields inside `match` arms. Also, when providing a fallback that requires an allocation (like string cloning), `unwrap_or_else(|| fallback.clone())` should be used instead of `unwrap_or(&fallback).clone()` to avoid eager allocation.
+**Action:** Replaced destructuring of `PluginSource::GitHub` and `PluginSource::Url` with `source.clone()`, and updated `version` fallback in `tsuzulint_registry/src/resolver.rs` to use `unwrap_or_else()`.

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -92,7 +92,9 @@ impl PluginResolver {
 
         match &spec.source {
             PluginSource::GitHub { version, .. } => {
-                let version_str = version.as_ref().unwrap_or(&manifest.rule.version).clone();
+                let version_str = version
+                    .clone()
+                    .unwrap_or_else(|| manifest.rule.version.clone());
                 self.resolve_remote(&fetcher_source, &version_str, manifest, alias)
                     .await
             }
@@ -112,21 +114,7 @@ impl PluginResolver {
 
     fn prepare_source(&self, source: &PluginSource) -> (PluginSource, Option<PathBuf>) {
         match source {
-            PluginSource::GitHub {
-                owner,
-                repo,
-                version,
-                server_url,
-            } => (
-                PluginSource::GitHub {
-                    owner: owner.clone(),
-                    repo: repo.clone(),
-                    version: version.clone(),
-                    server_url: server_url.clone(),
-                },
-                None,
-            ),
-            PluginSource::Url(url) => (PluginSource::Url(url.clone()), None),
+            PluginSource::GitHub { .. } | PluginSource::Url(_) => (source.clone(), None),
             PluginSource::Path(path) => {
                 let p = if path.is_dir() {
                     path.join("tsuzulint-rule.json")


### PR DESCRIPTION
💡 **Improvement:** Refactored the `prepare_source` function in `crates/tsuzulint_registry/src/resolver.rs` to stop manually destructuring the `PluginSource` enum variants (`GitHub` and `Url`) just to clone each internal field. Instead, simply cloned the enum instance itself. Also replaced `.as_ref().unwrap_or(&manifest.rule.version).clone()` with `.clone().unwrap_or_else(|| manifest.rule.version.clone())` to prevent eager evaluation of the fallback string allocation. 
🦀 **Why:** When an enum derives `Clone`, destructuring it to clone individual fields manually inside `match` arms is verbose and non-idiomatic. Relying on the derived `Clone` logic simplifies the code significantly. Replacing the fallback `.unwrap_or(&...).clone()` with lazy `.unwrap_or_else(|| ...)` defers memory allocation until strictly necessary, making it more memory efficient and idiomatic. 
🔍 **Verification:** Verified by building and passing workspace tests using `cargo test -p tsuzulint_registry` and linting with `make fmt-check` and `make lint`. No behavior changes; tests still succeed. Documented learning in `.jules/ferris.md`.

---
*PR created automatically by Jules for task [11152253543891674672](https://jules.google.com/task/11152253543891674672) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 開発ベストプラクティスに関する新しいドキュメントエントリを追加しました。

* **Refactor**
  * コード内部の実装を簡略化し、パフォーマンスと保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->