### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via IPv4-compatible IPv6 addresses

### DIFF
--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -32,13 +32,13 @@ pub fn check_ip(ip: std::net::IpAddr) -> Result<(), SecurityError> {
             }
         }
         std::net::IpAddr::V6(ipv6) => {
-            // Check for IPv6-mapped IPv4 addresses (e.g., ::ffff:127.0.0.1)
-            // These must be checked as IPv4 to prevent SSRF bypass
-            if let Some(ipv4) = ipv6.to_ipv4_mapped() {
-                return check_ip(std::net::IpAddr::V4(ipv4));
-            }
             if ipv6.is_loopback() || ipv6.is_unspecified() {
                 return Err(SecurityError::LoopbackDenied(ipv6.to_string()));
+            }
+            // Check for IPv6-mapped and IPv4-compatible IPv4 addresses (e.g., ::ffff:127.0.0.1, ::127.0.0.1)
+            // These must be checked as IPv4 to prevent SSRF bypass
+            if let Some(ipv4) = ipv6.to_ipv4() {
+                return check_ip(std::net::IpAddr::V4(ipv4));
             }
             // Unique local (fc00::/7)
             if (ipv6.segments()[0] & 0xfe00) == 0xfc00 || ipv6.is_unicast_link_local() {
@@ -354,6 +354,30 @@ mod tests {
         assert!(
             check_ip(ip).is_ok(),
             "::ffff:8.8.8.8 should be allowed as public"
+        );
+    }
+
+    #[test]
+    fn test_check_ip_ipv4_compatible_ipv6() {
+        // IPv4-compatible loopback
+        let ip: std::net::IpAddr = "::127.0.0.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::LoopbackDenied(_))),
+            "::127.0.0.1 should be denied as loopback"
+        );
+
+        // IPv4-compatible private (10.0.0.0/8)
+        let ip: std::net::IpAddr = "::10.0.0.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::PrivateIpDenied(_))),
+            "::10.0.0.1 should be denied as private"
+        );
+
+        // IPv4-compatible public
+        let ip: std::net::IpAddr = "::8.8.8.8".parse().unwrap();
+        assert!(
+            check_ip(ip).is_ok(),
+            "::8.8.8.8 should be allowed as public"
         );
     }
 }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix SSRF bypass via IPv4-compatible IPv6 addresses

🚨 **Severity:** HIGH
💡 **Vulnerability:** SSRF bypass via IPv4-compatible IPv6 addresses in `check_ip`.
🎯 **Impact:** An attacker could bypass IP loopback filters by sending an IPv4-compatible address like `::127.0.0.1`.
🔧 **Fix:** Replaced `.to_ipv4_mapped()` with `.to_ipv4()` to capture both compatible and mapped formats. Moved the IPv6 `is_loopback` check above the conversion because the IPv6 loopback `::1` converts to `0.0.0.1`, bypassing the IPv4 loopback check.
✅ **Verification:** Added tests for IPv4-compatible public, loopback, and private IPs and ran the full suite via `make test`.

---
*PR created automatically by Jules for task [3271298744143012104](https://jules.google.com/task/3271298744143012104) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * IPv6アドレスのセキュリティ検証処理を改善しました。ループバックおよびプライベートアドレスの検出精度が向上しています。

* **テスト**
  * IPv6互換フォーマットのアドレスに対するセキュリティ検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->