### PR TITLE
🦀 Ferris: Optimize string allocation in tokenizer and context

### DIFF
--- a/crates/tsuzulint_core/src/context.rs
+++ b/crates/tsuzulint_core/src/context.rs
@@ -396,7 +396,7 @@ impl<'a> LintContext<'a> {
             }
             NodeType::Link | NodeType::Image => {
                 let url = node.url().unwrap_or("").to_string();
-                let title = node.title().map(|s| s.to_string());
+                let title = node.title().map(String::from);
                 structure.links.push(LinkInfo {
                     url,
                     title,
@@ -405,7 +405,7 @@ impl<'a> LintContext<'a> {
                 });
             }
             NodeType::CodeBlock => {
-                let lang = node.lang().map(|s| s.to_string());
+                let lang = node.lang().map(String::from);
                 structure.code_blocks.push(CodeBlockInfo {
                     lang,
                     span: node.span,

--- a/crates/tsuzulint_core/src/formatters/sarif.rs
+++ b/crates/tsuzulint_core/src/formatters/sarif.rs
@@ -114,7 +114,7 @@ impl ToolComponent {
         let rules_vec: Vec<_> = rules.into_values().collect();
         Self {
             name: TOOL_NAME.to_string(),
-            version: option_env!("CARGO_PKG_VERSION").map(|s| s.to_string()),
+            version: option_env!("CARGO_PKG_VERSION").map(String::from),
             rules: rules_vec,
         }
     }

--- a/crates/tsuzulint_plugin/src/host.rs
+++ b/crates/tsuzulint_plugin/src/host.rs
@@ -634,7 +634,7 @@ mod tests {
         assert_eq!(guest_request.source, source);
         assert_eq!(guest_request.tokens, tokens);
         assert_eq!(guest_request.sentences, sentences);
-        assert_eq!(guest_request.file_path, file_path.map(|s| s.to_string()));
+        assert_eq!(guest_request.file_path, file_path.map(String::from));
         assert_eq!(guest_request.node, node_data);
         assert_eq!(guest_request.helpers, None);
     }

--- a/crates/tsuzulint_text/src/tokenizer.rs
+++ b/crates/tsuzulint_text/src/tokenizer.rs
@@ -69,14 +69,14 @@ impl Tokenizer {
                 .iter()
                 .take(4)
                 .filter(|s| **s != "*")
-                .map(|s| s.to_string())
+                .map(|s| String::from(*s))
                 .collect();
 
             let detail: Vec<String> = details
                 .iter()
                 .skip(4)
                 .filter(|s| **s != "*")
-                .map(|s| s.to_string())
+                .map(|s| String::from(*s))
                 .collect();
 
             let span = lindera_token.byte_start..lindera_token.byte_end;


### PR DESCRIPTION
💡 Improvement: Replaced instances of `.map(|s| s.to_string())` with the more idiomatic `.map(String::from)` across the codebase.
🦀 Why: In modern Rust, `.to_string()` on `&str` or string-like types often involves implicit display formatting layers and redundant closure instantiations. Using the `String::from` function pointer directly is cleaner, resolves potential `clippy::redundant_closure` complaints, and operates optimally as a known allocation pathway. When dealing with double references (`&&str`), passing `|s| String::from(*s)` correctly dereferences before converting without the `Display` overhead of `ToString`.
🔍 Verification: Checked compilation using `cargo check` and ensured all tests passed with `cargo test --workspace --all-features`. Verified no clippy warnings via `cargo clippy --workspace --all-targets -- -D warnings`.

---
*PR created automatically by Jules for task [6080421523449440061](https://jules.google.com/task/6080421523449440061) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 複数のモジュール内の文字列変換メソッドを最適化しました。ユーザー向けの機能や動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->