### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via IPv4-compatible IPv6 addresses

### DIFF
--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -32,13 +32,14 @@ pub fn check_ip(ip: std::net::IpAddr) -> Result<(), SecurityError> {
             }
         }
         std::net::IpAddr::V6(ipv6) => {
-            // Check for IPv6-mapped IPv4 addresses (e.g., ::ffff:127.0.0.1)
-            // These must be checked as IPv4 to prevent SSRF bypass
-            if let Some(ipv4) = ipv6.to_ipv4_mapped() {
-                return check_ip(std::net::IpAddr::V4(ipv4));
-            }
             if ipv6.is_loopback() || ipv6.is_unspecified() {
                 return Err(SecurityError::LoopbackDenied(ipv6.to_string()));
+            }
+            // Check for IPv6-mapped IPv4 addresses (e.g., ::ffff:127.0.0.1)
+            // and IPv4-compatible IPv6 addresses (e.g., ::127.0.0.1)
+            // These must be checked as IPv4 to prevent SSRF bypass
+            if let Some(ipv4) = ipv6.to_ipv4() {
+                return check_ip(std::net::IpAddr::V4(ipv4));
             }
             // Unique local (fc00::/7)
             if (ipv6.segments()[0] & 0xfe00) == 0xfc00 || ipv6.is_unicast_link_local() {
@@ -302,6 +303,59 @@ mod tests {
         assert!(
             check_ip(ip).is_ok(),
             "2001:4860:4860::8888 should be allowed"
+        );
+    }
+
+    #[test]
+    fn test_check_ip_ipv4_compatible_ipv6() {
+        // IPv4-compatible loopback
+        let ip: std::net::IpAddr = "::127.0.0.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::LoopbackDenied(_))),
+            "::127.0.0.1 should be denied as loopback"
+        );
+
+        // IPv4-compatible private (10.0.0.0/8)
+        let ip: std::net::IpAddr = "::10.0.0.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::PrivateIpDenied(_))),
+            "::10.0.0.1 should be denied as private"
+        );
+
+        // IPv4-compatible private (172.16.0.0/12)
+        let ip: std::net::IpAddr = "::172.16.0.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::PrivateIpDenied(_))),
+            "::172.16.0.1 should be denied as private"
+        );
+
+        // IPv4-compatible private (192.168.0.0/16)
+        let ip: std::net::IpAddr = "::192.168.1.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::PrivateIpDenied(_))),
+            "::192.168.1.1 should be denied as private"
+        );
+
+        // IPv4-compatible link-local
+        let ip: std::net::IpAddr = "::169.254.1.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::PrivateIpDenied(_))),
+            "::169.254.1.1 should be denied as link-local"
+        );
+
+        // IPv4-compatible unspecified
+        // Note: ::0.0.0.0 parses correctly as ::
+        let ip: std::net::IpAddr = "::0.0.0.0".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::LoopbackDenied(_))),
+            "::0.0.0.0 should be denied as unspecified"
+        );
+
+        // IPv4-compatible public
+        let ip: std::net::IpAddr = "::8.8.8.8".parse().unwrap();
+        assert!(
+            check_ip(ip).is_ok(),
+            "::8.8.8.8 should be allowed as public"
         );
     }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Server-Side Request Forgery (SSRF) bypass via IPv4-compatible IPv6 addresses.
🎯 Impact: An attacker could bypass local, loopback, or private IP address restrictions in `check_ip` by providing an IPv4-compatible IPv6 address such as `::127.0.0.1` or `::192.168.1.1` instead of the standard IPv4 or IPv4-mapped format, potentially allowing access to restricted local resources.
🔧 Fix: Used `ipv6.to_ipv4()` instead of `ipv6.to_ipv4_mapped()` to accurately extract the underlying IPv4 address in both mapped and compatible forms. Rearranged loopback and unspecified checks above the translation to prevent `::1` bypass. Added comprehensive unit tests covering IPv4-compatible variants.
✅ Verification: Ensure the new test `test_check_ip_ipv4_compatible_ipv6` passes with `make test`.

---
*PR created automatically by Jules for task [12391839156580366184](https://jules.google.com/task/12391839156580366184) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * IPv6アドレスの検証ロジックを改善し、ループバックおよび未指定アドレスの処理を強化しました。
  * IPv4互換IPv6アドレスの処理を最適化しました。

* **テスト**
  * IPv4互換IPv6アドレスをカバーする新しいテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->