### PR TITLE
🦀 Ferris: Refactor to_string_lossy().to_string() to into_owned()

### DIFF
--- a/crates/tsuzulint_core/src/formatters/sarif.rs
+++ b/crates/tsuzulint_core/src/formatters/sarif.rs
@@ -232,7 +232,7 @@ impl ArtifactLocation {
     /// Creates artifact location from path
     fn new(path: &std::path::Path) -> Self {
         Self {
-            uri: path.to_string_lossy().to_string(),
+            uri: path.to_string_lossy().into_owned(),
         }
     }
 }

--- a/crates/tsuzulint_core/src/linter.rs
+++ b/crates/tsuzulint_core/src/linter.rs
@@ -171,7 +171,7 @@ mod tests {
         let mut config = LinterConfig::new();
         config.cache = crate::config::CacheConfig::Detail(crate::config::CacheConfigDetail {
             enabled: true,
-            path: temp_dir.path().to_string_lossy().to_string(),
+            path: temp_dir.path().to_string_lossy().into_owned(),
         });
         (config, temp_dir)
     }
@@ -421,7 +421,7 @@ mod tests {
                 github: None,
                 server_url: None,
                 url: None,
-                path: Some(abs_manifest_path.to_string_lossy().to_string()),
+                path: Some(abs_manifest_path.to_string_lossy().into_owned()),
                 r#as: None,
             },
         ));

--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -373,4 +373,25 @@ mod tests {
             "::10.0.0.1 should be denied as private"
         );
     }
+
+    #[test]
+    fn test_validate_local_wasm_path_absolute() {
+        let manifest_dir = std::path::PathBuf::from("/base/dir");
+        let result = validate_local_wasm_path(std::path::Path::new("/absolute/path.wasm"), &manifest_dir);
+        assert!(matches!(result, Err(SecurityError::AbsolutePathNotAllowed(_))));
+    }
+
+    #[test]
+    fn test_validate_local_wasm_path_parent_dir() {
+        let manifest_dir = std::path::PathBuf::from("/base/dir");
+        let result = validate_local_wasm_path(std::path::Path::new("../parent/path.wasm"), &manifest_dir);
+        assert!(matches!(result, Err(SecurityError::ParentDirNotAllowed(_))));
+    }
+
+    #[test]
+    fn test_validate_local_wasm_path_not_found() {
+        let manifest_dir = std::path::PathBuf::from("/base/dir");
+        let result = validate_local_wasm_path(std::path::Path::new("not_found.wasm"), &manifest_dir);
+        assert!(matches!(result, Err(SecurityError::FileNotFound { .. })));
+    }
 }

--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -377,21 +377,50 @@ mod tests {
     #[test]
     fn test_validate_local_wasm_path_absolute() {
         let manifest_dir = std::path::PathBuf::from("/base/dir");
-        let result = validate_local_wasm_path(std::path::Path::new("/absolute/path.wasm"), &manifest_dir);
-        assert!(matches!(result, Err(SecurityError::AbsolutePathNotAllowed(_))));
+        let result =
+            validate_local_wasm_path(std::path::Path::new("/absolute/path.wasm"), &manifest_dir);
+        assert!(matches!(
+            result,
+            Err(SecurityError::AbsolutePathNotAllowed(_))
+        ));
     }
 
     #[test]
     fn test_validate_local_wasm_path_parent_dir() {
         let manifest_dir = std::path::PathBuf::from("/base/dir");
-        let result = validate_local_wasm_path(std::path::Path::new("../parent/path.wasm"), &manifest_dir);
+        let result =
+            validate_local_wasm_path(std::path::Path::new("../parent/path.wasm"), &manifest_dir);
         assert!(matches!(result, Err(SecurityError::ParentDirNotAllowed(_))));
     }
 
     #[test]
     fn test_validate_local_wasm_path_not_found() {
         let manifest_dir = std::path::PathBuf::from("/base/dir");
-        let result = validate_local_wasm_path(std::path::Path::new("not_found.wasm"), &manifest_dir);
+        let result =
+            validate_local_wasm_path(std::path::Path::new("not_found.wasm"), &manifest_dir);
         assert!(matches!(result, Err(SecurityError::FileNotFound { .. })));
+    }
+
+    #[test]
+    fn test_validate_local_wasm_path_traversal_symlink() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_dir = temp_dir.path().join("base");
+        std::fs::create_dir(&base_dir).unwrap();
+
+        let outside_dir = temp_dir.path().join("outside");
+        std::fs::create_dir(&outside_dir).unwrap();
+
+        let outside_wasm = outside_dir.join("rule.wasm");
+        std::fs::write(&outside_wasm, "fake wasm").unwrap();
+
+        let symlink_wasm = base_dir.join("rule.wasm");
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside_wasm, &symlink_wasm).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&outside_wasm, &symlink_wasm).unwrap();
+
+        let result = validate_local_wasm_path(std::path::Path::new("rule.wasm"), &base_dir);
+        assert!(matches!(result, Err(SecurityError::PathTraversal { .. })));
     }
 }

--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -119,8 +119,8 @@ pub fn validate_local_wasm_path(
 
     if !wasm_canon.starts_with(&manifest_canon) {
         return Err(SecurityError::PathTraversal {
-            path: wasm_path.display().to_string(),
-            base: manifest_dir.display().to_string(),
+            path: wasm_path.to_string_lossy().into_owned(),
+            base: manifest_dir.to_string_lossy().into_owned(),
         });
     }
 

--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -82,7 +82,7 @@ pub fn validate_local_wasm_path(
 ) -> Result<PathBuf, SecurityError> {
     if wasm_relative.is_absolute() || wasm_relative.has_root() {
         return Err(SecurityError::AbsolutePathNotAllowed(
-            wasm_relative.to_string_lossy().to_string(),
+            wasm_relative.to_string_lossy().into_owned(),
         ));
     }
 
@@ -91,7 +91,7 @@ pub fn validate_local_wasm_path(
         .any(|c| matches!(c, std::path::Component::ParentDir))
     {
         return Err(SecurityError::ParentDirNotAllowed(
-            wasm_relative.to_string_lossy().to_string(),
+            wasm_relative.to_string_lossy().into_owned(),
         ));
     }
 
@@ -99,22 +99,22 @@ pub fn validate_local_wasm_path(
 
     if !wasm_path.exists() {
         return Err(SecurityError::FileNotFound {
-            path: wasm_path.to_string_lossy().to_string(),
+            path: wasm_path.to_string_lossy().into_owned(),
         });
     }
 
     let manifest_canon = manifest_dir
         .canonicalize()
         .map_err(|_| SecurityError::PathTraversal {
-            path: wasm_path.to_string_lossy().to_string(),
-            base: manifest_dir.to_string_lossy().to_string(),
+            path: wasm_path.to_string_lossy().into_owned(),
+            base: manifest_dir.to_string_lossy().into_owned(),
         })?;
 
     let wasm_canon = wasm_path
         .canonicalize()
         .map_err(|_| SecurityError::PathTraversal {
-            path: wasm_path.to_string_lossy().to_string(),
-            base: manifest_dir.to_string_lossy().to_string(),
+            path: wasm_path.to_string_lossy().into_owned(),
+            base: manifest_dir.to_string_lossy().into_owned(),
         })?;
 
     if !wasm_canon.starts_with(&manifest_canon) {


### PR DESCRIPTION
💡 Improvement: Replaced `.to_string_lossy().to_string()` with `.to_string_lossy().into_owned()` in `crates/tsuzulint_registry/src/security.rs` and `crates/tsuzulint_core` files.

🦀 Why: `Path::to_string_lossy()` returns a `Cow<'_, str>`. Calling `.to_string()` on a `Cow` clones the string unconditionally, performing a double-allocation if the path had invalid UTF-8 and the `Cow` was already owned. Calling `.into_owned()` correctly consumes the `Cow`, converting to a `String` while reusing the underlying buffer if it was already owned, adhering to idiomatic Rust and zero-cost abstractions.

🔍 Verification: Verified with `cargo test --workspace --all-features`, `cargo clippy`, and `cargo fmt`. All tests pass.

---
*PR created automatically by Jules for task [6420020705025095473](https://jules.google.com/task/6420020705025095473) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ファイルパス処理における文字列生成メカニズムを最適化しました。複数の内部モジュール（フォーマッタ、リンター、セキュリティ検証）で文字列変換の実装を改善し、内部処理の効率性を向上させています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->