### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via IPv4-compatible IPv6 addresses

### DIFF
--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -32,13 +32,13 @@ pub fn check_ip(ip: std::net::IpAddr) -> Result<(), SecurityError> {
             }
         }
         std::net::IpAddr::V6(ipv6) => {
-            // Check for IPv6-mapped IPv4 addresses (e.g., ::ffff:127.0.0.1)
-            // These must be checked as IPv4 to prevent SSRF bypass
-            if let Some(ipv4) = ipv6.to_ipv4_mapped() {
-                return check_ip(std::net::IpAddr::V4(ipv4));
-            }
             if ipv6.is_loopback() || ipv6.is_unspecified() {
                 return Err(SecurityError::LoopbackDenied(ipv6.to_string()));
+            }
+            // Check for IPv6-mapped and IPv4-compatible addresses
+            // These must be checked as IPv4 to prevent SSRF bypass
+            if let Some(ipv4) = ipv6.to_ipv4() {
+                return check_ip(std::net::IpAddr::V4(ipv4));
             }
             // Unique local (fc00::/7)
             if (ipv6.segments()[0] & 0xfe00) == 0xfc00 || ipv6.is_unicast_link_local() {
@@ -354,6 +354,20 @@ mod tests {
         assert!(
             check_ip(ip).is_ok(),
             "::ffff:8.8.8.8 should be allowed as public"
+        );
+
+        // IPv4-compatible loopback
+        let ip: std::net::IpAddr = "::127.0.0.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::LoopbackDenied(_))),
+            "::127.0.0.1 should be denied as loopback"
+        );
+
+        // IPv4-compatible private
+        let ip: std::net::IpAddr = "::10.0.0.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::PrivateIpDenied(_))),
+            "::10.0.0.1 should be denied as private"
         );
     }
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The URL validation logic in `tsuzulint_registry` failed to check IPv4-compatible IPv6 addresses (e.g. `::127.0.0.1`) when ensuring URLs do not resolve to local/private network resources, allowing an SSRF bypass.
🎯 Impact: Attackers could potentially force the application to make internal requests to the loopback interface or private network endpoints.
🔧 Fix: Changed `to_ipv4_mapped()` to `to_ipv4()` to validate all embedded IPv4 addresses. Ensure IPv6 loopback/unspecified checks happen prior to conversion so native `::1` is evaluated securely.
✅ Verification: Ran `cargo test --workspace` to verify fix using the new IPv4-compatible test cases.

---
*PR created automatically by Jules for task [2994857727080576281](https://jules.google.com/task/2994857727080576281) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/329" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
