### PR TITLE
🦀 Ferris: [refactor] idiomatic enum cloning

### DIFF
--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -112,21 +112,7 @@ impl PluginResolver {
 
     fn prepare_source(&self, source: &PluginSource) -> (PluginSource, Option<PathBuf>) {
         match source {
-            PluginSource::GitHub {
-                owner,
-                repo,
-                version,
-                server_url,
-            } => (
-                PluginSource::GitHub {
-                    owner: owner.clone(),
-                    repo: repo.clone(),
-                    version: version.clone(),
-                    server_url: server_url.clone(),
-                },
-                None,
-            ),
-            PluginSource::Url(url) => (PluginSource::Url(url.clone()), None),
+            PluginSource::GitHub { .. } | PluginSource::Url(_) => (source.clone(), None),
             PluginSource::Path(path) => {
                 let p = if path.is_dir() {
                     path.join("tsuzulint-rule.json")


### PR DESCRIPTION
💡 Improvement: Simplified `prepare_source` in `tsuzulint_registry/src/resolver.rs` by combining the `PluginSource::GitHub` and `PluginSource::Url` match arms to directly use `source.clone()`.
🦀 Why: When an enum derives `Clone`, destructuring it to clone individual fields manually is non-idiomatic and unnecessarily verbose. Cloning the instance directly is cleaner and expresses the intent better.
🔍 Verification: Ran `cargo test --workspace --all-features`, `make lint`, and `make fmt-check`. All tests and checks passed. No behavioral changes.

---
*PR created automatically by Jules for task [18246826077508227010](https://jules.google.com/task/18246826077508227010) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * パフォーマンス最適化により、プラグインソースの処理速度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->