### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via IPv4-compatible IPv6 addresses

### DIFF
--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -32,13 +32,13 @@ pub fn check_ip(ip: std::net::IpAddr) -> Result<(), SecurityError> {
             }
         }
         std::net::IpAddr::V6(ipv6) => {
-            // Check for IPv6-mapped IPv4 addresses (e.g., ::ffff:127.0.0.1)
-            // These must be checked as IPv4 to prevent SSRF bypass
-            if let Some(ipv4) = ipv6.to_ipv4_mapped() {
-                return check_ip(std::net::IpAddr::V4(ipv4));
-            }
             if ipv6.is_loopback() || ipv6.is_unspecified() {
                 return Err(SecurityError::LoopbackDenied(ipv6.to_string()));
+            }
+            // Check for IPv6-mapped and IPv4-compatible addresses
+            // These must be checked as IPv4 to prevent SSRF bypass
+            if let Some(ipv4) = ipv6.to_ipv4() {
+                return check_ip(std::net::IpAddr::V4(ipv4));
             }
             // Unique local (fc00::/7)
             if (ipv6.segments()[0] & 0xfe00) == 0xfc00 || ipv6.is_unicast_link_local() {
@@ -354,6 +354,23 @@ mod tests {
         assert!(
             check_ip(ip).is_ok(),
             "::ffff:8.8.8.8 should be allowed as public"
+        );
+    }
+
+    #[test]
+    fn test_check_ip_ipv4_compatible_ipv6() {
+        // IPv4-compatible loopback
+        let ip: std::net::IpAddr = "::127.0.0.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::LoopbackDenied(_))),
+            "::127.0.0.1 should be denied as loopback"
+        );
+
+        // IPv4-compatible private (10.0.0.0/8)
+        let ip: std::net::IpAddr = "::10.0.0.1".parse().unwrap();
+        assert!(
+            matches!(check_ip(ip), Err(SecurityError::PrivateIpDenied(_))),
+            "::10.0.0.1 should be denied as private"
         );
     }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `check_ip` function evaluated the IPv6 `is_loopback` and `is_unspecified` functions after IPv4 conversion and only checked for IPv4-mapped addresses (`to_ipv4_mapped()`). This meant IPv4-compatible loopback and private IPs (like `::127.0.0.1` and `::10.0.0.1`) were not caught.
🎯 **Impact:** An attacker could bypass IP validations and cause the application to resolve and interact with restricted private network addresses (SSRF), potentially accessing internal services or sensitive configuration.
🔧 **Fix:** Reordered the loopback/unspecified checks to occur before the IPv4 conversion. Replaced `to_ipv4_mapped` with `to_ipv4` to safely handle both IPv4-compatible and IPv4-mapped addresses.
✅ **Verification:** Added `test_check_ip_ipv4_compatible_ipv6` to explicitly test that IPv4-compatible private and loopback addresses trigger the appropriate `SecurityError`. Tests run via `make test`.

---
*PR created automatically by Jules for task [4280388605809646606](https://jules.google.com/task/4280388605809646606) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * IPv6アドレスの処理を改善し、IPv6マップ済みおよびIPv4互換アドレスからのIPv4アドレス抽出を強化しました。再帰的な検証により、セキュリティ上の潜在的なリスクを軽減しています。

* **テスト**
  * IPv4互換IPv6形式のループバックおよびプライベートアドレスに関する新しいテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->