### PR TITLE
🦀 Ferris: [refactor] Replace unwrap_or_else with unwrap_or for zero-cost fallbacks

### DIFF
--- a/crates/tsuzulint_core/src/rule_manifest.rs
+++ b/crates/tsuzulint_core/src/rule_manifest.rs
@@ -69,7 +69,7 @@ pub fn load_rule_manifest(manifest_path: &Path) -> Result<LoadRuleManifestResult
         ))
     })?;
 
-    let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new("."));
+    let manifest_dir = manifest_path.parent().unwrap_or(Path::new("."));
 
     let mut resolved_wasm = None;
     for w in &manifest.wasm {


### PR DESCRIPTION
💡 Improvement:
Replaced `.unwrap_or_else(|| Path::new("."))` with `.unwrap_or(Path::new("."))` in `crates/tsuzulint_core/src/rule_manifest.rs`.

🦀 Why:
`Path::new(".")` is a zero-cost operation that does not allocate memory. Using a lazy evaluation closure (`unwrap_or_else`) is unnecessarily verbose for this scenario. Replacing it with `unwrap_or` is more idiomatic and concise, aligning with `clippy::unnecessary_lazy_evaluations` checks.

🔍 Verification:
Ran `make test`, `make lint`, and `make fmt-check` to ensure no functionality is broken. Tests pass and clippy reports zero warnings.

---
*PR created automatically by Jules for task [643501704287695001](https://jules.google.com/task/643501704287695001) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 内部コードの最適化を実施しました。ユーザーに対する機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->