### PR TITLE
feat(core): add native rule engine with 10 built-in rules

### DIFF
--- a/crates/tsuzulint_core/src/config.rs
+++ b/crates/tsuzulint_core/src/config.rs
@@ -267,6 +267,7 @@ impl LinterConfig {
             .collect()
     }
 
+
     /// Computes a hash of the configuration for cache invalidation.
     pub fn hash(&self) -> Result<[u8; 32], LinterError> {
         let json = serde_json::to_string(self)

--- a/crates/tsuzulint_core/src/config.rs
+++ b/crates/tsuzulint_core/src/config.rs
@@ -267,7 +267,6 @@ impl LinterConfig {
             .collect()
     }
 
-
     /// Computes a hash of the configuration for cache invalidation.
     pub fn hash(&self) -> Result<[u8; 32], LinterError> {
         let json = serde_json::to_string(self)

--- a/crates/tsuzulint_core/src/config.rs
+++ b/crates/tsuzulint_core/src/config.rs
@@ -271,7 +271,18 @@ impl LinterConfig {
     pub fn hash(&self) -> Result<[u8; 32], LinterError> {
         let json = serde_json::to_string(self)
             .map_err(|e| LinterError::Internal(format!("Failed to serialize config: {}", e)))?;
-        Ok(blake3::hash(json.as_bytes()).into())
+        // Mix the tsuzulint crate version into the hash so that native rule
+        // behaviour changes between binary versions invalidate the cache.
+        // Native rule versions are not tracked in the per-rule
+        // `rule_versions` map (unlike WASM rules which expose a manifest
+        // version), so without this the cache would happily serve stale
+        // diagnostics after a binary upgrade that changed a native rule's
+        // semantics.
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(env!("CARGO_PKG_VERSION").as_bytes());
+        hasher.update(b"\0");
+        hasher.update(json.as_bytes());
+        Ok(hasher.finalize().into())
     }
 }
 

--- a/crates/tsuzulint_core/src/file_linter.rs
+++ b/crates/tsuzulint_core/src/file_linter.rs
@@ -32,6 +32,10 @@ pub struct LintContext<'a> {
     pub enabled_rules: &'a HashSet<&'a str>,
     pub rule_versions: &'a HashMap<String, String>,
     pub timings_enabled: bool,
+    /// Options for enabled rules keyed by rule alias. Used by the native
+    /// rule engine to hand per-rule config to rules (the WASM host path
+    /// wires options through its own `configure_rule` mechanism).
+    pub rule_options: &'a HashMap<String, serde_json::Value>,
 }
 
 pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, LinterError> {
@@ -44,6 +48,7 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
         enabled_rules,
         rule_versions,
         timings_enabled,
+        rule_options,
     } = ctx;
     let timings_enabled = *timings_enabled;
     debug!("Linting {}", path.display());
@@ -100,8 +105,21 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
 
     // host is &mut &'a mut PluginHost after destructuring LintContext.
     // We double-dereference and take an immutable borrow to pass &PluginHost to read-only helpers.
-    let needs_morphology = any_rule_needs_morphology(host.loaded_rules(), &**host, enabled_rules);
-    let needs_sentences = any_rule_needs_sentences(host.loaded_rules(), &**host, enabled_rules);
+    let wasm_needs_morphology =
+        any_rule_needs_morphology(host.loaded_rules(), &**host, enabled_rules);
+    let wasm_needs_sentences =
+        any_rule_needs_sentences(host.loaded_rules(), &**host, enabled_rules);
+    // Native rules also declare capability needs. Without this, a native rule
+    // that sets `needs_morphology()` would silently get an empty token slice.
+    let registry = crate::native_rules::builtin_registry();
+    let native_needs_morphology = enabled_rules
+        .iter()
+        .any(|name| registry.get(name).is_some_and(|r| r.needs_morphology()));
+    let native_needs_sentences = enabled_rules
+        .iter()
+        .any(|name| registry.get(name).is_some_and(|r| r.needs_sentences()));
+    let needs_morphology = wasm_needs_morphology || native_needs_morphology;
+    let needs_sentences = wasm_needs_sentences || native_needs_sentences;
 
     let tokens = if needs_morphology {
         tokenizer
@@ -233,8 +251,43 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
         }
     }
 
+    // Native rules run after WASM rules so they see the same pre-computed
+    // tokens/sentences and share the ignore_ranges-aware splitter output.
+    // We only dispatch native rules whose name appears in enabled_rules AND
+    // is not already loaded as a WASM rule — that lets a user override a
+    // built-in rule with a custom WASM plugin just by loading one with the
+    // same name.
+    let mut native_diagnostics: Vec<tsuzulint_plugin::Diagnostic> = Vec::new();
+    let registry = crate::native_rules::builtin_registry();
+    let null_options = serde_json::Value::Null;
+    for &rule_name in enabled_rules.iter() {
+        if host.loaded_rules().any(|loaded| loaded == rule_name) {
+            continue;
+        }
+        let Some(rule) = registry.get(rule_name) else {
+            continue;
+        };
+        let options = rule_options.get(rule_name).unwrap_or(&null_options);
+        let native_ctx = crate::native_rules::RuleContext {
+            ast: &ast,
+            source: &content,
+            tokens: &tokens,
+            sentences: &sentences,
+            options,
+            file_path: Some(path),
+        };
+        let start = Instant::now();
+        native_diagnostics.extend(rule.lint(&native_ctx));
+        if timings_enabled {
+            *timings
+                .entry(rule_name.to_string())
+                .or_insert(Duration::ZERO) += start.elapsed();
+        }
+    }
+
     let mut local_diagnostics = reused_diagnostics;
     local_diagnostics.extend(block_diagnostics);
+    local_diagnostics.extend(native_diagnostics);
 
     // Filter out diagnostics that are covered by global rules (by checking rule ID).
     // Global rules take precedence, and their diagnostics should not be stored in block cache.
@@ -398,6 +451,9 @@ where
                 IsolationLevel::Global => global_rules.push(name),
                 IsolationLevel::Block => block_rules.push(name),
             }
+        } else if crate::native_rules::builtin_registry().get(name).is_some() {
+            // Rule is served by the native engine; handled in `lint_file_internal`
+            // after the WASM dispatch loop. No warning to avoid noise.
         } else {
             warn!("Missing manifest for enabled rule: {}", name);
         }

--- a/crates/tsuzulint_core/src/file_linter.rs
+++ b/crates/tsuzulint_core/src/file_linter.rs
@@ -258,6 +258,7 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
     // built-in rule with a custom WASM plugin just by loading one with the
     // same name.
     let mut native_diagnostics: Vec<tsuzulint_plugin::Diagnostic> = Vec::new();
+    let mut native_rule_ids: HashSet<&str> = HashSet::new();
     let registry = crate::native_rules::builtin_registry();
     let null_options = serde_json::Value::Null;
     for &rule_name in enabled_rules.iter() {
@@ -267,6 +268,7 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
         let Some(rule) = registry.get(rule_name) else {
             continue;
         };
+        native_rule_ids.insert(rule_name);
         let options = rule_options.get(rule_name).unwrap_or(&null_options);
         let native_ctx = crate::native_rules::RuleContext {
             ast: &ast,
@@ -286,8 +288,12 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
     }
 
     let mut local_diagnostics = reused_diagnostics;
+    // Native rules are recomputed for the whole file on every non-full-cache
+    // run, so any native diagnostics surviving in per-block cache from a
+    // previous run must be dropped to avoid stale results when only a subset
+    // of blocks changed.
+    local_diagnostics.retain(|d| !native_rule_ids.contains(d.rule_id.as_str()));
     local_diagnostics.extend(block_diagnostics);
-    local_diagnostics.extend(native_diagnostics);
 
     // Filter out diagnostics that are covered by global rules (by checking rule ID).
     // Global rules take precedence, and their diagnostics should not be stored in block cache.
@@ -297,12 +303,14 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
     local_diagnostics.sort_unstable();
     local_diagnostics.dedup();
 
-    // Distribute local diagnostics to blocks.
+    // Distribute local diagnostics to blocks. Native diagnostics are kept out
+    // of this distribution so they are not stored in per-block cache.
     // We pass an empty set for global_keys because we already filtered them out from local_diagnostics.
     let new_blocks = distribute_diagnostics(current_blocks, &local_diagnostics, &HashSet::new());
 
     let mut final_diagnostics = local_diagnostics;
-    final_diagnostics.reserve(global_diagnostics.len());
+    final_diagnostics.reserve(native_diagnostics.len() + global_diagnostics.len());
+    final_diagnostics.extend(native_diagnostics);
     final_diagnostics.extend(global_diagnostics);
 
     final_diagnostics.sort_unstable();

--- a/crates/tsuzulint_core/src/lib.rs
+++ b/crates/tsuzulint_core/src/lib.rs
@@ -35,6 +35,7 @@ pub mod formatters;
 mod ignore_range;
 mod linter;
 mod manifest_resolver;
+pub mod native_rules;
 mod parallel_linter;
 pub mod pool;
 pub mod resolver;

--- a/crates/tsuzulint_core/src/linter.rs
+++ b/crates/tsuzulint_core/src/linter.rs
@@ -12,7 +12,7 @@
 //! - [`manifest_resolver`]: Secure manifest path resolution
 //! - [`parallel_linter`]: Parallel file linting logic
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tracing::warn;
@@ -109,6 +109,10 @@ impl Linter {
 
         let enabled_rules_vec = self.config.enabled_rules();
         let enabled_rules: HashSet<&str> = enabled_rules_vec.iter().map(|(n, _)| *n).collect();
+        let rule_options: HashMap<String, serde_json::Value> = enabled_rules_vec
+            .iter()
+            .map(|(name, opt)| ((*name).to_string(), opt.options()))
+            .collect();
         let rule_versions = crate::rule_loader::get_rule_versions_from_host(&host);
 
         let mut ctx = crate::file_linter::LintContext {
@@ -120,6 +124,7 @@ impl Linter {
             enabled_rules: &enabled_rules,
             rule_versions: &rule_versions,
             timings_enabled: self.config.timings,
+            rule_options: &rule_options,
         };
 
         lint_file_internal(&mut ctx)

--- a/crates/tsuzulint_core/src/native_rules/context.rs
+++ b/crates/tsuzulint_core/src/native_rules/context.rs
@@ -1,0 +1,28 @@
+//! Per-invocation context handed to every native rule.
+
+use serde_json::Value;
+use std::path::Path;
+use tsuzulint_ast::TxtNode;
+use tsuzulint_text::{Sentence, Token};
+
+/// Everything a native rule needs to produce diagnostics for a single file.
+///
+/// The lifetime `'a` ties the borrows to the file-linting session, so the
+/// rule can return diagnostics that reference substrings of `source` or
+/// spans into `ast` without cloning.
+pub struct RuleContext<'a> {
+    /// Parsed AST root (`Document` node).
+    pub ast: &'a TxtNode<'a>,
+    /// Original source text, indexable by byte spans from the AST.
+    pub source: &'a str,
+    /// Morphological tokens. Empty unless some rule declared
+    /// `needs_morphology()`.
+    pub tokens: &'a [Token],
+    /// Pre-split sentences. Empty unless some rule declared `needs_sentences()`.
+    pub sentences: &'a [Sentence],
+    /// The rule's configured options (raw JSON). Defaults to `Value::Null`
+    /// when the config leaves the rule at its defaults.
+    pub options: &'a Value,
+    /// Absolute path of the file being linted, when known.
+    pub file_path: Option<&'a Path>,
+}

--- a/crates/tsuzulint_core/src/native_rules/mod.rs
+++ b/crates/tsuzulint_core/src/native_rules/mod.rs
@@ -1,0 +1,31 @@
+//! Native (built-in) rule engine.
+//!
+//! Native rules run as Rust code compiled into the linter binary, without
+//! going through the WASM plugin boundary. This is the fastest execution path
+//! and is the home of rules that are (a) broadly useful, (b) expressible with
+//! the standard library + `tsuzulint_text`, and (c) stable enough that shipping
+//! them in the binary is reasonable.
+//!
+//! WASM plugins remain the right fit for user-specific rules, experimental
+//! rules, or rules that depend on user-provided dictionaries.
+//!
+//! # Architecture
+//!
+//! - [`Rule`] — the trait every native rule implements.
+//! - [`RuleContext`] — carries the parsed AST, source text, morphological
+//!   tokens, sentences, and the per-rule options into the rule.
+//! - [`BuiltinRegistry`] — a process-global registry of all built-in rules,
+//!   looked up by name.
+//!
+//! The linter pipeline consults [`BuiltinRegistry::get`] for each name listed
+//! in `LinterConfig.builtin_rules`, then invokes the rule with a `RuleContext`
+//! assembled from the current file's AST.
+
+mod context;
+mod registry;
+mod rule_trait;
+mod rules;
+
+pub use context::RuleContext;
+pub use registry::{BuiltinRegistry, builtin_registry};
+pub use rule_trait::Rule;

--- a/crates/tsuzulint_core/src/native_rules/registry.rs
+++ b/crates/tsuzulint_core/src/native_rules/registry.rs
@@ -1,0 +1,65 @@
+//! Process-global registry of native rules.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use super::rule_trait::Rule;
+use super::rules;
+
+/// A registry of built-in, natively compiled rules keyed by name.
+///
+/// The registry is immutable after construction and holds `&'static` rule
+/// instances, so lookups are cheap and safe to share across threads.
+pub struct BuiltinRegistry {
+    rules: HashMap<&'static str, &'static dyn Rule>,
+}
+
+impl BuiltinRegistry {
+    /// Retrieve a rule by name, or `None` if unknown.
+    pub fn get(&self, name: &str) -> Option<&'static dyn Rule> {
+        self.rules.get(name).copied()
+    }
+
+    /// Names of all registered rules (useful for diagnostics / `tzlint list`).
+    pub fn names(&self) -> impl Iterator<Item = &&'static str> {
+        self.rules.keys()
+    }
+
+    /// Build the registry with all rules that ship in this binary.
+    ///
+    /// Adding a new built-in rule is a two-step change:
+    /// 1. Create the rule in `native_rules::rules::...`
+    /// 2. Register it here
+    fn load() -> Self {
+        let mut rules: HashMap<&'static str, &'static dyn Rule> = HashMap::new();
+        for &rule in rules::all() {
+            rules.insert(rule.name(), rule);
+        }
+        Self { rules }
+    }
+}
+
+/// Returns a reference to the process-global built-in registry.
+pub fn builtin_registry() -> &'static BuiltinRegistry {
+    static REGISTRY: OnceLock<BuiltinRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(BuiltinRegistry::load)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_contains_no_todo() {
+        let registry = builtin_registry();
+        let rule = registry
+            .get("no-todo")
+            .expect("no-todo should be registered");
+        assert_eq!(rule.name(), "no-todo");
+    }
+
+    #[test]
+    fn registry_returns_none_for_unknown() {
+        assert!(builtin_registry().get("made-up-rule").is_none());
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rule_trait.rs
+++ b/crates/tsuzulint_core/src/native_rules/rule_trait.rs
@@ -1,0 +1,47 @@
+//! The `Rule` trait that every native rule implements.
+
+use tsuzulint_plugin::Diagnostic;
+
+use super::context::RuleContext;
+
+/// A rule that runs natively inside the linter binary.
+///
+/// Implementations should be cheap to construct (the registry holds one
+/// instance per rule for the process lifetime) and must be `Send + Sync`
+/// because the linter dispatches files across a rayon thread pool.
+///
+/// The `lint` method is expected to walk the AST it cares about and return
+/// diagnostics. Rules are responsible for their own descendant traversal —
+/// the linter hands over the whole document and lets the rule decide what
+/// nodes are interesting (this matches how ESLint / textlint rules work).
+pub trait Rule: Send + Sync {
+    /// Stable identifier used in configs and diagnostics (e.g. `"no-todo"`).
+    fn name(&self) -> &'static str;
+
+    /// Human-readable description used in docs and error messages.
+    fn description(&self) -> &'static str {
+        ""
+    }
+
+    /// Whether the rule can produce auto-fix suggestions.
+    fn fixable(&self) -> bool {
+        false
+    }
+
+    /// Whether the rule needs morphological tokens to run.
+    ///
+    /// The linter skips the tokenizer entirely when no enabled rule declares
+    /// it needs morphology, so flipping this from `false` to `true` has a
+    /// real cost on languages that require morphological analysis.
+    fn needs_morphology(&self) -> bool {
+        false
+    }
+
+    /// Whether the rule needs pre-split sentences.
+    fn needs_sentences(&self) -> bool {
+        false
+    }
+
+    /// Run the rule and return any diagnostics.
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic>;
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/ja_no_mixed_period.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/ja_no_mixed_period.rs
@@ -21,7 +21,7 @@ impl Rule for JaNoMixedPeriod {
     }
 
     fn description(&self) -> &'static str {
-        "Disallow mixing '。' and '.' as sentence terminators in the same document."
+        "同一ドキュメント内で句点「。」と「.」が混在することを禁止する。"
     }
 
     fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
@@ -52,8 +52,8 @@ impl Rule for JaNoMixedPeriod {
                 Diagnostic::new(
                     RULE_ID,
                     format!(
-                        "Mixed period style: this '{}' should be '{}' to match the document's dominant style.",
-                        minority_label, majority_label
+                        "句点の表記が混在しています。文書全体で多く使われている「{}」に合わせて「{}」を書き換えてください。",
+                        majority_label, minority_label
                     ),
                     Span::new(s as u32, e as u32),
                 )

--- a/crates/tsuzulint_core/src/native_rules/rules/ja_no_mixed_period.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/ja_no_mixed_period.rs
@@ -1,0 +1,170 @@
+//! Native port of `ja-no-mixed-period`.
+//!
+//! Flags documents that use both Japanese periods (`。`) and full-stops (`.`)
+//! as sentence terminators. The rule picks the dominant style (more frequent
+//! terminator) and reports occurrences of the other.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "ja-no-mixed-period";
+
+pub struct JaNoMixedPeriod;
+pub static RULE: JaNoMixedPeriod = JaNoMixedPeriod;
+
+impl Rule for JaNoMixedPeriod {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Disallow mixing '。' and '.' as sentence terminators in the same document."
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let _ = Value::Null;
+        let mut positions_period_ja: Vec<(usize, usize)> = Vec::new();
+        let mut positions_period_en: Vec<(usize, usize)> = Vec::new();
+        collect(
+            ctx.ast,
+            ctx.source,
+            &mut positions_period_ja,
+            &mut positions_period_en,
+        );
+        if positions_period_ja.is_empty() || positions_period_en.is_empty() {
+            return Vec::new();
+        }
+        // Report the less-frequent one as the "minority" style that should be
+        // normalized. When equal, we flag the English '.' (Japanese prose
+        // convention in the wild).
+        let (minority, minority_label, majority_label) =
+            if positions_period_ja.len() < positions_period_en.len() {
+                (positions_period_ja, "。", ".")
+            } else {
+                (positions_period_en, ".", "。")
+            };
+        minority
+            .into_iter()
+            .map(|(s, e)| {
+                Diagnostic::new(
+                    RULE_ID,
+                    format!(
+                        "Mixed period style: this '{}' should be '{}' to match the document's dominant style.",
+                        minority_label, majority_label
+                    ),
+                    Span::new(s as u32, e as u32),
+                )
+                .with_severity(Severity::Warning)
+            })
+            .collect()
+    }
+}
+
+fn collect(
+    node: &TxtNode<'_>,
+    source: &str,
+    ja_hits: &mut Vec<(usize, usize)>,
+    en_hits: &mut Vec<(usize, usize)>,
+) {
+    if matches!(node.node_type, NodeType::CodeBlock | NodeType::Code) {
+        return;
+    }
+    if node.node_type == NodeType::Str {
+        let start = node.span.start as usize;
+        let end = node.span.end as usize;
+        if end > source.len() || start > end {
+            return;
+        }
+        let text = &source[start..end];
+        let mut byte_pos = 0usize;
+        let mut prev_char: Option<char> = None;
+        let mut next_chars = text.chars().peekable();
+        while let Some(c) = next_chars.next() {
+            let char_len = c.len_utf8();
+            match c {
+                '。' => ja_hits.push((start + byte_pos, start + byte_pos + char_len)),
+                '.' => {
+                    // Only treat '.' as a sentence terminator when it is
+                    // followed by whitespace, end of text, or a newline — i.e.
+                    // not a decimal ("1.5") or abbreviation ("e.g.").
+                    let after = next_chars.peek().copied();
+                    let before = prev_char;
+                    let looks_like_sentence_end = match after {
+                        None => true,
+                        Some(next_c) => next_c.is_whitespace() || next_c == '\n',
+                    };
+                    let looks_numeric = before.is_some_and(|p| p.is_ascii_digit())
+                        && after.is_some_and(|a| a.is_ascii_digit());
+                    if looks_like_sentence_end && !looks_numeric {
+                        en_hits.push((start + byte_pos, start + byte_pos + char_len));
+                    }
+                }
+                _ => {}
+            }
+            byte_pos += char_len;
+            prev_char = Some(c);
+        }
+        return;
+    }
+    for child in node.children.iter() {
+        collect(child, source, ja_hits, en_hits);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn lint(text: &str) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let s = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, text.len() as u32),
+            text,
+        ));
+        let pc = arena.alloc_slice_copy(&[*s]);
+        let p = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, text.len() as u32),
+            pc,
+        ));
+        let dc = arena.alloc_slice_copy(&[*p]);
+        let ast = TxtNode::new_parent(NodeType::Document, AstSpan::new(0, text.len() as u32), dc);
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &Value::Null,
+            file_path: None,
+        };
+        JaNoMixedPeriod.lint(&ctx)
+    }
+
+    #[test]
+    fn passes_when_only_ja() {
+        assert!(lint("これは文です。そしてもう一つ。").is_empty());
+    }
+
+    #[test]
+    fn passes_when_only_en() {
+        assert!(lint("This is a sentence. And another.").is_empty());
+    }
+
+    #[test]
+    fn flags_minority_en_period() {
+        let diags = lint("これは文です。もう一つ。最後の一つだ.");
+        assert_eq!(diags.len(), 1, "{:?}", diags);
+    }
+
+    #[test]
+    fn ignores_decimals() {
+        // "1.5" must not be treated as a sentence-terminating period.
+        let diags = lint("これは文です。値は1.5です。");
+        assert!(diags.is_empty());
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/max_kanji_continuous_len.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/max_kanji_continuous_len.rs
@@ -1,0 +1,172 @@
+//! Native port of `max-kanji-continuous-len`.
+//!
+//! Flags runs of consecutive kanji characters longer than the configured
+//! max length. Long kanji strings hurt readability; inserting ひらがな or
+//! 送り仮名 breaks them up.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "max-kanji-continuous-len";
+const DEFAULT_MAX: usize = 5;
+
+fn is_kanji(c: char) -> bool {
+    // CJK Unified Ideographs + Extension A
+    let cp = c as u32;
+    (0x3400..=0x4DBF).contains(&cp) || (0x4E00..=0x9FFF).contains(&cp)
+}
+
+struct Config {
+    max: usize,
+}
+
+impl Config {
+    fn from_options(options: &Value) -> Self {
+        let mut cfg = Self { max: DEFAULT_MAX };
+        if let Value::Object(map) = options
+            && let Some(Value::Number(n)) = map.get("max")
+            && let Some(v) = n.as_u64()
+        {
+            cfg.max = v as usize;
+        }
+        cfg
+    }
+}
+
+pub struct MaxKanjiContinuousLen;
+pub static RULE: MaxKanjiContinuousLen = MaxKanjiContinuousLen;
+
+impl Rule for MaxKanjiContinuousLen {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Flag continuous kanji runs longer than the configured maximum."
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let config = Config::from_options(ctx.options);
+        let mut out = Vec::new();
+        scan(ctx.ast, ctx.source, &config, &mut out);
+        out
+    }
+}
+
+fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnostic>) {
+    if matches!(node.node_type, NodeType::CodeBlock | NodeType::Code) {
+        return;
+    }
+    if node.node_type == NodeType::Str {
+        let start = node.span.start as usize;
+        let end = node.span.end as usize;
+        if end > source.len() || start > end {
+            return;
+        }
+        let text = &source[start..end];
+        let mut byte_pos = 0usize;
+        let mut run_start: Option<usize> = None;
+        let mut run_char_count = 0usize;
+        for c in text.chars() {
+            let char_len = c.len_utf8();
+            if is_kanji(c) {
+                if run_start.is_none() {
+                    run_start = Some(byte_pos);
+                    run_char_count = 1;
+                } else {
+                    run_char_count += 1;
+                }
+            } else if let Some(rs) = run_start.take() {
+                if run_char_count > config.max {
+                    out.push(
+                        Diagnostic::new(
+                            RULE_ID,
+                            format!(
+                                "Kanji run of length {} exceeds the maximum of {}.",
+                                run_char_count, config.max
+                            ),
+                            Span::new((start + rs) as u32, (start + byte_pos) as u32),
+                        )
+                        .with_severity(Severity::Warning),
+                    );
+                }
+                run_char_count = 0;
+            }
+            byte_pos += char_len;
+        }
+        if let Some(rs) = run_start
+            && run_char_count > config.max
+        {
+            out.push(
+                Diagnostic::new(
+                    RULE_ID,
+                    format!(
+                        "Kanji run of length {} exceeds the maximum of {}.",
+                        run_char_count, config.max
+                    ),
+                    Span::new((start + rs) as u32, (start + byte_pos) as u32),
+                )
+                .with_severity(Severity::Warning),
+            );
+        }
+        return;
+    }
+    for child in node.children.iter() {
+        scan(child, source, config, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn lint(text: &str, max: usize) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let s = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, text.len() as u32),
+            text,
+        ));
+        let pc = arena.alloc_slice_copy(&[*s]);
+        let p = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, text.len() as u32),
+            pc,
+        ));
+        let dc = arena.alloc_slice_copy(&[*p]);
+        let ast = TxtNode::new_parent(NodeType::Document, AstSpan::new(0, text.len() as u32), dc);
+        let options = serde_json::json!({ "max": max });
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &options,
+            file_path: None,
+        };
+        MaxKanjiContinuousLen.lint(&ctx)
+    }
+
+    #[test]
+    fn short_run_passes() {
+        assert!(lint("本日は晴天", 5).is_empty());
+    }
+
+    #[test]
+    fn long_run_flagged() {
+        // 8 consecutive kanji, max 5 → flagged
+        let diags = lint("一二三四五六七八する", 5);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn hiragana_breaks_run() {
+        // two short runs, neither over the limit
+        let diags = lint("一二三の四五六", 5);
+        assert!(diags.is_empty());
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/max_kanji_continuous_len.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/max_kanji_continuous_len.rs
@@ -45,7 +45,7 @@ impl Rule for MaxKanjiContinuousLen {
     }
 
     fn description(&self) -> &'static str {
-        "Flag continuous kanji runs longer than the configured maximum."
+        "指定した長さを超える漢字の連続を検出する。"
     }
 
     fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
@@ -104,7 +104,7 @@ fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnos
                 Diagnostic::new(
                     RULE_ID,
                     format!(
-                        "Kanji run of length {} exceeds the maximum of {}.",
+                        "漢字が {} 字連続しています。上限は {} 字です。",
                         run_char_count, config.max
                     ),
                     Span::new((start + rs) as u32, (start + byte_pos) as u32),
@@ -158,9 +158,16 @@ mod tests {
 
     #[test]
     fn long_run_flagged() {
-        // 8 consecutive kanji, max 5 → flagged
-        let diags = lint("一二三四五六七八する", 5);
+        // 7 consecutive kanji, max 6 → flagged at the tight boundary
+        // (`max: 6` matches the ja-technical-writing preset default).
+        let diags = lint("一二三四五六七する", 6);
         assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn run_at_max_passes() {
+        // 6 kanji with max 6: equal to the limit, should pass.
+        assert!(lint("一二三四五六する", 6).is_empty());
     }
 
     #[test]

--- a/crates/tsuzulint_core/src/native_rules/rules/max_ten.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/max_ten.rs
@@ -1,0 +1,204 @@
+//! Native port of `max-ten`.
+//!
+//! Reports sentences that contain more commas (読点、、) than the
+//! configured maximum. Matches the public textlint-rule-max-ten defaults.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "max-ten";
+const DEFAULT_MAX: usize = 3;
+const DEFAULT_TOUTEN: char = '、';
+const DEFAULT_KUTEN: char = '。';
+
+struct Config {
+    max: usize,
+    touten: char,
+    kuten: char,
+}
+
+impl Config {
+    fn from_options(options: &Value) -> Self {
+        let mut cfg = Self {
+            max: DEFAULT_MAX,
+            touten: DEFAULT_TOUTEN,
+            kuten: DEFAULT_KUTEN,
+        };
+        let Value::Object(map) = options else {
+            return cfg;
+        };
+        if let Some(Value::Number(n)) = map.get("max")
+            && let Some(max) = n.as_u64()
+        {
+            cfg.max = max as usize;
+        }
+        if let Some(Value::String(s)) = map.get("touten")
+            && let Some(c) = s.chars().next()
+        {
+            cfg.touten = c;
+        }
+        if let Some(Value::String(s)) = map.get("kuten")
+            && let Some(c) = s.chars().next()
+        {
+            cfg.kuten = c;
+        }
+        cfg
+    }
+}
+
+pub struct MaxTen;
+
+pub static RULE: MaxTen = MaxTen;
+
+impl Rule for MaxTen {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Limit the number of Japanese commas (読点) per sentence."
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let config = Config::from_options(ctx.options);
+        let mut out = Vec::new();
+        scan(ctx.ast, ctx.source, &config, &mut out);
+        out
+    }
+}
+
+fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnostic>) {
+    match node.node_type {
+        NodeType::CodeBlock | NodeType::Code | NodeType::Html => {}
+        NodeType::Paragraph
+        | NodeType::Header
+        | NodeType::ListItem
+        | NodeType::TableCell
+        | NodeType::BlockQuote => {
+            check_block(node, source, config, out);
+            for child in node.children.iter() {
+                scan(child, source, config, out);
+            }
+        }
+        _ => {
+            for child in node.children.iter() {
+                scan(child, source, config, out);
+            }
+        }
+    }
+}
+
+fn check_block(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnostic>) {
+    let start = node.span.start as usize;
+    let end = node.span.end as usize;
+    if end > source.len() || start > end {
+        return;
+    }
+    let text = &source[start..end];
+
+    let mut sentence_start = 0usize;
+    let mut ten_count = 0usize;
+    let mut byte_pos = 0usize;
+    for c in text.chars() {
+        let char_len = c.len_utf8();
+        if c == config.touten {
+            ten_count += 1;
+        } else if c == config.kuten {
+            if ten_count > config.max {
+                let abs_start = start + sentence_start;
+                let abs_end = start + byte_pos + char_len;
+                out.push(
+                    Diagnostic::new(
+                        RULE_ID,
+                        format!(
+                            "Sentence contains {} '{}' marks (limit is {}).",
+                            ten_count, config.touten, config.max
+                        ),
+                        Span::new(abs_start as u32, abs_end as u32),
+                    )
+                    .with_severity(Severity::Warning),
+                );
+            }
+            ten_count = 0;
+            sentence_start = byte_pos + char_len;
+        }
+        byte_pos += char_len;
+    }
+    // Trailing sentence without a kuten: still check it.
+    if ten_count > config.max && sentence_start < byte_pos {
+        let abs_start = start + sentence_start;
+        let abs_end = start + byte_pos;
+        out.push(
+            Diagnostic::new(
+                RULE_ID,
+                format!(
+                    "Sentence contains {} '{}' marks (limit is {}).",
+                    ten_count, config.touten, config.max
+                ),
+                Span::new(abs_start as u32, abs_end as u32),
+            )
+            .with_severity(Severity::Warning),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn run(text: &str, max: usize) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let s = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, text.len() as u32),
+            text,
+        ));
+        let pc = arena.alloc_slice_copy(&[*s]);
+        let p = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, text.len() as u32),
+            pc,
+        ));
+        let dc = arena.alloc_slice_copy(&[*p]);
+        let ast = TxtNode::new_parent(NodeType::Document, AstSpan::new(0, text.len() as u32), dc);
+        let options = serde_json::json!({ "max": max });
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &options,
+            file_path: None,
+        };
+        MaxTen.lint(&ctx)
+    }
+
+    #[test]
+    fn allows_up_to_max() {
+        let diags = run("あ、い、う、え。", 3);
+        assert!(diags.is_empty(), "{:?}", diags);
+    }
+
+    #[test]
+    fn flags_too_many_commas() {
+        let diags = run("あ、い、う、え、お。", 3);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn per_sentence_reset() {
+        // Each sentence independently under the limit
+        let diags = run("あ、い、う。か、き、く。", 3);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn flags_trailing_sentence_without_kuten() {
+        let diags = run("あ、い、う、え、お", 3);
+        assert_eq!(diags.len(), 1);
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/max_ten.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/max_ten.rs
@@ -73,15 +73,11 @@ impl Rule for MaxTen {
 fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnostic>) {
     match node.node_type {
         NodeType::CodeBlock | NodeType::Code | NodeType::Html => {}
-        NodeType::Paragraph
-        | NodeType::Header
-        | NodeType::ListItem
-        | NodeType::TableCell
-        | NodeType::BlockQuote => {
+        // Run the comma-count check only on *leaf* blocks. Container blocks
+        // like ListItem or BlockQuote wrap paragraphs, so checking them in
+        // addition to their children would count the same commas twice.
+        NodeType::Paragraph | NodeType::Header | NodeType::TableCell => {
             check_block(node, source, config, out);
-            for child in node.children.iter() {
-                scan(child, source, config, out);
-            }
         }
         _ => {
             for child in node.children.iter() {
@@ -200,5 +196,47 @@ mod tests {
     fn flags_trailing_sentence_without_kuten() {
         let diags = run("あ、い、う、え、お", 3);
         assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn nested_list_item_paragraph_is_not_double_counted() {
+        // Regression: ListItem wrapping a Paragraph would previously be
+        // scanned at both levels, double-counting commas.
+        let arena = AstArena::new();
+        let text = "あ、い、う、え、お。";
+        let str_node = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, text.len() as u32),
+            text,
+        ));
+        let paragraph_children = arena.alloc_slice_copy(&[*str_node]);
+        let paragraph = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, text.len() as u32),
+            paragraph_children,
+        ));
+        let list_item_children = arena.alloc_slice_copy(&[*paragraph]);
+        let list_item = arena.alloc(TxtNode::new_parent(
+            NodeType::ListItem,
+            AstSpan::new(0, text.len() as u32),
+            list_item_children,
+        ));
+        let doc_children = arena.alloc_slice_copy(&[*list_item]);
+        let ast = TxtNode::new_parent(
+            NodeType::Document,
+            AstSpan::new(0, text.len() as u32),
+            doc_children,
+        );
+        let options = serde_json::json!({ "max": 3 });
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &options,
+            file_path: None,
+        };
+        let diags = MaxTen.lint(&ctx);
+        assert_eq!(diags.len(), 1, "{:?}", diags);
     }
 }

--- a/crates/tsuzulint_core/src/native_rules/rules/max_ten.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/max_ten.rs
@@ -59,7 +59,7 @@ impl Rule for MaxTen {
     }
 
     fn description(&self) -> &'static str {
-        "Limit the number of Japanese commas (読点) per sentence."
+        "一文に含まれる読点 (「、」) の数を制限する。"
     }
 
     fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
@@ -114,8 +114,8 @@ fn check_block(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<
                     Diagnostic::new(
                         RULE_ID,
                         format!(
-                            "Sentence contains {} '{}' marks (limit is {}).",
-                            ten_count, config.touten, config.max
+                            "一文に「{}」が {} 個あります。上限は {} 個です。",
+                            config.touten, ten_count, config.max
                         ),
                         Span::new(abs_start as u32, abs_end as u32),
                     )

--- a/crates/tsuzulint_core/src/native_rules/rules/mod.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/mod.rs
@@ -1,0 +1,37 @@
+//! Concrete native rule implementations.
+//!
+//! Every rule exposes a `pub static` singleton that the registry can wire up.
+
+pub mod ja_no_mixed_period;
+pub mod max_kanji_continuous_len;
+pub mod max_ten;
+pub mod no_doubled_joshi;
+pub mod no_exclamation_question_mark;
+pub mod no_hankaku_kana;
+pub mod no_mixed_zenkaku_hankaku_alphabet;
+pub mod no_nfd;
+pub mod no_todo;
+pub mod no_zero_width_spaces;
+pub mod sentence_length;
+
+use super::rule_trait::Rule;
+
+/// All rules that the binary knows about at link time.
+///
+/// Ordering is irrelevant — the registry keys by name.
+pub fn all() -> &'static [&'static dyn Rule] {
+    static ALL: &[&'static dyn Rule] = &[
+        &ja_no_mixed_period::RULE,
+        &max_kanji_continuous_len::RULE,
+        &max_ten::RULE,
+        &no_doubled_joshi::RULE,
+        &no_exclamation_question_mark::RULE,
+        &no_hankaku_kana::RULE,
+        &no_mixed_zenkaku_hankaku_alphabet::RULE,
+        &no_nfd::RULE,
+        &no_todo::RULE,
+        &no_zero_width_spaces::RULE,
+        &sentence_length::RULE,
+    ];
+    ALL
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/no_doubled_joshi.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_doubled_joshi.rs
@@ -375,4 +375,59 @@ mod tests {
         let particles = extract_particles(&tokens, &config);
         assert!(particles.is_empty());
     }
+
+    #[test]
+    fn interval_below_min_is_flagged() {
+        // Two は with 0 commas between them. Default min_interval=1 flags this.
+        let source = "私は彼は好きだ";
+        let tokens = vec![
+            make_token("私", vec!["名詞"], 0, 3),
+            make_token("は", vec!["助詞", "係助詞"], 3, 6),
+            make_token("彼", vec!["名詞"], 6, 9),
+            make_token("は", vec!["助詞", "係助詞"], 9, 12),
+            make_token("好き", vec!["名詞"], 12, 18),
+        ];
+        let config = Config::from_options(&Value::Null);
+        let particles = extract_particles(&tokens, &config);
+        let diags = detect_doubles(&particles, source, &config);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn interval_at_min_passes() {
+        // Two は with one 、 between them. interval=1 == min_interval=1 passes.
+        let source = "私は、彼は好きだ";
+        let tokens = vec![
+            make_token("私", vec!["名詞"], 0, 3),
+            make_token("は", vec!["助詞", "係助詞"], 3, 6),
+            make_token("、", vec!["記号", "読点"], 6, 9),
+            make_token("彼", vec!["名詞"], 9, 12),
+            make_token("は", vec!["助詞", "係助詞"], 12, 15),
+            make_token("好き", vec!["名詞"], 15, 21),
+        ];
+        let config = Config::from_options(&Value::Null);
+        let particles = extract_particles(&tokens, &config);
+        let diags = detect_doubles(&particles, source, &config);
+        assert!(diags.is_empty(), "{:?}", diags);
+    }
+
+    #[test]
+    fn interval_one_below_custom_min_is_flagged() {
+        // min_interval=2, but text has one 、 between the は particles.
+        // interval=1 < min_interval=2 → flagged at the boundary.
+        let source = "私は、彼は好きだ";
+        let tokens = vec![
+            make_token("私", vec!["名詞"], 0, 3),
+            make_token("は", vec!["助詞", "係助詞"], 3, 6),
+            make_token("、", vec!["記号", "読点"], 6, 9),
+            make_token("彼", vec!["名詞"], 9, 12),
+            make_token("は", vec!["助詞", "係助詞"], 12, 15),
+            make_token("好き", vec!["名詞"], 15, 21),
+        ];
+        let options = serde_json::json!({ "min_interval": 2 });
+        let config = Config::from_options(&options);
+        let particles = extract_particles(&tokens, &config);
+        let diags = detect_doubles(&particles, source, &config);
+        assert_eq!(diags.len(), 1);
+    }
 }

--- a/crates/tsuzulint_core/src/native_rules/rules/no_doubled_joshi.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_doubled_joshi.rs
@@ -1,0 +1,378 @@
+//! Native port of `no-doubled-joshi`.
+//!
+//! Flags repeated Japanese particles (助詞) inside a single sentence. Mirrors
+//! the semantics of `textlint-rule-no-doubled-joshi` and the existing WASM
+//! `rules/no-doubled-joshi` plugin. Needs morphological tokens, which the
+//! linter populates because the rule declares `needs_morphology()`.
+
+use serde_json::Value;
+use std::collections::HashMap;
+use tsuzulint_ast::Span;
+use tsuzulint_plugin::{Diagnostic, Severity};
+use tsuzulint_text::Token;
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "no-doubled-joshi";
+const DEFAULT_SEPARATORS: &[char] = &['.', '．', '。', '?', '!', '？', '！'];
+const DEFAULT_COMMAS: &[char] = &['、', '，'];
+
+struct Config {
+    min_interval: usize,
+    strict: bool,
+    allow: Vec<String>,
+    separators: Vec<char>,
+    commas: Vec<char>,
+}
+
+impl Config {
+    fn from_options(options: &Value) -> Self {
+        let mut cfg = Self {
+            min_interval: 1,
+            strict: false,
+            allow: Vec::new(),
+            separators: DEFAULT_SEPARATORS.to_vec(),
+            commas: DEFAULT_COMMAS.to_vec(),
+        };
+        let Value::Object(map) = options else {
+            return cfg;
+        };
+        if let Some(Value::Number(n)) = map.get("min_interval")
+            && let Some(v) = n.as_u64()
+        {
+            cfg.min_interval = v as usize;
+        }
+        if let Some(Value::Bool(b)) = map.get("strict") {
+            cfg.strict = *b;
+        }
+        if let Some(Value::Array(arr)) = map.get("allow") {
+            cfg.allow = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+        }
+        if let Some(Value::Array(arr)) = map.get("separator_characters") {
+            cfg.separators = arr
+                .iter()
+                .filter_map(|v| v.as_str().and_then(|s| s.chars().next()))
+                .collect();
+        }
+        if let Some(Value::Array(arr)) = map.get("comma_characters") {
+            cfg.commas = arr
+                .iter()
+                .filter_map(|v| v.as_str().and_then(|s| s.chars().next()))
+                .collect();
+        }
+        cfg
+    }
+}
+
+pub struct NoDoubledJoshi;
+pub static RULE: NoDoubledJoshi = NoDoubledJoshi;
+
+impl Rule for NoDoubledJoshi {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Detect the same Japanese particle repeating within a single sentence."
+    }
+
+    fn needs_morphology(&self) -> bool {
+        true
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let config = Config::from_options(ctx.options);
+        let tokens = ctx.tokens;
+        if tokens.is_empty() {
+            // Linter didn't provide tokens (e.g. tokenizer disabled for non-JP);
+            // nothing for us to do.
+            return Vec::new();
+        }
+        let particles = extract_particles(tokens, &config);
+        let particles = concat_adjacent(particles);
+        detect_doubles(&particles, ctx.source, &config)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Particle {
+    surface: String,
+    key: String,
+    byte_start: usize,
+    byte_end: usize,
+    /// Reserved for future pair-level heuristics (e.g. recovering the exact
+    /// tokens surrounding a possible match). Not used today, but removing it
+    /// would complicate re-adding such heuristics.
+    #[allow(dead_code)]
+    token_index: usize,
+    subtype: Option<String>,
+    prev_word: String,
+}
+
+fn is_particle(tok: &Token) -> bool {
+    tok.pos.first().map(String::as_str) == Some("助詞")
+}
+
+fn particle_subtype(tok: &Token) -> Option<String> {
+    tok.pos.get(1).cloned()
+}
+
+/// `の`(連体化), `を`(格助詞), `て`(接続助詞) are commonly doubled in clean
+/// prose — textlint's no-doubled-joshi exempts them unless `strict` is set.
+fn is_exception_particle(tok: &Token) -> bool {
+    let subtype = particle_subtype(tok);
+    matches!(
+        (tok.surface.as_str(), subtype.as_deref()),
+        ("の", Some("連体化")) | ("を", Some("格助詞")) | ("て", Some("接続助詞"))
+    )
+}
+
+fn particle_key(tok: &Token) -> String {
+    let pos1 = tok.pos.first().cloned().unwrap_or_default();
+    match particle_subtype(tok) {
+        Some(sub) if !sub.is_empty() => format!("{}:{}.{}", tok.surface, pos1, sub),
+        _ => format!("{}:{}", tok.surface, pos1),
+    }
+}
+
+fn extract_particles(tokens: &[Token], config: &Config) -> Vec<Particle> {
+    let mut out = Vec::new();
+    for (idx, tok) in tokens.iter().enumerate() {
+        if !is_particle(tok) {
+            continue;
+        }
+        if config.allow.contains(&tok.surface) {
+            continue;
+        }
+        if !config.strict && is_exception_particle(tok) {
+            continue;
+        }
+        let prev_word = if idx == 0 {
+            String::new()
+        } else {
+            tokens[idx - 1].surface.clone()
+        };
+        out.push(Particle {
+            surface: tok.surface.clone(),
+            key: particle_key(tok),
+            byte_start: tok.span.start,
+            byte_end: tok.span.end,
+            token_index: idx,
+            subtype: particle_subtype(tok),
+            prev_word,
+        });
+    }
+    out
+}
+
+/// Merge adjacent particles into a compound (連語) so "に" + "は" becomes
+/// "には" and is compared against other "には" occurrences.
+fn concat_adjacent(particles: Vec<Particle>) -> Vec<Particle> {
+    let mut out: Vec<Particle> = Vec::with_capacity(particles.len());
+    for p in particles {
+        if let Some(curr) = out.last_mut()
+            && p.byte_start == curr.byte_end
+        {
+            curr.surface.push_str(&p.surface);
+            curr.key = format!("{}:連語", curr.surface);
+            curr.byte_end = p.byte_end;
+            curr.subtype = Some("連語".to_string());
+            continue;
+        }
+        out.push(p);
+    }
+    out
+}
+
+fn calculate_interval(prev: &Particle, curr: &Particle, source: &str, config: &Config) -> usize {
+    if curr.byte_start <= prev.byte_end {
+        return 0;
+    }
+    let between = &source[prev.byte_end..curr.byte_start];
+    let mut interval = 0usize;
+    for c in between.chars() {
+        if config.separators.contains(&c) {
+            return usize::MAX;
+        }
+        if config.commas.contains(&c) {
+            interval += 1;
+        }
+        if matches!(c, '(' | ')' | '（' | '）' | '「' | '」') {
+            interval += 1;
+        }
+    }
+    interval
+}
+
+fn is_ka_douka_pair(p1: &Particle, p2: &Particle, tokens_between: &str) -> bool {
+    p1.surface == "か" && p2.surface == "か" && tokens_between.contains("どう")
+}
+
+fn detect_doubles(particles: &[Particle], source: &str, config: &Config) -> Vec<Diagnostic> {
+    let mut out = Vec::new();
+    let mut by_key: HashMap<&str, Vec<&Particle>> = HashMap::new();
+    for p in particles {
+        by_key.entry(p.key.as_str()).or_default().push(p);
+    }
+    for (_key, matches) in by_key {
+        if matches.len() < 2 {
+            continue;
+        }
+        if !config.strict
+            && matches
+                .iter()
+                .all(|p| p.subtype.as_deref() == Some("並立助詞"))
+        {
+            continue;
+        }
+        for i in 1..matches.len() {
+            let prev = matches[i - 1];
+            let curr = matches[i];
+            let between = &source[prev.byte_end..curr.byte_start];
+            if !config.strict && is_ka_douka_pair(prev, curr, between) {
+                continue;
+            }
+            let interval = calculate_interval(prev, curr, source, config);
+            if interval < config.min_interval {
+                let message = build_message(&curr.surface, prev, curr);
+                out.push(
+                    Diagnostic::new(
+                        RULE_ID,
+                        message,
+                        Span::new(curr.byte_start as u32, curr.byte_end as u32),
+                    )
+                    .with_severity(Severity::Warning),
+                );
+            }
+        }
+    }
+    // Stable order: deterministic diagnostic output.
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+fn build_message(name: &str, prev: &Particle, curr: &Particle) -> String {
+    let mut msg = format!(
+        "一文に二回以上利用されている助詞 \"{}\" がみつかりました。\n\n文中の助詞が連続しているため、読みにくくなります。\n\n",
+        name
+    );
+    for p in [prev, curr] {
+        if p.prev_word.is_empty() {
+            msg.push_str(&format!("- \"{}\"\n", p.surface));
+        } else {
+            msg.push_str(&format!("- {}\"{}\"\n", p.prev_word, p.surface));
+        }
+    }
+    let _ = curr;
+    msg.push_str(
+        "\n同じ助詞を連続して利用しない、文の中で順番を入れ替える、文を分割するなどを検討してください。\n",
+    );
+    msg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_token(surface: &str, pos: Vec<&str>, start: usize, end: usize) -> Token {
+        Token {
+            surface: surface.to_string(),
+            pos: pos.iter().map(|s| s.to_string()).collect(),
+            detail: Vec::new(),
+            span: start..end,
+        }
+    }
+
+    #[test]
+    fn flags_doubled_ha() {
+        let source = "私は彼は好きだ";
+        let tokens = vec![
+            make_token("私", vec!["名詞"], 0, 3),
+            make_token("は", vec!["助詞", "係助詞"], 3, 6),
+            make_token("彼", vec!["名詞"], 6, 9),
+            make_token("は", vec!["助詞", "係助詞"], 9, 12),
+            make_token("好き", vec!["名詞"], 12, 18),
+        ];
+        let config = Config::from_options(&Value::Null);
+        let particles = extract_particles(&tokens, &config);
+        let diags = detect_doubles(&particles, source, &config);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("\"は\""));
+    }
+
+    #[test]
+    fn skips_no_exception() {
+        let tokens = vec![
+            make_token("既存", vec!["名詞"], 0, 6),
+            make_token("の", vec!["助詞", "連体化"], 6, 9),
+            make_token("コード", vec!["名詞"], 9, 15),
+            make_token("の", vec!["助詞", "連体化"], 15, 18),
+            make_token("利用", vec!["名詞"], 18, 24),
+        ];
+        let config = Config::from_options(&Value::Null);
+        let particles = extract_particles(&tokens, &config);
+        assert!(particles.is_empty(), "の(連体化) should be exempt");
+    }
+
+    #[test]
+    fn strict_mode_catches_no() {
+        let source = "既存のコードの利用";
+        let tokens = vec![
+            make_token("既存", vec!["名詞"], 0, 6),
+            make_token("の", vec!["助詞", "連体化"], 6, 9),
+            make_token("コード", vec!["名詞"], 9, 15),
+            make_token("の", vec!["助詞", "連体化"], 15, 18),
+            make_token("利用", vec!["名詞"], 18, 24),
+        ];
+        let options = serde_json::json!({ "strict": true });
+        let config = Config::from_options(&options);
+        let particles = extract_particles(&tokens, &config);
+        let diags = detect_doubles(&particles, source, &config);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn concat_ni_ha() {
+        let particles = vec![
+            Particle {
+                surface: "に".into(),
+                key: "に:助詞.格助詞".into(),
+                byte_start: 0,
+                byte_end: 3,
+                token_index: 0,
+                subtype: Some("格助詞".into()),
+                prev_word: "".into(),
+            },
+            Particle {
+                surface: "は".into(),
+                key: "は:助詞.係助詞".into(),
+                byte_start: 3,
+                byte_end: 6,
+                token_index: 1,
+                subtype: Some("係助詞".into()),
+                prev_word: "".into(),
+            },
+        ];
+        let merged = concat_adjacent(particles);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].surface, "には");
+    }
+
+    #[test]
+    fn allow_suppresses() {
+        let tokens = vec![
+            make_token("太字", vec!["名詞"], 0, 6),
+            make_token("も", vec!["助詞", "係助詞"], 6, 9),
+            make_token("強調", vec!["名詞"], 9, 15),
+            make_token("も", vec!["助詞", "係助詞"], 15, 18),
+        ];
+        let options = serde_json::json!({ "allow": ["も"] });
+        let config = Config::from_options(&options);
+        let particles = extract_particles(&tokens, &config);
+        assert!(particles.is_empty());
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/no_exclamation_question_mark.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_exclamation_question_mark.rs
@@ -1,0 +1,164 @@
+//! Native port of `no-exclamation-question-mark`.
+//!
+//! Flags "!", "?", "！", "？" in prose. Technical writing style guides
+//! generally discourage exclamation / question marks; this rule makes that
+//! a lint error so reviewers don't have to catch it.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "no-exclamation-question-mark";
+
+struct Config {
+    allow_halfwidth_exclamation: bool,
+    allow_fullwidth_exclamation: bool,
+    allow_halfwidth_question: bool,
+    allow_fullwidth_question: bool,
+}
+
+impl Config {
+    fn from_options(options: &Value) -> Self {
+        let mut cfg = Self {
+            allow_halfwidth_exclamation: false,
+            allow_fullwidth_exclamation: false,
+            allow_halfwidth_question: false,
+            allow_fullwidth_question: false,
+        };
+        let Value::Object(map) = options else {
+            return cfg;
+        };
+        if let Some(Value::Bool(b)) = map.get("allow_halfwidth_exclamation") {
+            cfg.allow_halfwidth_exclamation = *b;
+        }
+        if let Some(Value::Bool(b)) = map.get("allow_fullwidth_exclamation") {
+            cfg.allow_fullwidth_exclamation = *b;
+        }
+        if let Some(Value::Bool(b)) = map.get("allow_halfwidth_question") {
+            cfg.allow_halfwidth_question = *b;
+        }
+        if let Some(Value::Bool(b)) = map.get("allow_fullwidth_question") {
+            cfg.allow_fullwidth_question = *b;
+        }
+        cfg
+    }
+}
+
+pub struct NoExclamationQuestionMark;
+
+pub static RULE: NoExclamationQuestionMark = NoExclamationQuestionMark;
+
+impl Rule for NoExclamationQuestionMark {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Disallow exclamation / question marks in technical prose."
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let config = Config::from_options(ctx.options);
+        let mut out = Vec::new();
+        scan(ctx.ast, ctx.source, &config, &mut out);
+        out
+    }
+}
+
+fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnostic>) {
+    if matches!(node.node_type, NodeType::CodeBlock | NodeType::Code) {
+        return;
+    }
+    if node.node_type == NodeType::Str {
+        let start = node.span.start as usize;
+        let end = node.span.end as usize;
+        if end > source.len() || start > end {
+            return;
+        }
+        let text = &source[start..end];
+        let mut byte_pos = 0usize;
+        for c in text.chars() {
+            let char_len = c.len_utf8();
+            let hit = match c {
+                '!' if !config.allow_halfwidth_exclamation => Some("!"),
+                '！' if !config.allow_fullwidth_exclamation => Some("！"),
+                '?' if !config.allow_halfwidth_question => Some("?"),
+                '？' if !config.allow_fullwidth_question => Some("？"),
+                _ => None,
+            };
+            if let Some(mark) = hit {
+                let abs_start = start + byte_pos;
+                let abs_end = abs_start + char_len;
+                out.push(
+                    Diagnostic::new(
+                        RULE_ID,
+                        format!("Disallowed punctuation: '{}'.", mark),
+                        Span::new(abs_start as u32, abs_end as u32),
+                    )
+                    .with_severity(Severity::Warning),
+                );
+            }
+            byte_pos += char_len;
+        }
+        return;
+    }
+    for child in node.children.iter() {
+        scan(child, source, config, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn run(text: &str) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let s = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, text.len() as u32),
+            text,
+        ));
+        let paragraph_children = arena.alloc_slice_copy(&[*s]);
+        let paragraph = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, text.len() as u32),
+            paragraph_children,
+        ));
+        let doc_children = arena.alloc_slice_copy(&[*paragraph]);
+        let ast = TxtNode::new_parent(
+            NodeType::Document,
+            AstSpan::new(0, text.len() as u32),
+            doc_children,
+        );
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &Value::Null,
+            file_path: None,
+        };
+        NoExclamationQuestionMark.lint(&ctx)
+    }
+
+    #[test]
+    fn detects_half_width_exclamation() {
+        let diags = run("hello!");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn detects_full_width_question() {
+        let diags = run("ですか？");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn clean_text_passes() {
+        let diags = run("これは普通の文です。");
+        assert!(diags.is_empty());
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/no_exclamation_question_mark.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_exclamation_question_mark.rs
@@ -56,7 +56,7 @@ impl Rule for NoExclamationQuestionMark {
     }
 
     fn description(&self) -> &'static str {
-        "Disallow exclamation / question marks in technical prose."
+        "技術文書における感嘆符・疑問符 (! ? ！ ？) の使用を禁止する。"
     }
 
     fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
@@ -94,7 +94,7 @@ fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnos
                 out.push(
                     Diagnostic::new(
                         RULE_ID,
-                        format!("Disallowed punctuation: '{}'.", mark),
+                        format!("「{}」は技術文書では使用を避けてください。", mark),
                         Span::new(abs_start as u32, abs_end as u32),
                     )
                     .with_severity(Severity::Warning),

--- a/crates/tsuzulint_core/src/native_rules/rules/no_hankaku_kana.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_hankaku_kana.rs
@@ -25,7 +25,7 @@ impl Rule for NoHankakuKana {
     }
 
     fn description(&self) -> &'static str {
-        "Disallow half-width katakana in prose."
+        "半角カタカナの使用を禁止する (全角カタカナを推奨)。"
     }
 
     fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
@@ -59,7 +59,7 @@ fn scan(node: &TxtNode<'_>, source: &str, out: &mut Vec<Diagnostic>) {
                 out.push(
                     Diagnostic::new(
                         RULE_ID,
-                        "Half-width katakana is discouraged; prefer full-width.",
+                        "半角カタカナは推奨されません。全角カタカナを使ってください。",
                         Span::new((start + rs) as u32, (start + byte_pos) as u32),
                     )
                     .with_severity(Severity::Warning),
@@ -71,7 +71,7 @@ fn scan(node: &TxtNode<'_>, source: &str, out: &mut Vec<Diagnostic>) {
             out.push(
                 Diagnostic::new(
                     RULE_ID,
-                    "Half-width katakana is discouraged; prefer full-width.",
+                    "半角カタカナは推奨されません。全角カタカナを使ってください。",
                     Span::new((start + rs) as u32, (start + byte_pos) as u32),
                 )
                 .with_severity(Severity::Warning),

--- a/crates/tsuzulint_core/src/native_rules/rules/no_hankaku_kana.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_hankaku_kana.rs
@@ -1,0 +1,129 @@
+//! Native port of `no-hankaku-kana`.
+//!
+//! Flags half-width katakana characters (U+FF61..U+FF9F) in prose. Full-width
+//! katakana is the convention for modern Japanese technical writing.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "no-hankaku-kana";
+
+fn is_halfwidth_kana(c: char) -> bool {
+    let cp = c as u32;
+    (0xFF61..=0xFF9F).contains(&cp)
+}
+
+pub struct NoHankakuKana;
+pub static RULE: NoHankakuKana = NoHankakuKana;
+
+impl Rule for NoHankakuKana {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Disallow half-width katakana in prose."
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let _ = Value::Null;
+        let mut out = Vec::new();
+        scan(ctx.ast, ctx.source, &mut out);
+        out
+    }
+}
+
+fn scan(node: &TxtNode<'_>, source: &str, out: &mut Vec<Diagnostic>) {
+    if matches!(node.node_type, NodeType::CodeBlock | NodeType::Code) {
+        return;
+    }
+    if node.node_type == NodeType::Str {
+        let start = node.span.start as usize;
+        let end = node.span.end as usize;
+        if end > source.len() || start > end {
+            return;
+        }
+        let text = &source[start..end];
+        let mut byte_pos = 0usize;
+        let mut run_start: Option<usize> = None;
+        for c in text.chars() {
+            let char_len = c.len_utf8();
+            if is_halfwidth_kana(c) {
+                if run_start.is_none() {
+                    run_start = Some(byte_pos);
+                }
+            } else if let Some(rs) = run_start.take() {
+                out.push(
+                    Diagnostic::new(
+                        RULE_ID,
+                        "Half-width katakana is discouraged; prefer full-width.",
+                        Span::new((start + rs) as u32, (start + byte_pos) as u32),
+                    )
+                    .with_severity(Severity::Warning),
+                );
+            }
+            byte_pos += char_len;
+        }
+        if let Some(rs) = run_start {
+            out.push(
+                Diagnostic::new(
+                    RULE_ID,
+                    "Half-width katakana is discouraged; prefer full-width.",
+                    Span::new((start + rs) as u32, (start + byte_pos) as u32),
+                )
+                .with_severity(Severity::Warning),
+            );
+        }
+        return;
+    }
+    for child in node.children.iter() {
+        scan(child, source, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn run(text: &str) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let s = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, text.len() as u32),
+            text,
+        ));
+        let pc = arena.alloc_slice_copy(&[*s]);
+        let p = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, text.len() as u32),
+            pc,
+        ));
+        let dc = arena.alloc_slice_copy(&[*p]);
+        let ast = TxtNode::new_parent(NodeType::Document, AstSpan::new(0, text.len() as u32), dc);
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &Value::Null,
+            file_path: None,
+        };
+        NoHankakuKana.lint(&ctx)
+    }
+
+    #[test]
+    fn detects_halfwidth_katakana() {
+        let diags = run("ｺﾝﾆﾁﾊ");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn fullwidth_passes() {
+        let diags = run("コンニチハ");
+        assert!(diags.is_empty());
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/no_mixed_zenkaku_hankaku_alphabet.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_mixed_zenkaku_hankaku_alphabet.rs
@@ -32,7 +32,7 @@ impl Rule for NoMixedZenkakuHankakuAlphabet {
     }
 
     fn description(&self) -> &'static str {
-        "Flag prose that mixes half-width and full-width alphabet characters."
+        "半角英字と全角英字が混在している段落を検出する。"
     }
 
     fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
@@ -82,7 +82,7 @@ fn scan(node: &TxtNode<'_>, source: &str, out: &mut Vec<Diagnostic>) {
             out.push(
                 Diagnostic::new(
                     RULE_ID,
-                    "This text mixes half-width and full-width alphabet characters. Pick one style for consistency.",
+                    "半角英字と全角英字が混在しています。どちらかに統一してください。",
                     Span::new(span_start as u32, span_end as u32),
                 )
                 .with_severity(Severity::Warning),

--- a/crates/tsuzulint_core/src/native_rules/rules/no_mixed_zenkaku_hankaku_alphabet.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_mixed_zenkaku_hankaku_alphabet.rs
@@ -1,0 +1,147 @@
+//! Native port of `no-mixed-zenkaku-and-hankaku-alphabet`.
+//!
+//! Flags any Str node that contains both half-width (ASCII) alphabet
+//! characters and full-width (U+FF21..U+FF5A) alphabet characters — a
+//! common source of search / collation bugs in Japanese technical text.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "no-mixed-zenkaku-hankaku-alphabet";
+
+fn is_halfwidth_alpha(c: char) -> bool {
+    c.is_ascii_alphabetic()
+}
+
+fn is_fullwidth_alpha(c: char) -> bool {
+    // U+FF21..U+FF3A (A-Z) and U+FF41..U+FF5A (a-z)
+    let cp = c as u32;
+    (0xFF21..=0xFF3A).contains(&cp) || (0xFF41..=0xFF5A).contains(&cp)
+}
+
+pub struct NoMixedZenkakuHankakuAlphabet;
+
+pub static RULE: NoMixedZenkakuHankakuAlphabet = NoMixedZenkakuHankakuAlphabet;
+
+impl Rule for NoMixedZenkakuHankakuAlphabet {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Flag prose that mixes half-width and full-width alphabet characters."
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let _ = Value::Null;
+        let mut out = Vec::new();
+        scan(ctx.ast, ctx.source, &mut out);
+        out
+    }
+}
+
+fn scan(node: &TxtNode<'_>, source: &str, out: &mut Vec<Diagnostic>) {
+    if matches!(node.node_type, NodeType::CodeBlock | NodeType::Code) {
+        return;
+    }
+    if node.node_type == NodeType::Str {
+        let start = node.span.start as usize;
+        let end = node.span.end as usize;
+        if end > source.len() || start > end {
+            return;
+        }
+        let text = &source[start..end];
+
+        let mut half_pos: Option<usize> = None;
+        let mut full_pos: Option<usize> = None;
+        let mut byte_pos = 0usize;
+        for c in text.chars() {
+            let char_len = c.len_utf8();
+            if is_halfwidth_alpha(c) && half_pos.is_none() {
+                half_pos = Some(byte_pos);
+            }
+            if is_fullwidth_alpha(c) && full_pos.is_none() {
+                full_pos = Some(byte_pos);
+            }
+            byte_pos += char_len;
+            if half_pos.is_some() && full_pos.is_some() {
+                break;
+            }
+        }
+
+        if let (Some(h), Some(f)) = (half_pos, full_pos) {
+            let first = h.min(f);
+            // Report the single mixed span covering the earliest offending
+            // character's single-char range; callers who want the full block
+            // can look at the Str node.
+            let span_start = start + first;
+            let span_end = span_start + 1;
+            out.push(
+                Diagnostic::new(
+                    RULE_ID,
+                    "This text mixes half-width and full-width alphabet characters. Pick one style for consistency.",
+                    Span::new(span_start as u32, span_end as u32),
+                )
+                .with_severity(Severity::Warning),
+            );
+        }
+        return;
+    }
+    for child in node.children.iter() {
+        scan(child, source, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn run(text: &str) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let s = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, text.len() as u32),
+            text,
+        ));
+        let pc = arena.alloc_slice_copy(&[*s]);
+        let p = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, text.len() as u32),
+            pc,
+        ));
+        let dc = arena.alloc_slice_copy(&[*p]);
+        let ast = TxtNode::new_parent(NodeType::Document, AstSpan::new(0, text.len() as u32), dc);
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &Value::Null,
+            file_path: None,
+        };
+        NoMixedZenkakuHankakuAlphabet.lint(&ctx)
+    }
+
+    #[test]
+    fn flags_mixed() {
+        // half-width "git" and full-width "Ｇｉｔ" in the same paragraph
+        let diags = run("gitとＧｉｔは区別される");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn halfwidth_only_passes() {
+        let diags = run("gitで管理する");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn fullwidth_only_passes() {
+        let diags = run("Ｇｉｔで管理する");
+        assert!(diags.is_empty());
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/no_mixed_zenkaku_hankaku_alphabet.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_mixed_zenkaku_hankaku_alphabet.rs
@@ -1,8 +1,11 @@
 //! Native port of `no-mixed-zenkaku-and-hankaku-alphabet`.
 //!
-//! Flags any Str node that contains both half-width (ASCII) alphabet
-//! characters and full-width (U+FF21..U+FF5A) alphabet characters — a
-//! common source of search / collation bugs in Japanese technical text.
+//! Flags documents that mix half-width (ASCII A-Z, a-z) and full-width
+//! (U+FF21..U+FF5A) alphabet characters — a common source of search /
+//! collation bugs in Japanese technical text. Checked across the whole
+//! document so a stray mismatched character in a different paragraph is
+//! still caught. When both widths appear, every occurrence of the rarer
+//! style is reported (same pattern as `ja-no-mixed-period`).
 
 use serde_json::Value;
 use tsuzulint_ast::{NodeType, Span, TxtNode};
@@ -32,18 +35,49 @@ impl Rule for NoMixedZenkakuHankakuAlphabet {
     }
 
     fn description(&self) -> &'static str {
-        "半角英字と全角英字が混在している段落を検出する。"
+        "半角英字と全角英字が文書内で混在しているかを検査する。"
     }
 
     fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
         let _ = Value::Null;
-        let mut out = Vec::new();
-        scan(ctx.ast, ctx.source, &mut out);
-        out
+        let mut half_hits: Vec<(usize, usize)> = Vec::new();
+        let mut full_hits: Vec<(usize, usize)> = Vec::new();
+        collect(ctx.ast, ctx.source, &mut half_hits, &mut full_hits);
+        if half_hits.is_empty() || full_hits.is_empty() {
+            return Vec::new();
+        }
+        // Report every occurrence of the minority style. When the two counts
+        // are equal we treat half-width as the minority; in Japanese
+        // technical writing full-width letters are the outlier worth fixing
+        // in most repos.
+        let (minority, majority_label) = if full_hits.len() <= half_hits.len() {
+            (full_hits, "半角英字")
+        } else {
+            (half_hits, "全角英字")
+        };
+        minority
+            .into_iter()
+            .map(|(s, e)| {
+                Diagnostic::new(
+                    RULE_ID,
+                    format!(
+                        "半角英字と全角英字が混在しています。文書全体で多く使われている{}に統一してください。",
+                        majority_label
+                    ),
+                    Span::new(s as u32, e as u32),
+                )
+                .with_severity(Severity::Warning)
+            })
+            .collect()
     }
 }
 
-fn scan(node: &TxtNode<'_>, source: &str, out: &mut Vec<Diagnostic>) {
+fn collect(
+    node: &TxtNode<'_>,
+    source: &str,
+    half_hits: &mut Vec<(usize, usize)>,
+    full_hits: &mut Vec<(usize, usize)>,
+) {
     if matches!(node.node_type, NodeType::CodeBlock | NodeType::Code) {
         return;
     }
@@ -54,44 +88,20 @@ fn scan(node: &TxtNode<'_>, source: &str, out: &mut Vec<Diagnostic>) {
             return;
         }
         let text = &source[start..end];
-
-        let mut half_pos: Option<usize> = None;
-        let mut full_pos: Option<usize> = None;
         let mut byte_pos = 0usize;
         for c in text.chars() {
             let char_len = c.len_utf8();
-            if is_halfwidth_alpha(c) && half_pos.is_none() {
-                half_pos = Some(byte_pos);
-            }
-            if is_fullwidth_alpha(c) && full_pos.is_none() {
-                full_pos = Some(byte_pos);
+            if is_halfwidth_alpha(c) {
+                half_hits.push((start + byte_pos, start + byte_pos + char_len));
+            } else if is_fullwidth_alpha(c) {
+                full_hits.push((start + byte_pos, start + byte_pos + char_len));
             }
             byte_pos += char_len;
-            if half_pos.is_some() && full_pos.is_some() {
-                break;
-            }
-        }
-
-        if let (Some(h), Some(f)) = (half_pos, full_pos) {
-            let first = h.min(f);
-            // Report the single mixed span covering the earliest offending
-            // character's single-char range; callers who want the full block
-            // can look at the Str node.
-            let span_start = start + first;
-            let span_end = span_start + 1;
-            out.push(
-                Diagnostic::new(
-                    RULE_ID,
-                    "半角英字と全角英字が混在しています。どちらかに統一してください。",
-                    Span::new(span_start as u32, span_end as u32),
-                )
-                .with_severity(Severity::Warning),
-            );
         }
         return;
     }
     for child in node.children.iter() {
-        scan(child, source, out);
+        collect(child, source, half_hits, full_hits);
     }
 }
 
@@ -100,8 +110,8 @@ mod tests {
     use super::*;
     use tsuzulint_ast::{AstArena, Span as AstSpan};
 
-    fn run(text: &str) -> Vec<Diagnostic> {
-        let arena = AstArena::new();
+    /// Helper: wrap `text` in a single-paragraph document.
+    fn one_paragraph<'a>(arena: &'a AstArena, text: &'a str) -> TxtNode<'a> {
         let s = arena.alloc(TxtNode::new_text(
             NodeType::Str,
             AstSpan::new(0, text.len() as u32),
@@ -114,10 +124,43 @@ mod tests {
             pc,
         ));
         let dc = arena.alloc_slice_copy(&[*p]);
-        let ast = TxtNode::new_parent(NodeType::Document, AstSpan::new(0, text.len() as u32), dc);
+        TxtNode::new_parent(NodeType::Document, AstSpan::new(0, text.len() as u32), dc)
+    }
+
+    /// Helper: wrap each of `texts` in its own paragraph so mixing happens
+    /// across paragraph boundaries rather than inside a single Str node.
+    fn multi_paragraph<'a>(arena: &'a AstArena, source: &'a str, texts: &[&'a str]) -> TxtNode<'a> {
+        let mut cursor = 0usize;
+        let mut paragraphs = Vec::with_capacity(texts.len());
+        for text in texts {
+            // Advance past any whitespace/separator bytes in `source`.
+            while !source[cursor..].starts_with(*text) {
+                cursor += source[cursor..].chars().next().unwrap().len_utf8();
+            }
+            let start = cursor;
+            let end = start + text.len();
+            cursor = end;
+
+            let s = arena.alloc(TxtNode::new_text(
+                NodeType::Str,
+                AstSpan::new(start as u32, end as u32),
+                text,
+            ));
+            let pc = arena.alloc_slice_copy(&[*s]);
+            paragraphs.push(*arena.alloc(TxtNode::new_parent(
+                NodeType::Paragraph,
+                AstSpan::new(start as u32, end as u32),
+                pc,
+            )));
+        }
+        let dc = arena.alloc_slice_copy(&paragraphs);
+        TxtNode::new_parent(NodeType::Document, AstSpan::new(0, source.len() as u32), dc)
+    }
+
+    fn run(source: &str, ast: TxtNode<'_>) -> Vec<Diagnostic> {
         let ctx = RuleContext {
             ast: &ast,
-            source: text,
+            source,
             tokens: &[],
             sentences: &[],
             options: &Value::Null,
@@ -127,21 +170,57 @@ mod tests {
     }
 
     #[test]
-    fn flags_mixed() {
-        // half-width "git" and full-width "Ｇｉｔ" in the same paragraph
-        let diags = run("gitとＧｉｔは区別される");
-        assert_eq!(diags.len(), 1);
+    fn flags_minority_fullwidth_in_same_paragraph() {
+        // 3 half-width letters (git) vs 3 full-width letters (Ｇｉｔ).
+        // Tied counts → full-width labeled minority; 3 flags.
+        let arena = AstArena::new();
+        let text = "gitとＧｉｔは区別される";
+        let ast = one_paragraph(&arena, text);
+        let diags = run(text, ast);
+        assert_eq!(diags.len(), 3, "{:?}", diags);
+    }
+
+    #[test]
+    fn flags_minority_across_paragraphs() {
+        // First paragraph: half-width only. Second: single full-width letter.
+        // Without cross-paragraph checking this would pass; with it we catch
+        // the stray full-width letter.
+        let arena = AstArena::new();
+        let source = "git で管理する\n\nＡ だけ全角";
+        let ast = multi_paragraph(&arena, source, &["git で管理する", "Ａ だけ全角"]);
+        let diags = run(source, ast);
+        assert_eq!(diags.len(), 1, "only the single full-width Ａ is flagged");
     }
 
     #[test]
     fn halfwidth_only_passes() {
-        let diags = run("gitで管理する");
-        assert!(diags.is_empty());
+        let arena = AstArena::new();
+        let text = "gitで管理する";
+        let ast = one_paragraph(&arena, text);
+        assert!(run(text, ast).is_empty());
     }
 
     #[test]
     fn fullwidth_only_passes() {
-        let diags = run("Ｇｉｔで管理する");
-        assert!(diags.is_empty());
+        let arena = AstArena::new();
+        let text = "Ｇｉｔで管理する";
+        let ast = one_paragraph(&arena, text);
+        assert!(run(text, ast).is_empty());
+    }
+
+    #[test]
+    fn single_minority_across_the_file_is_flagged() {
+        // 5 half-width letters spread across paragraphs, plus exactly one
+        // stray full-width letter in the last paragraph. The full-width is
+        // the unambiguous minority and must be reported.
+        let arena = AstArena::new();
+        let source = "git は小文字\n\nGitHub にも半角\n\n誤植の Ａ";
+        let ast = multi_paragraph(
+            &arena,
+            source,
+            &["git は小文字", "GitHub にも半角", "誤植の Ａ"],
+        );
+        let diags = run(source, ast);
+        assert_eq!(diags.len(), 1);
     }
 }

--- a/crates/tsuzulint_core/src/native_rules/rules/no_nfd.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_nfd.rs
@@ -1,0 +1,145 @@
+//! Native port of `no-nfd`.
+//!
+//! Flags documents containing decomposed (NFD) Unicode codepoints that
+//! should be normalized to NFC. Decomposed characters often sneak in from
+//! macOS filesystems or certain copy-paste sources and break search / grep.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "no-nfd";
+
+/// Unicode combining marks (Mn category codepoints that are commonly used
+/// to compose with a preceding base character). We detect them as a proxy
+/// for "this text is likely in NFD form".
+fn is_combining_mark(c: char) -> bool {
+    let cp = c as u32;
+    // U+0300..U+036F: Combining Diacritical Marks
+    // U+1AB0..U+1AFF: Combining Diacritical Marks Extended
+    // U+1DC0..U+1DFF: Combining Diacritical Marks Supplement
+    // U+20D0..U+20FF: Combining Diacritical Marks for Symbols
+    // U+FE20..U+FE2F: Combining Half Marks
+    // U+3099..U+309A: Japanese voicing mark / semi-voicing mark
+    matches!(cp,
+        0x0300..=0x036F
+        | 0x1AB0..=0x1AFF
+        | 0x1DC0..=0x1DFF
+        | 0x20D0..=0x20FF
+        | 0xFE20..=0xFE2F
+        | 0x3099..=0x309A
+    )
+}
+
+pub struct NoNfd;
+pub static RULE: NoNfd = NoNfd;
+
+impl Rule for NoNfd {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Flag text that contains decomposed (NFD) Unicode codepoints; normalize to NFC."
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let _ = Value::Null;
+        let mut out = Vec::new();
+        scan(ctx.ast, ctx.source, &mut out);
+        out
+    }
+}
+
+fn scan(node: &TxtNode<'_>, source: &str, out: &mut Vec<Diagnostic>) {
+    if matches!(node.node_type, NodeType::CodeBlock | NodeType::Code) {
+        return;
+    }
+    if node.node_type == NodeType::Str {
+        let start = node.span.start as usize;
+        let end = node.span.end as usize;
+        if end > source.len() || start > end {
+            return;
+        }
+        let text = &source[start..end];
+        let mut byte_pos = 0usize;
+        for c in text.chars() {
+            let char_len = c.len_utf8();
+            if is_combining_mark(c) {
+                out.push(
+                    Diagnostic::new(
+                        RULE_ID,
+                        format!(
+                            "Combining mark U+{:04X} detected; normalize text to NFC.",
+                            c as u32
+                        ),
+                        Span::new(
+                            (start + byte_pos) as u32,
+                            (start + byte_pos + char_len) as u32,
+                        ),
+                    )
+                    .with_severity(Severity::Warning),
+                );
+            }
+            byte_pos += char_len;
+        }
+        return;
+    }
+    for child in node.children.iter() {
+        scan(child, source, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn lint(text: &str) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let s = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, text.len() as u32),
+            text,
+        ));
+        let pc = arena.alloc_slice_copy(&[*s]);
+        let p = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, text.len() as u32),
+            pc,
+        ));
+        let dc = arena.alloc_slice_copy(&[*p]);
+        let ast = TxtNode::new_parent(NodeType::Document, AstSpan::new(0, text.len() as u32), dc);
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &Value::Null,
+            file_path: None,
+        };
+        NoNfd.lint(&ctx)
+    }
+
+    #[test]
+    fn detects_nfd_japanese_dakuten() {
+        // NFC "が" = U+304C; NFD = U+304B (か) + U+3099 (combining dakuten)
+        let diags = lint("か\u{3099}");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn nfc_passes() {
+        let diags = lint("がぎぐげご");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn detects_accented_latin_nfd() {
+        // NFC "é" = U+00E9; NFD = e + U+0301
+        let diags = lint("e\u{0301}xample");
+        assert_eq!(diags.len(), 1);
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/no_todo.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_todo.rs
@@ -104,44 +104,19 @@ fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnos
 }
 
 fn report_matches(text: &str, base_offset: u32, config: &Config, out: &mut Vec<Diagnostic>) {
-    // Building the haystack once per Str node is cheaper than re-casing per
-    // pattern. `to_lowercase` is O(n) but only fires when the user opted out
-    // of case sensitivity (the default for textlint-rule-no-todo).
-    let haystack_owned;
-    let haystack: &str = if config.case_sensitive {
-        text
-    } else {
-        haystack_owned = text.to_lowercase();
-        haystack_owned.as_str()
-    };
-
-    let patterns: Vec<String> = if config.case_sensitive {
-        config.patterns.clone()
-    } else {
-        config.patterns.iter().map(|p| p.to_lowercase()).collect()
-    };
-    let ignore_patterns: Vec<String> = if config.case_sensitive {
-        config.ignore_patterns.clone()
-    } else {
-        config
-            .ignore_patterns
-            .iter()
-            .map(|p| p.to_lowercase())
-            .collect()
-    };
-
-    for (pattern, pattern_cased) in patterns.iter().zip(config.patterns.iter()) {
+    for (pattern_idx, pattern) in config.patterns.iter().enumerate() {
         let mut search_start = 0usize;
-        while let Some(idx) = haystack[search_start..].find(pattern.as_str()) {
-            let match_start = search_start + idx;
-            let match_end = match_start + pattern.len();
+        while let Some((match_start, match_end)) =
+            find_pattern(text, pattern, search_start, config.case_sensitive)
+        {
             let matched_text = &text[match_start..match_end];
 
-            if !ignore_patterns
-                .iter()
-                .any(|p| matched_text.to_lowercase().contains(p.as_str()))
-            {
-                let display = pattern_cased.trim_end();
+            let ignored = config.ignore_patterns.iter().any(|ignore_pat| {
+                contains_pattern(matched_text, ignore_pat, config.case_sensitive)
+            });
+
+            if !ignored {
+                let display = config.patterns[pattern_idx].trim_end();
                 out.push(
                     Diagnostic::new(
                         RULE_ID,
@@ -161,6 +136,84 @@ fn report_matches(text: &str, base_offset: u32, config: &Config, out: &mut Vec<D
             search_start = match_end;
         }
     }
+}
+
+/// Find the first occurrence of `pattern` in `haystack[start..]`, returning
+/// `(match_start, match_end)` as byte offsets into the **original**
+/// `haystack`.
+///
+/// This avoids the trap where `text.to_lowercase()` can change byte length
+/// for a handful of Unicode characters (e.g. U+1E9E `ẞ` → "ss", U+0130
+/// `İ` → "i\u{0307}"). A naive "lowercase then .find()" implementation
+/// returns byte positions into the lowercased string which are not
+/// necessarily valid in the original — slicing the original there can land
+/// mid-codepoint and panic.
+fn find_pattern(
+    haystack: &str,
+    pattern: &str,
+    start: usize,
+    case_sensitive: bool,
+) -> Option<(usize, usize)> {
+    if case_sensitive {
+        let idx = haystack[start..].find(pattern)?;
+        let match_start = start + idx;
+        return Some((match_start, match_start + pattern.len()));
+    }
+
+    // Case-insensitive: walk the haystack character-by-character, comparing
+    // against the pattern via case-insensitive char equality, while keeping
+    // byte positions anchored to the ORIGINAL haystack.
+    let pattern_chars: Vec<char> = pattern.chars().collect();
+    if pattern_chars.is_empty() {
+        return Some((start, start));
+    }
+
+    let mut char_starts: Vec<usize> = Vec::new();
+    for (i, _) in haystack[start..].char_indices() {
+        char_starts.push(start + i);
+    }
+    char_starts.push(haystack.len());
+
+    'outer: for (i, &anchor) in char_starts[..char_starts.len().saturating_sub(1)]
+        .iter()
+        .enumerate()
+    {
+        let mut cursor = anchor;
+        for &pc in &pattern_chars {
+            let Some(hc) = haystack[cursor..].chars().next() else {
+                continue 'outer;
+            };
+            if !chars_equal_ignore_case(pc, hc) {
+                continue 'outer;
+            }
+            cursor += hc.len_utf8();
+        }
+        let _ = i;
+        return Some((anchor, cursor));
+    }
+    None
+}
+
+fn contains_pattern(haystack: &str, pattern: &str, case_sensitive: bool) -> bool {
+    find_pattern(haystack, pattern, 0, case_sensitive).is_some()
+}
+
+/// Case-insensitive char equality that works for the characters TODO / FIXME
+/// marker users actually type. We compare by lowercasing each char into a
+/// small String; this handles the special-case multi-char expansions (e.g.
+/// `İ → i\u{0307}`) by treating them as non-matches for single-char
+/// patterns, which is the safe default — the markers we care about are all
+/// ASCII anyway.
+fn chars_equal_ignore_case(a: char, b: char) -> bool {
+    if a == b {
+        return true;
+    }
+    let mut la = a.to_lowercase();
+    let mut lb = b.to_lowercase();
+    let (Some(ca), Some(cb)) = (la.next(), lb.next()) else {
+        return false;
+    };
+    ca == cb && la.next().is_none() && lb.next().is_none()
 }
 
 #[cfg(test)]
@@ -211,6 +264,34 @@ mod tests {
     fn detects_fixme_case_insensitive() {
         let diags = run("fixme: check this");
         assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn does_not_panic_on_multi_byte_lowercase_expanding_chars() {
+        // Regression: `str::to_lowercase()` changes the byte length of
+        // U+1E9E (`ẞ` → "ss") and U+0130 (`İ` → "i\u{0307}"), which used
+        // to shift the byte index of a TODO: match into the middle of a
+        // multi-byte char when indexing the original text afterwards.
+        // This test exercises both "expanding" (ẞ) and "growing" (İ) forms
+        // and passes only if the rule tracks byte positions in the
+        // *original* text rather than the lowercased copy.
+        let inputs = [
+            "日ẞ日TODO: fix",  // expanding: ẞ (3B) → "ss" (2B)
+            "İabcTODO: later", // growing:  İ (2B) → "i\u{0307}" (3B)
+            "FOOẞBARFIXME: x",
+        ];
+        for text in inputs {
+            let diags = run(text);
+            assert!(
+                !diags.is_empty(),
+                "expected at least one diagnostic for {:?}",
+                text
+            );
+            for d in &diags {
+                // Spans must not panic when slicing the original text.
+                let _slice = &text[d.span.start as usize..d.span.end as usize];
+            }
+        }
     }
 
     #[test]

--- a/crates/tsuzulint_core/src/native_rules/rules/no_todo.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_todo.rs
@@ -1,0 +1,259 @@
+//! Native port of the `no-todo` rule.
+//!
+//! Detects task markers (TODO, FIXME, HACK, XXX) in prose nodes. Mirrors the
+//! semantics of `textlint-rule-no-todo` and the WASM `rules/no-todo` plugin so
+//! existing configs keep working, but runs as native Rust without a WASM
+//! round-trip.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "no-todo";
+const DEFAULT_PATTERNS: &[&str] = &[
+    "TODO:", "TODO ", "FIXME:", "FIXME ", "XXX:", "XXX ", "HACK:",
+];
+
+struct Config {
+    patterns: Vec<String>,
+    ignore_patterns: Vec<String>,
+    case_sensitive: bool,
+}
+
+impl Config {
+    fn from_options(options: &Value) -> Self {
+        let mut cfg = Self {
+            patterns: DEFAULT_PATTERNS.iter().map(|s| (*s).to_string()).collect(),
+            ignore_patterns: Vec::new(),
+            case_sensitive: false,
+        };
+
+        let Value::Object(map) = options else {
+            return cfg;
+        };
+
+        if let Some(Value::Array(arr)) = map.get("patterns") {
+            let patterns: Vec<String> = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+            if !patterns.is_empty() {
+                cfg.patterns = patterns;
+            }
+        }
+
+        if let Some(Value::Array(arr)) = map.get("ignore_patterns") {
+            cfg.ignore_patterns = arr
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect();
+        }
+
+        if let Some(Value::Bool(b)) = map.get("case_sensitive") {
+            cfg.case_sensitive = *b;
+        }
+
+        cfg
+    }
+}
+
+pub struct NoTodo;
+
+pub static RULE: NoTodo = NoTodo;
+
+impl Rule for NoTodo {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Disallow TODO/FIXME/HACK/XXX markers in prose."
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let config = Config::from_options(ctx.options);
+        let mut diagnostics = Vec::new();
+        scan(ctx.ast, ctx.source, &config, &mut diagnostics);
+        diagnostics
+    }
+}
+
+fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnostic>) {
+    // Skip code blocks and inline code: they frequently contain TODO markers
+    // that are meant for the code, not the prose.
+    if matches!(node.node_type, NodeType::CodeBlock | NodeType::Code) {
+        return;
+    }
+
+    if node.node_type == NodeType::Str {
+        let start = node.span.start as usize;
+        let end = node.span.end as usize;
+        if end > source.len() || start > end {
+            return;
+        }
+        let text = &source[start..end];
+        report_matches(text, start as u32, config, out);
+        return;
+    }
+
+    for child in node.children.iter() {
+        scan(child, source, config, out);
+    }
+}
+
+fn report_matches(text: &str, base_offset: u32, config: &Config, out: &mut Vec<Diagnostic>) {
+    // Building the haystack once per Str node is cheaper than re-casing per
+    // pattern. `to_lowercase` is O(n) but only fires when the user opted out
+    // of case sensitivity (the default for textlint-rule-no-todo).
+    let haystack_owned;
+    let haystack: &str = if config.case_sensitive {
+        text
+    } else {
+        haystack_owned = text.to_lowercase();
+        haystack_owned.as_str()
+    };
+
+    let patterns: Vec<String> = if config.case_sensitive {
+        config.patterns.clone()
+    } else {
+        config.patterns.iter().map(|p| p.to_lowercase()).collect()
+    };
+    let ignore_patterns: Vec<String> = if config.case_sensitive {
+        config.ignore_patterns.clone()
+    } else {
+        config
+            .ignore_patterns
+            .iter()
+            .map(|p| p.to_lowercase())
+            .collect()
+    };
+
+    for (pattern, pattern_cased) in patterns.iter().zip(config.patterns.iter()) {
+        let mut search_start = 0usize;
+        while let Some(idx) = haystack[search_start..].find(pattern.as_str()) {
+            let match_start = search_start + idx;
+            let match_end = match_start + pattern.len();
+            let matched_text = &text[match_start..match_end];
+
+            if !ignore_patterns
+                .iter()
+                .any(|p| matched_text.to_lowercase().contains(p.as_str()))
+            {
+                let display = pattern_cased.trim_end();
+                out.push(
+                    Diagnostic::new(
+                        RULE_ID,
+                        format!(
+                            "Found '{}' marker. Consider resolving this before committing.",
+                            display
+                        ),
+                        Span::new(
+                            base_offset + match_start as u32,
+                            base_offset + match_end as u32,
+                        ),
+                    )
+                    .with_severity(Severity::Warning),
+                );
+            }
+
+            search_start = match_end;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn make_str_ast<'a>(arena: &'a AstArena, text: &'a str) -> TxtNode<'a> {
+        let start = 0u32;
+        let end = text.len() as u32;
+        let str_node = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(start, end),
+            text,
+        ));
+        let paragraph_children = arena.alloc_slice_copy(&[*str_node]);
+        let paragraph = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(start, end),
+            paragraph_children,
+        ));
+        let doc_children = arena.alloc_slice_copy(&[*paragraph]);
+        TxtNode::new_parent(NodeType::Document, AstSpan::new(start, end), doc_children)
+    }
+
+    fn run(text: &str) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let ast = make_str_ast(&arena, text);
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &Value::Null,
+            file_path: None,
+        };
+        NoTodo.lint(&ctx)
+    }
+
+    #[test]
+    fn detects_todo() {
+        let diags = run("本節は後でTODO: 書き直す。");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("TODO"));
+    }
+
+    #[test]
+    fn detects_fixme_case_insensitive() {
+        let diags = run("fixme: check this");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn no_match_for_clean_text() {
+        let diags = run("単なる普通の文である。");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn skips_code_block() {
+        let arena = AstArena::new();
+        let text = "TODO: still visible\n```\nTODO: hidden\n```";
+        let para_text = "TODO: still visible";
+        let code_text = "TODO: hidden";
+        let str_node = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, para_text.len() as u32),
+            para_text,
+        ));
+        let para_children = arena.alloc_slice_copy(&[*str_node]);
+        let para = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, para_text.len() as u32),
+            para_children,
+        ));
+        let code_start = para_text.len() as u32 + 1;
+        let code_end = code_start + code_text.len() as u32;
+        let code = arena.alloc(TxtNode::new_text(
+            NodeType::CodeBlock,
+            AstSpan::new(code_start, code_end),
+            code_text,
+        ));
+        let doc_children = arena.alloc_slice_copy(&[*para, *code]);
+        let ast = TxtNode::new_parent(NodeType::Document, AstSpan::new(0, code_end), doc_children);
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &Value::Null,
+            file_path: None,
+        };
+        let diags = NoTodo.lint(&ctx);
+        assert_eq!(diags.len(), 1, "only paragraph TODO should fire");
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/no_zero_width_spaces.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_zero_width_spaces.rs
@@ -1,0 +1,136 @@
+//! Native port of `no-zero-width-spaces`.
+//!
+//! Detects zero-width-ish invisible codepoints that often sneak in via
+//! copy/paste from rich-text editors. Reported as warnings because they
+//! are almost never intentional in technical writing.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "no-zero-width-spaces";
+
+/// Characters that render as zero-width or near-zero-width in most fonts.
+/// Excludes code-block-only characters (e.g. byte order marks in headers of
+/// files, which are intentional).
+const INVISIBLE: &[char] = &[
+    '\u{200B}', // ZERO WIDTH SPACE
+    '\u{200C}', // ZERO WIDTH NON-JOINER
+    '\u{200D}', // ZERO WIDTH JOINER
+    '\u{2060}', // WORD JOINER
+    '\u{FEFF}', // ZERO WIDTH NO-BREAK SPACE (BOM)
+];
+
+pub struct NoZeroWidthSpaces;
+
+pub static RULE: NoZeroWidthSpaces = NoZeroWidthSpaces;
+
+impl Rule for NoZeroWidthSpaces {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Disallow invisible / zero-width Unicode codepoints that are usually unintended."
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let _ = Value::Null; // options reserved for future per-codepoint toggles
+        let mut out = Vec::new();
+        scan(ctx.ast, ctx.source, &mut out);
+        out
+    }
+}
+
+fn scan(node: &TxtNode<'_>, source: &str, out: &mut Vec<Diagnostic>) {
+    // CodeBlock / Code: intentional invisibles are common (e.g. demonstrating
+    // Unicode), but plain prose should not contain them.
+    if matches!(node.node_type, NodeType::CodeBlock | NodeType::Code) {
+        return;
+    }
+    if node.node_type == NodeType::Str {
+        let start = node.span.start as usize;
+        let end = node.span.end as usize;
+        if end > source.len() || start > end {
+            return;
+        }
+        let text = &source[start..end];
+        let mut byte_pos = 0usize;
+        for c in text.chars() {
+            let char_len = c.len_utf8();
+            if INVISIBLE.contains(&c) {
+                let abs_start = start + byte_pos;
+                let abs_end = abs_start + char_len;
+                out.push(
+                    Diagnostic::new(
+                        RULE_ID,
+                        format!(
+                            "Invisible codepoint U+{:04X} is not allowed in prose.",
+                            c as u32
+                        ),
+                        Span::new(abs_start as u32, abs_end as u32),
+                    )
+                    .with_severity(Severity::Warning),
+                );
+            }
+            byte_pos += char_len;
+        }
+        return;
+    }
+    for child in node.children.iter() {
+        scan(child, source, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn run(text: &str) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let s = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, text.len() as u32),
+            text,
+        ));
+        let pc = arena.alloc_slice_copy(&[*s]);
+        let p = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, text.len() as u32),
+            pc,
+        ));
+        let dc = arena.alloc_slice_copy(&[*p]);
+        let ast = TxtNode::new_parent(NodeType::Document, AstSpan::new(0, text.len() as u32), dc);
+        let ctx = RuleContext {
+            ast: &ast,
+            source: text,
+            tokens: &[],
+            sentences: &[],
+            options: &Value::Null,
+            file_path: None,
+        };
+        NoZeroWidthSpaces.lint(&ctx)
+    }
+
+    #[test]
+    fn detects_zws() {
+        let diags = run("hello\u{200B}world");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("U+200B"));
+    }
+
+    #[test]
+    fn clean_text_passes() {
+        let diags = run("普通の文章です。");
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn detects_bom_mid_text() {
+        let diags = run("foo\u{FEFF}bar");
+        assert_eq!(diags.len(), 1);
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/sentence_length.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/sentence_length.rs
@@ -1,0 +1,259 @@
+//! Native port of `sentence-length`.
+//!
+//! Flags sentences whose character count exceeds the configured `max`.
+//! Matches the semantics of `textlint-rule-sentence-length` and the
+//! `rules/sentence-length` WASM plugin.
+
+use serde_json::Value;
+use tsuzulint_ast::{NodeType, Span, TxtNode};
+use tsuzulint_plugin::{Diagnostic, Severity};
+
+use crate::native_rules::{Rule, RuleContext};
+
+const RULE_ID: &str = "sentence-length";
+const DEFAULT_MAX: usize = 100;
+
+struct Config {
+    max: usize,
+    skip_urls: bool,
+}
+
+impl Config {
+    fn from_options(options: &Value) -> Self {
+        let mut cfg = Self {
+            max: DEFAULT_MAX,
+            skip_urls: true,
+        };
+        let Value::Object(map) = options else {
+            return cfg;
+        };
+        if let Some(Value::Number(n)) = map.get("max")
+            && let Some(max) = n.as_u64()
+        {
+            cfg.max = max as usize;
+        }
+        if let Some(Value::Bool(b)) = map.get("skip_urls") {
+            cfg.skip_urls = *b;
+        }
+        cfg
+    }
+}
+
+pub struct SentenceLength;
+
+pub static RULE: SentenceLength = SentenceLength;
+
+impl Rule for SentenceLength {
+    fn name(&self) -> &'static str {
+        RULE_ID
+    }
+
+    fn description(&self) -> &'static str {
+        "Report sentences longer than the configured maximum length."
+    }
+
+    fn needs_sentences(&self) -> bool {
+        // We run per-text-node sentence splitting rather than the global
+        // host splitter because individual paragraphs are the natural unit
+        // (per-block diagnostics scope cleanly this way) and the per-node
+        // call is already fast. If that changes later we'll flip this to
+        // `true` and read from `ctx.sentences`.
+        false
+    }
+
+    fn lint(&self, ctx: &RuleContext<'_>) -> Vec<Diagnostic> {
+        let config = Config::from_options(ctx.options);
+        let mut diagnostics = Vec::new();
+        scan(ctx.ast, ctx.source, &config, &mut diagnostics);
+        diagnostics
+    }
+}
+
+/// Scan the AST for prose blocks and check each one's sentence lengths.
+///
+/// We operate at the block level (Paragraph / Header / ListItem / TableCell /
+/// BlockQuote) so that we can (a) skip code blocks cleanly and (b) reuse the
+/// block's text range for diagnostic spans.
+fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnostic>) {
+    match node.node_type {
+        NodeType::CodeBlock | NodeType::Code | NodeType::Html | NodeType::HorizontalRule => {}
+        NodeType::Paragraph
+        | NodeType::Header
+        | NodeType::ListItem
+        | NodeType::TableCell
+        | NodeType::BlockQuote => {
+            check_block(node, source, config, out);
+            for child in node.children.iter() {
+                // Blocks can nest (ListItem > Paragraph > ...), so keep walking.
+                scan(child, source, config, out);
+            }
+        }
+        _ => {
+            for child in node.children.iter() {
+                scan(child, source, config, out);
+            }
+        }
+    }
+}
+
+fn check_block(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnostic>) {
+    let start = node.span.start as usize;
+    let end = node.span.end as usize;
+    if end > source.len() || start > end {
+        return;
+    }
+    let text = &source[start..end];
+    // We strip URLs from the whole block BEFORE splitting, because dots inside
+    // URLs would otherwise split "example.com" as two sentences. We keep a
+    // parallel copy of the original sentence byte ranges so diagnostic spans
+    // still point at real source offsets.
+    let working_text: String = if config.skip_urls {
+        strip_urls(text)
+    } else {
+        text.to_string()
+    };
+    for (sentence_text, _sentence_start) in split_sentences(&working_text) {
+        let char_count = sentence_text.chars().count();
+        if char_count > config.max {
+            // Point the diagnostic at the block's overall span: sentence-level
+            // positions would need to be reconciled with the stripped-URL
+            // offsets, which adds complexity for little reader benefit.
+            out.push(
+                Diagnostic::new(
+                    RULE_ID,
+                    format!(
+                        "Sentence is too long ({} characters). Maximum allowed is {}.",
+                        char_count, config.max
+                    ),
+                    Span::new(start as u32, end as u32),
+                )
+                .with_severity(Severity::Warning),
+            );
+        }
+    }
+}
+
+fn split_sentences(text: &str) -> Vec<(&str, usize)> {
+    let delimiters = ['.', '!', '?', '。', '！', '？'];
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    let mut byte_pos = 0usize;
+    for c in text.chars() {
+        let char_len = c.len_utf8();
+        if delimiters.contains(&c) {
+            let sentence_end = byte_pos + char_len;
+            let sentence = text[start..sentence_end].trim_start();
+            if !sentence.is_empty() {
+                let leading_ws = text[start..sentence_end].len() - sentence.len();
+                out.push((sentence, start + leading_ws));
+            }
+            start = sentence_end;
+        }
+        byte_pos += char_len;
+    }
+    if start < text.len() {
+        let tail = text[start..].trim_start();
+        if !tail.is_empty() {
+            let leading_ws = text.len() - start - tail.len();
+            out.push((tail, start + leading_ws));
+        }
+    }
+    out
+}
+
+fn strip_urls(text: &str) -> String {
+    // Replace http(s)://… URL runs with a single placeholder char so their
+    // character cost collapses to 1. Anything up to the next whitespace or
+    // closing punctuation is considered part of the URL.
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0usize;
+    let bytes = text.as_bytes();
+    while i < bytes.len() {
+        let rest = &text[i..];
+        if rest.starts_with("http://") || rest.starts_with("https://") {
+            out.push('・');
+            let url_end = rest
+                .find(|c: char| c.is_whitespace() || matches!(c, '」' | '）' | ')' | '、' | '。'))
+                .unwrap_or(rest.len());
+            i += url_end;
+            continue;
+        }
+        let ch = text[i..]
+            .chars()
+            .next()
+            .expect("i is a valid char boundary");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsuzulint_ast::{AstArena, Span as AstSpan};
+
+    fn run(source: &str, max: usize) -> Vec<Diagnostic> {
+        let arena = AstArena::new();
+        let str_node = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, source.len() as u32),
+            source,
+        ));
+        let para_children = arena.alloc_slice_copy(&[*str_node]);
+        let para = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, source.len() as u32),
+            para_children,
+        ));
+        let doc_children = arena.alloc_slice_copy(&[*para]);
+        let ast = TxtNode::new_parent(
+            NodeType::Document,
+            AstSpan::new(0, source.len() as u32),
+            doc_children,
+        );
+        let options = serde_json::json!({ "max": max });
+        let ctx = RuleContext {
+            ast: &ast,
+            source,
+            tokens: &[],
+            sentences: &[],
+            options: &options,
+            file_path: None,
+        };
+        SentenceLength.lint(&ctx)
+    }
+
+    #[test]
+    fn short_sentence_passes() {
+        let diags = run("短い文。", 100);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn long_sentence_fails() {
+        let long = "あ".repeat(120) + "。";
+        let diags = run(&long, 100);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn multiple_sentences_mixed() {
+        let text = format!("短い文。{}。", "あ".repeat(120));
+        let diags = run(&text, 100);
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn url_is_collapsed_when_skip_urls() {
+        // The text without the URL is well under 100 chars; with the URL
+        // counted verbatim it would exceed the limit. Default skip_urls=true
+        // collapses the URL so the diagnostic does not fire.
+        let text = format!(
+            "詳細は {} を参照してください。",
+            "https://example.com/".to_string() + &"a".repeat(200)
+        );
+        let diags = run(&text, 30);
+        assert!(diags.is_empty(), "URL should be collapsed: {:?}", diags);
+    }
+}

--- a/crates/tsuzulint_core/src/native_rules/rules/sentence_length.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/sentence_length.rs
@@ -225,21 +225,26 @@ mod tests {
     }
 
     #[test]
-    fn short_sentence_passes() {
-        let diags = run("短い文。", 100);
-        assert!(diags.is_empty());
+    fn sentence_at_exact_limit_passes() {
+        // 99 "あ" + "。" = 100 chars — exactly at the limit, must pass.
+        let text = "あ".repeat(99) + "。";
+        let diags = run(&text, 100);
+        assert!(diags.is_empty(), "{:?}", diags);
     }
 
     #[test]
-    fn long_sentence_fails() {
-        let long = "あ".repeat(120) + "。";
-        let diags = run(&long, 100);
+    fn sentence_one_char_over_limit_fails() {
+        // 100 "あ" + "。" = 101 chars — one char over the limit.
+        let text = "あ".repeat(100) + "。";
+        let diags = run(&text, 100);
         assert_eq!(diags.len(), 1);
     }
 
     #[test]
-    fn multiple_sentences_mixed() {
-        let text = format!("短い文。{}。", "あ".repeat(120));
+    fn only_over_limit_sentence_is_flagged() {
+        // First sentence is at the limit (passes); second sentence is one
+        // char over (fails). Verifies per-sentence evaluation.
+        let text = format!("{}。{}。", "あ".repeat(99), "い".repeat(100));
         let diags = run(&text, 100);
         assert_eq!(diags.len(), 1);
     }

--- a/crates/tsuzulint_core/src/native_rules/rules/sentence_length.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/sentence_length.rs
@@ -71,22 +71,17 @@ impl Rule for SentenceLength {
 
 /// Scan the AST for prose blocks and check each one's sentence lengths.
 ///
-/// We operate at the block level (Paragraph / Header / ListItem / TableCell /
-/// BlockQuote) so that we can (a) skip code blocks cleanly and (b) reuse the
-/// block's text range for diagnostic spans.
+/// We operate at the *leaf* block level (Paragraph / Header / TableCell)
+/// rather than container blocks (ListItem / BlockQuote / Document) because
+/// list items and block quotes wrap paragraphs, and counting them as their
+/// own block produces duplicate diagnostics for the same underlying text.
+/// Container blocks are still traversed — we just don't run the sentence
+/// check on them directly.
 fn scan(node: &TxtNode<'_>, source: &str, config: &Config, out: &mut Vec<Diagnostic>) {
     match node.node_type {
         NodeType::CodeBlock | NodeType::Code | NodeType::Html | NodeType::HorizontalRule => {}
-        NodeType::Paragraph
-        | NodeType::Header
-        | NodeType::ListItem
-        | NodeType::TableCell
-        | NodeType::BlockQuote => {
+        NodeType::Paragraph | NodeType::Header | NodeType::TableCell => {
             check_block(node, source, config, out);
-            for child in node.children.iter() {
-                // Blocks can nest (ListItem > Paragraph > ...), so keep walking.
-                scan(child, source, config, out);
-            }
         }
         _ => {
             for child in node.children.iter() {
@@ -260,5 +255,48 @@ mod tests {
         );
         let diags = run(&text, 30);
         assert!(diags.is_empty(), "URL should be collapsed: {:?}", diags);
+    }
+
+    #[test]
+    fn nested_list_item_paragraph_is_not_double_counted() {
+        // Regression: ListItem containing a Paragraph would previously be
+        // checked at both the ListItem *and* the Paragraph level, producing
+        // two diagnostics (with overlapping spans) for the same sentence.
+        let arena = AstArena::new();
+        let source = "あ".repeat(101) + "。";
+        let str_node = arena.alloc(TxtNode::new_text(
+            NodeType::Str,
+            AstSpan::new(0, source.len() as u32),
+            &source,
+        ));
+        let paragraph_children = arena.alloc_slice_copy(&[*str_node]);
+        let paragraph = arena.alloc(TxtNode::new_parent(
+            NodeType::Paragraph,
+            AstSpan::new(0, source.len() as u32),
+            paragraph_children,
+        ));
+        let list_item_children = arena.alloc_slice_copy(&[*paragraph]);
+        let list_item = arena.alloc(TxtNode::new_parent(
+            NodeType::ListItem,
+            AstSpan::new(0, source.len() as u32),
+            list_item_children,
+        ));
+        let doc_children = arena.alloc_slice_copy(&[*list_item]);
+        let ast = TxtNode::new_parent(
+            NodeType::Document,
+            AstSpan::new(0, source.len() as u32),
+            doc_children,
+        );
+        let options = serde_json::json!({ "max": 100 });
+        let ctx = RuleContext {
+            ast: &ast,
+            source: &source,
+            tokens: &[],
+            sentences: &[],
+            options: &options,
+            file_path: None,
+        };
+        let diags = SentenceLength.lint(&ctx);
+        assert_eq!(diags.len(), 1, "{:?}", diags);
     }
 }

--- a/crates/tsuzulint_core/src/parallel_linter.rs
+++ b/crates/tsuzulint_core/src/parallel_linter.rs
@@ -26,6 +26,10 @@ pub fn lint_files(
     let enabled_rules_vec = config.enabled_rules();
     let enabled_rules: std::collections::HashSet<&str> =
         enabled_rules_vec.iter().map(|(n, _)| *n).collect();
+    let rule_options: std::collections::HashMap<String, serde_json::Value> = enabled_rules_vec
+        .iter()
+        .map(|(name, opt)| ((*name).to_string(), opt.options()))
+        .collect();
     let timings_enabled = config.timings;
 
     let results: Vec<Result<LintResult, (PathBuf, LinterError)>> = paths
@@ -64,6 +68,7 @@ pub fn lint_files(
                     enabled_rules: &enabled_rules,
                     rule_versions,
                     timings_enabled,
+                    rule_options: &rule_options,
                 };
 
                 lint_file_internal(&mut ctx).map_err(|e| (path.clone(), e))

--- a/crates/tsuzulint_registry/src/security.rs
+++ b/crates/tsuzulint_registry/src/security.rs
@@ -59,11 +59,10 @@ pub fn validate_url(url: &Url, allow_local: bool) -> Result<(), SecurityError> {
     }
 
     match url.host() {
-        Some(url::Host::Domain(domain)) => {
-            if domain == "localhost" {
-                return Err(SecurityError::LoopbackDenied(domain.to_string()));
-            }
+        Some(url::Host::Domain(domain)) if domain == "localhost" => {
+            return Err(SecurityError::LoopbackDenied(domain.to_string()));
         }
+        Some(url::Host::Domain(_)) => {}
         Some(url::Host::Ipv4(ipv4)) => {
             check_ip(std::net::IpAddr::V4(ipv4))?;
         }


### PR DESCRIPTION
## Summary

Introduces a Rust-native rule engine alongside the existing WASM plugin system, with 10 textlint-compatible built-in rules. Native rules compile directly into the binary, share the parser's AST and morphological tokens, and skip the WASM boundary — the fastest execution path for rules that ship in the default distribution.

Benchmark numbers and preset bundles live in follow-up PRs stacked on top of this one.

Addresses #33 (Built-in Rules Engine) and #34 (Port Core Rules).

## Why native?

WASM is the right fit for user-specific, experimental, or third-party rules, but rules that are (a) broadly useful, (b) expressible with stdlib + `tsuzulint_text`, and (c) stable enough to ship in the binary get a large performance win from running natively. The two engines coexist: a WASM rule registered under the same name shadows the native rule, so users can always override a built-in with a plugin of the same name.

## Architecture

- `native_rules::Rule` — the trait each native rule implements (`name`, `description`, `fixable`, `needs_morphology`, `needs_sentences`, `lint`).
- `native_rules::RuleContext` — carries AST, source, tokens, sentences, per-rule options, file path into the rule.
- `native_rules::BuiltinRegistry` — process-global `OnceLock`-backed registry keyed by rule name.

Integration in `file_linter::lint_file_internal`: after the WASM dispatch loop, iterate enabled rules whose name is in the built-in registry and not already loaded as a WASM rule. `needs_morphology` / `needs_sentences` aggregation now considers both engines so the tokenizer / sentence splitter fire exactly when any enabled rule wants them.

## Rules (all with unit tests)

| Rule | Category | Textlint equivalent |
| :--- | :--- | :--- |
| `no-todo`                            | Marker        | `textlint-rule-no-todo` |
| `sentence-length`                    | Style         | `textlint-rule-sentence-length` |
| `max-ten`                            | Style         | `textlint-rule-max-ten` |
| `max-kanji-continuous-len`           | Style         | `textlint-rule-max-kanji-continuous-len` |
| `no-doubled-joshi`                   | Morphological | `textlint-rule-no-doubled-joshi` |
| `no-exclamation-question-mark`       | Punctuation   | `textlint-rule-no-exclamation-question-mark` |
| `no-hankaku-kana`                    | Character     | `textlint-rule-no-hankaku-kana` |
| `no-mixed-zenkaku-hankaku-alphabet`  | Character     | `textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet` |
| `no-zero-width-spaces`               | Character     | `textlint-rule-no-zero-width-spaces` |
| `no-nfd`                             | Unicode       | `textlint-rule-no-nfd` |
| `ja-no-mixed-period`                 | Punctuation   | `textlint-rule-ja-no-mixed-period` |

Semantics mirror the corresponding `textlint-rule-*` packages so existing `.textlintrc` configurations map cleanly. `CodeBlock` / `Code` nodes are skipped in all rules.

## Stacked PRs

- **this PR** — native rule engine + 10 rules (targets `main`)
- next — preset mechanism + `ja-technical-writing` / `ja-basic` (targets this branch)
- last — textlint benchmark harness + docs (targets the presets branch)

## Test plan

- [x] `cargo nextest run -p tsuzulint_core` — 319 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --release --bin tzlint` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ネイティブ実装された11個の新しいリントルールが追加されました。日本語ピリオド混在検出、漢字連続長チェック、読点最大数チェック、助詞重複検出、感嘆符検出、半角カナ検出、文字幅混在検出、NFD形式検出、TODO検出、ゼロ幅スペース検出、文長チェックが利用可能になりました。
  * ルール単位での細粒度な設定オプション指定に対応しました。

* **パフォーマンス**
  * WASMバウンダリを回避したネイティブルール実行により、処理速度が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->