### PR TITLE
feat(config): add native rule presets (ja-technical-writing, ja-basic)

### DIFF
--- a/crates/tsuzulint_core/src/config.rs
+++ b/crates/tsuzulint_core/src/config.rs
@@ -25,6 +25,12 @@ pub struct LinterConfig {
     #[serde(default)]
     pub rules: Vec<RuleDefinition>,
 
+    /// Native presets to enable (e.g. `"ja-technical-writing"`). Each preset
+    /// expands to a list of built-in rules with default options. User-supplied
+    /// entries in `options` override the preset defaults.
+    #[serde(default)]
+    pub presets: Vec<String>,
+
     /// Rule configuration (enable/disable/options).
     #[serde(default)]
     pub options: HashMap<String, RuleOption>,
@@ -184,6 +190,7 @@ impl LinterConfig {
     pub fn new() -> Self {
         Self {
             rules: Vec::new(),
+            presets: Vec::new(),
             options: HashMap::new(),
             include: Vec::new(),
             exclude: Vec::new(),
@@ -252,8 +259,14 @@ impl LinterConfig {
             )));
         }
 
-        serde_json::from_value(value)
-            .map_err(|e| LinterError::config(format!("Invalid config: {}", e)))
+        let mut config: Self = serde_json::from_value(value)
+            .map_err(|e| LinterError::config(format!("Invalid config: {}", e)))?;
+        // Expand presets here so every public entry point (from_json and
+        // from_file both) produces a ready-to-use config — previously only
+        // from_file expanded them and a caller reaching for from_json would
+        // silently end up with no rules enabled from presets.
+        config.apply_presets();
+        Ok(config)
     }
 
     /// Returns enabled rules (Iterator over options).
@@ -265,6 +278,34 @@ impl LinterConfig {
             .filter(|(_, config)| config.is_enabled())
             .map(|(name, config)| (name.as_str(), config))
             .collect()
+    }
+
+    /// Expand referenced `presets` into the `options` map.
+    ///
+    /// Applied at config-load time. User-supplied entries in `options` always
+    /// win, so users can override a preset rule by setting it explicitly —
+    /// including disabling it with `"rule-name": false`.
+    pub fn apply_presets(&mut self) {
+        if self.presets.is_empty() {
+            return;
+        }
+        for preset_name in self.presets.clone() {
+            let Some(entries) = crate::native_rules::resolve_preset(&preset_name) else {
+                tracing::warn!("Unknown preset '{}'; skipping", preset_name);
+                continue;
+            };
+            for entry in entries {
+                // Don't clobber explicit user config.
+                if self.options.contains_key(entry.name) {
+                    continue;
+                }
+                let opt = match entry.default_options {
+                    serde_json::Value::Null => RuleOption::Enabled(true),
+                    other => RuleOption::Options(other),
+                };
+                self.options.insert(entry.name.to_string(), opt);
+            }
+        }
     }
 
     /// Computes a hash of the configuration for cache invalidation.

--- a/crates/tsuzulint_core/src/native_rules/mod.rs
+++ b/crates/tsuzulint_core/src/native_rules/mod.rs
@@ -22,10 +22,12 @@
 //! assembled from the current file's AST.
 
 mod context;
+pub mod presets;
 mod registry;
 mod rule_trait;
 mod rules;
 
 pub use context::RuleContext;
+pub use presets::{PresetEntry, all_preset_names, resolve_preset};
 pub use registry::{BuiltinRegistry, builtin_registry};
 pub use rule_trait::Rule;

--- a/crates/tsuzulint_core/src/native_rules/presets.rs
+++ b/crates/tsuzulint_core/src/native_rules/presets.rs
@@ -1,0 +1,110 @@
+//! Preset bundles of native rules.
+//!
+//! A preset enables a curated set of rules with sensible defaults so users
+//! don't have to wire each rule individually. Modeled after textlint's
+//! `preset-*` packages for familiarity.
+
+use serde_json::Value;
+
+/// Entry in a preset: rule name + default options (merged with user options
+/// from `.tsuzulint.jsonc` at lint time).
+#[derive(Debug, Clone)]
+pub struct PresetEntry {
+    pub name: &'static str,
+    pub default_options: Value,
+}
+
+impl PresetEntry {
+    const fn bare(name: &'static str) -> Self {
+        Self {
+            name,
+            default_options: Value::Null,
+        }
+    }
+}
+
+/// Resolve a preset name to its list of enabled rules, or `None` for an
+/// unknown preset.
+pub fn resolve_preset(name: &str) -> Option<Vec<PresetEntry>> {
+    match name {
+        "ja-technical-writing" | "preset-ja-technical-writing" => Some(ja_technical_writing()),
+        "ja-basic" | "preset-ja-basic" => Some(ja_basic()),
+        _ => None,
+    }
+}
+
+/// `ja-technical-writing`: the big bundle that matches textlint's
+/// technical-writing preset as closely as we currently can.
+fn ja_technical_writing() -> Vec<PresetEntry> {
+    vec![
+        PresetEntry {
+            name: "sentence-length",
+            default_options: serde_json::json!({ "max": 100 }),
+        },
+        PresetEntry {
+            name: "max-ten",
+            default_options: serde_json::json!({ "max": 3 }),
+        },
+        PresetEntry {
+            name: "max-kanji-continuous-len",
+            default_options: serde_json::json!({ "max": 6 }),
+        },
+        PresetEntry::bare("no-doubled-joshi"),
+        PresetEntry::bare("no-mixed-zenkaku-hankaku-alphabet"),
+        PresetEntry::bare("no-exclamation-question-mark"),
+        PresetEntry::bare("no-hankaku-kana"),
+        PresetEntry::bare("no-nfd"),
+        PresetEntry::bare("no-zero-width-spaces"),
+        PresetEntry::bare("ja-no-mixed-period"),
+    ]
+}
+
+/// `ja-basic`: a lighter bundle aimed at casual blogs and docs — no length
+/// limits, just the text-quality checks.
+fn ja_basic() -> Vec<PresetEntry> {
+    vec![
+        PresetEntry::bare("no-mixed-zenkaku-hankaku-alphabet"),
+        PresetEntry::bare("no-hankaku-kana"),
+        PresetEntry::bare("no-nfd"),
+        PresetEntry::bare("no-zero-width-spaces"),
+        PresetEntry::bare("ja-no-mixed-period"),
+    ]
+}
+
+/// Names of all presets this binary ships.
+pub fn all_preset_names() -> &'static [&'static str] {
+    &["ja-technical-writing", "ja-basic"]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_ja_technical_writing() {
+        let preset = resolve_preset("ja-technical-writing").unwrap();
+        assert!(preset.iter().any(|e| e.name == "sentence-length"));
+        assert!(preset.iter().any(|e| e.name == "max-ten"));
+    }
+
+    #[test]
+    fn resolves_prefixed_name() {
+        assert!(resolve_preset("preset-ja-technical-writing").is_some());
+    }
+
+    #[test]
+    fn unknown_preset_returns_none() {
+        assert!(resolve_preset("nope").is_none());
+    }
+
+    #[test]
+    fn all_presets_resolve() {
+        for name in all_preset_names() {
+            assert!(
+                resolve_preset(name).is_some(),
+                "preset '{}' should resolve",
+                name
+            );
+        }
+    }
+}

--- a/schemas/v1/config.json
+++ b/schemas/v1/config.json
@@ -104,6 +104,13 @@
         ]
       }
     },
+    "presets": {
+      "type": "array",
+      "description": "Native preset bundles to enable (e.g. 'ja-technical-writing', 'ja-basic'). User-supplied entries in 'options' override preset defaults.",
+      "items": {
+        "type": "string"
+      }
+    },
     "options": {
       "type": "object",
       "description": "Rule options. Keys are rule IDs, values are rule options or boolean/severity.",


### PR DESCRIPTION
## Summary

Adds a preset mechanism so users can enable a curated bundle of native rules in one line, matching textlint's `preset-*` package convention. Ships two bundles: `ja-technical-writing` (technical docs) and `ja-basic` (blog / casual prose).

Depends on feat/native-rule-engine-core for the `Rule` trait and `BuiltinRegistry` that the presets compose. Base this PR on that branch.

## Features

- `LinterConfig.presets: Vec<String>` field (+ JSON Schema update).
- `LinterConfig::apply_presets()` expands preset names into the `options` map at config load time. **User options always win**, so explicit entries — including `"rule-name": false` to opt out of a preset rule — take precedence over preset defaults.
- `native_rules::presets` module with two curated bundles:
  - `ja-technical-writing` — 10 rules close to textlint's `preset-ja-technical-writing` (sentence-length, max-ten, max-kanji-continuous-len, no-doubled-joshi, no-mixed-zenkaku-hankaku-alphabet, no-exclamation-question-mark, no-hankaku-kana, no-nfd, no-zero-width-spaces, ja-no-mixed-period).
  - `ja-basic` — 5 text-quality checks without length limits.
- Aliases accepted with the `preset-` prefix so `preset-ja-technical-writing` works identically to `ja-technical-writing`.

## Example

```jsonc
{
  "presets": ["ja-technical-writing"],
  "options": {
    "sentence-length": { "max": 90 },     // overrides preset default (100)
    "no-exclamation-question-mark": false // opts out entirely
  }
}
```

## Stacked PRs

- previous — native rule engine + 10 rules (`feat/native-rule-engine-core`)
- **this PR** — preset mechanism + 2 bundles
- next — textlint benchmark harness + docs (targets this branch)

## Test plan

- [x] `cargo nextest run -p tsuzulint_core` — 319 tests pass (4 new preset tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] End-to-end: sample `.tsuzulint.jsonc` with `"presets": ["ja-technical-writing"]` resolves and fires all bundled rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
