### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded file read in resolver

### DIFF
--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -6,8 +6,8 @@ use crate::error::FetchError;
 use crate::fetcher::ManifestFetcher;
 use crate::manifest::{ExternalRuleManifest, HashVerifier, IntegrityError};
 use crate::security::validate_local_wasm_path;
-use std::path::{Path, PathBuf};
 use std::io::Read;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 pub use crate::fetcher::PluginSource;
@@ -225,14 +225,24 @@ impl PluginResolver {
 
         let max_size = crate::downloader::DEFAULT_MAX_SIZE;
         if metadata.len() > max_size {
-            return Err(DownloadError::TooLarge { size: metadata.len(), max: max_size }.into());
+            return Err(DownloadError::TooLarge {
+                size: metadata.len(),
+                max: max_size,
+            }
+            .into());
         }
 
         let mut bytes = Vec::new();
-        std::io::Read::take(&mut file, max_size + 1).read_to_end(&mut bytes).map_err(DownloadError::IoError)?;
+        std::io::Read::take(&mut file, max_size + 1)
+            .read_to_end(&mut bytes)
+            .map_err(DownloadError::IoError)?;
 
         if bytes.len() as u64 > max_size {
-            return Err(DownloadError::TooLarge { size: bytes.len() as u64, max: max_size }.into());
+            return Err(DownloadError::TooLarge {
+                size: bytes.len() as u64,
+                max: max_size,
+            }
+            .into());
         }
 
         let expected_hash = expected_hash.ok_or_else(|| {

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -220,7 +220,7 @@ impl PluginResolver {
 
         let wasm_path = validate_local_wasm_path(wasm_relative, parent)?;
 
-        let mut file = std::fs::File::open(&wasm_path).map_err(DownloadError::IoError)?;
+        let file = std::fs::File::open(&wasm_path).map_err(DownloadError::IoError)?;
         let metadata = file.metadata().map_err(DownloadError::IoError)?;
 
         let max_size = crate::downloader::DEFAULT_MAX_SIZE;
@@ -232,8 +232,8 @@ impl PluginResolver {
             .into());
         }
 
-        let mut bytes = Vec::new();
-        std::io::Read::take(&mut file, max_size + 1)
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        file.take(max_size + 1)
             .read_to_end(&mut bytes)
             .map_err(DownloadError::IoError)?;
 
@@ -277,6 +277,53 @@ mod tests {
             "server_url": server_url
         }))
         .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_resolve_path_too_large() {
+        let dir = tempdir().unwrap();
+        let manifest_path = dir.path().join("tsuzulint-rule.json");
+        let wasm_path = dir.path().join("rule.wasm");
+
+        let manifest = json!({
+            "rule": { "name": "too-large-rule", "version": "1.0.0" },
+            "wasm": [{
+                "path": "rule.wasm",
+                "hash": "0000000000000000000000000000000000000000000000000000000000000000"
+            }]
+        });
+        std::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
+
+        // Let's make the metadata report a large file size on Windows/Linux
+        // by actually writing it but sparse if possible.
+        // It's 50MB, which is only ~0.05 seconds to write on a modern SSD. Let's do that!
+        let file = std::fs::File::create(&wasm_path).unwrap();
+        // Seek past end to make a sparse file
+        file.set_len(crate::downloader::DEFAULT_MAX_SIZE + 10)
+            .unwrap();
+
+        let cache_dir = tempdir().unwrap();
+        let resolver = PluginResolver::new()
+            .unwrap()
+            .with_cache(PluginCache::with_dir(cache_dir.path()));
+
+        let spec = PluginSpec {
+            source: PluginSource::Path(dir.path().to_path_buf()),
+            alias: None,
+        };
+
+        let result = resolver.resolve(&spec).await;
+
+        match result {
+            Err(ResolveError::DownloadError(crate::downloader::DownloadError::TooLarge {
+                ..
+            })) => {
+                // Success!
+            }
+            other => {
+                panic!("Expected TooLarge error, got {:?}", other);
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -7,6 +7,7 @@ use crate::fetcher::ManifestFetcher;
 use crate::manifest::{ExternalRuleManifest, HashVerifier, IntegrityError};
 use crate::security::validate_local_wasm_path;
 use std::path::{Path, PathBuf};
+use std::io::Read;
 use thiserror::Error;
 
 pub use crate::fetcher::PluginSource;
@@ -219,7 +220,20 @@ impl PluginResolver {
 
         let wasm_path = validate_local_wasm_path(wasm_relative, parent)?;
 
-        let bytes = std::fs::read(&wasm_path).map_err(DownloadError::IoError)?;
+        let mut file = std::fs::File::open(&wasm_path).map_err(DownloadError::IoError)?;
+        let metadata = file.metadata().map_err(DownloadError::IoError)?;
+
+        let max_size = crate::downloader::DEFAULT_MAX_SIZE;
+        if metadata.len() > max_size {
+            return Err(DownloadError::TooLarge { size: metadata.len(), max: max_size }.into());
+        }
+
+        let mut bytes = Vec::new();
+        std::io::Read::take(&mut file, max_size + 1).read_to_end(&mut bytes).map_err(DownloadError::IoError)?;
+
+        if bytes.len() as u64 > max_size {
+            return Err(DownloadError::TooLarge { size: bytes.len() as u64, max: max_size }.into());
+        }
 
         let expected_hash = expected_hash.ok_or_else(|| {
             ResolveError::SerializationError(


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unbounded file read of user-configurable local WASM paths. The `std::fs::read` function reads an entire file into memory without limits.
🎯 **Impact:** If an exceptionally large or maliciously crafted file is configured as a local plugin, it could lead to memory exhaustion (OOM), causing a Denial of Service (DoS) for the application.
🔧 **Fix:** Replaced the unbounded `std::fs::read` with a safe, bounded approach:
1. Opens the file and verifies `metadata.len()` is within the maximum allowed size (`DEFAULT_MAX_SIZE`).
2. Performs a bounded read using `std::io::Read::take(MAX_SIZE + 1)` and `read_to_end` to strictly enforce memory limits even for streams or files that modify their size after checking metadata.
✅ **Verification:** Verified by passing all test cases and clippy linters (`cargo test --workspace --all-features` and `cargo clippy --all-features -- -D warnings`).

---
*PR created automatically by Jules for task [12842981892598138300](https://jules.google.com/task/12842981892598138300) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ローカルプラグインのWASMファイルサイズ制限チェックが強化されました。ファイルメタデータと読み込み時の二段階でサイズ検証を実施し、制限を超えるファイルの読み込みを防止するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->