### PR TITLE
🦀 Ferris: [refactor] idiomatic string map conversion

### DIFF
--- a/crates/tsuzulint_core/src/context.rs
+++ b/crates/tsuzulint_core/src/context.rs
@@ -396,7 +396,7 @@ impl<'a> LintContext<'a> {
             }
             NodeType::Link | NodeType::Image => {
                 let url = node.url().unwrap_or("").to_string();
-                let title = node.title().map(|s| s.to_string());
+                let title = node.title().map(String::from);
                 structure.links.push(LinkInfo {
                     url,
                     title,
@@ -405,7 +405,7 @@ impl<'a> LintContext<'a> {
                 });
             }
             NodeType::CodeBlock => {
-                let lang = node.lang().map(|s| s.to_string());
+                let lang = node.lang().map(String::from);
                 structure.code_blocks.push(CodeBlockInfo {
                     lang,
                     span: node.span,

--- a/crates/tsuzulint_core/src/formatters/sarif.rs
+++ b/crates/tsuzulint_core/src/formatters/sarif.rs
@@ -114,7 +114,7 @@ impl ToolComponent {
         let rules_vec: Vec<_> = rules.into_values().collect();
         Self {
             name: TOOL_NAME.to_string(),
-            version: option_env!("CARGO_PKG_VERSION").map(|s| s.to_string()),
+            version: option_env!("CARGO_PKG_VERSION").map(String::from),
             rules: rules_vec,
         }
     }

--- a/crates/tsuzulint_plugin/src/host.rs
+++ b/crates/tsuzulint_plugin/src/host.rs
@@ -690,7 +690,7 @@ mod tests {
         assert_eq!(guest_request.source, source);
         assert_eq!(guest_request.tokens, tokens);
         assert_eq!(guest_request.sentences, sentences);
-        assert_eq!(guest_request.file_path, file_path.map(|s| s.to_string()));
+        assert_eq!(guest_request.file_path, file_path.map(String::from));
         assert_eq!(guest_request.node, node_data);
         assert_eq!(guest_request.helpers, None);
     }


### PR DESCRIPTION
💡 Improvement: Replaced redundant closures inside `.map()` with direct function pointers (e.g. `.map(String::from)`).
🦀 Why: This is a well-known idiomatic Rust practice that cleans up code, avoids creating unnecessary closures, and perfectly matches `clippy::redundant_closure` warnings.
🔍 Verification: Ran `cargo test --workspace`, `cargo clippy`, and `make fmt-check` to ensure there are no regressions or logic changes.

---
*PR created automatically by Jules for task [14314644436438915601](https://jules.google.com/task/14314644436438915601) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code optimizations and consistency improvements for better maintainability.

---

**Note:** This release contains only internal refactoring with no user-visible changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->