### PR TITLE
🦀 Ferris: [refactor] Use explicit lazy cloning in PluginResolver

### DIFF
--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -92,7 +92,9 @@ impl PluginResolver {
 
         match &spec.source {
             PluginSource::GitHub { version, .. } => {
-                let version_str = version.as_ref().unwrap_or(&manifest.rule.version).clone();
+                let version_str = version
+                    .clone()
+                    .unwrap_or_else(|| manifest.rule.version.clone());
                 self.resolve_remote(&fetcher_source, &version_str, manifest, alias)
                     .await
             }


### PR DESCRIPTION
💡 Improvement: Replaced the indirection of `.as_ref().unwrap_or(&...).clone()` with an explicit lazy allocation using `.clone().unwrap_or_else(|| ...)` in `PluginResolver::resolve`.
🦀 Why: This refactor removes the unnecessary indirection and makes the lazy evaluation explicit and readable while avoiding holding a borrow on `manifest.rule.version` across the asynchronous boundary when cloning is eventually required, leading to a cleaner and idiomatic fallback evaluation for `Option<String>`.
🔍 Verification: `cargo test --workspace --all-features`, `make lint`, and `make fmt-check` have all passed successfully.

---
*PR created automatically by Jules for task [13702933167932518132](https://jules.google.com/task/13702933167932518132) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * プラグインレゾルバーのバージョン選択処理を最適化しました。マニフェストバージョンはフォールバック時のみクローンされるようになり、メモリ効率が向上しました。ユーザーへの表示変化はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->