### PR TITLE
🦀 Ferris: [refactor] Use lazy evaluation for String fallback

### DIFF
--- a/crates/tsuzulint_registry/src/resolver.rs
+++ b/crates/tsuzulint_registry/src/resolver.rs
@@ -92,7 +92,9 @@ impl PluginResolver {
 
         match &spec.source {
             PluginSource::GitHub { version, .. } => {
-                let version_str = version.as_ref().unwrap_or(&manifest.rule.version).clone();
+                let version_str = version
+                    .clone()
+                    .unwrap_or_else(|| manifest.rule.version.clone());
                 self.resolve_remote(&fetcher_source, &version_str, manifest, alias)
                     .await
             }


### PR DESCRIPTION
💡 Improvement: Replaced an eager evaluation of a string clone during a fallback scenario with a lazy evaluation using `unwrap_or_else`.
🦀 Why: Idiomatic Rust favors zero-cost or lazy abstractions. `version.as_ref().unwrap_or(&fallback).clone()` eagerly processes the reference and is less idiomatic than `version.clone().unwrap_or_else(|| fallback.clone())`, which avoids an unnecessary allocation/clone when `version` is `Some`.
🔍 Verification: Checked out the code and successfully ran `make test`, `make lint`, and `make fmt-check` (via `cargo` fallbacks to verify across the workspace) to ensure regressions weren't introduced and all formatting and linters passed.

---
*PR created automatically by Jules for task [1299453745427737866](https://jules.google.com/task/1299453745427737866) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * プラグインの解決処理を最適化し、パフォーマンスを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->