### PR TITLE
🦀 Ferris: [refactor] Remove unnecessary string allocation in config tests

### DIFF
--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -461,7 +461,7 @@ mod tests {
         assert!(
             msg.contains("Refusing to modify configuration file because it is a symbolic link")
         );
-        assert!(msg.contains(&symlink_path.to_string_lossy().to_string()));
+        assert!(msg.contains(symlink_path.to_string_lossy().as_ref()));
 
         let target_content = std::fs::read(target_path).unwrap();
         assert!(


### PR DESCRIPTION
💡 Improvement: Replaced `.to_string()` with `.as_ref()` in `msg.contains` checks for `symlink_path.to_string_lossy()`.
🦀 Why: `Path::to_string_lossy()` returns a `Cow<'_, str>`. Calling `.to_string()` on it forces a new `String` heap allocation purely to pass it to a method that expects `&str` (like `msg.contains`). Using `.as_ref()` trivially borrows the `Cow` as `&str` with zero runtime allocation overhead. Idiomatic zero-cost abstraction!
🔍 Verification: `make test` and `make lint` both pass cleanly. Tests behave exactly as before.

---
*PR created automatically by Jules for task [16468086569945578778](https://jules.google.com/task/16468086569945578778) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト設定の効率化を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->