### PR TITLE
🦀 Ferris: [improvement] Use as_ref() instead of to_string() for Cow<str>

### DIFF
--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -461,7 +461,7 @@ mod tests {
         assert!(
             msg.contains("Refusing to modify configuration file because it is a symbolic link")
         );
-        assert!(msg.contains(&symlink_path.to_string_lossy().to_string()));
+        assert!(msg.contains(symlink_path.to_string_lossy().as_ref()));
 
         let target_content = std::fs::read(target_path).unwrap();
         assert!(


### PR DESCRIPTION
🦀 Ferris: [improvement] Use as_ref() instead of to_string() for Cow<str>

💡 Improvement: Replaced `.to_string_lossy().to_string()` with `.to_string_lossy().as_ref()` for substring checks via `msg.contains()` in `crates/tsuzulint_cli/src/config/editor.rs`.

🦀 Why: `Path::to_string_lossy()` returns a `Cow<'_, str>`. Calling `.to_string()` on it forces an unnecessary heap allocation to create an owned `String`, just so it can be passed by reference to `contains()`. Using `.as_ref()` correctly borrows the `&str` directly from the `Cow`, which prevents redundant memory allocations and conforms to zero-cost idiomatic Rust principles.

🔍 Verification: Ran `make test` and `make lint` confirming no logic changes or regressions.

---
*PR created automatically by Jules for task [691318484670847980](https://jules.google.com/task/691318484670847980) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * ユニットテストの内部最適化を実施しました。

このリリースに含まれるのは、ユーザーに直接影響しない内部的な改善です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->