### PR TITLE
⚡ Bolt: [performance improvement] avoid intermediate Vector allocation in manager tests

### DIFF
--- a/crates/tsuzulint_cache/src/manager.rs
+++ b/crates/tsuzulint_cache/src/manager.rs
@@ -636,10 +636,9 @@ mod tests {
 
         // Verify that we got the correct diagnostics back (meaning correct blocks were matched)
         // Since we didn't shift positions (current == cached), spans should be identical to cached diagnostics.
-        let messages: Vec<String> = diagnostics.iter().map(|d| d.message.clone()).collect();
-        assert!(messages.contains(&"Err1".to_string()));
-        assert!(messages.contains(&"Err2".to_string()));
-        assert!(messages.contains(&"Err3".to_string()));
+        assert!(diagnostics.iter().any(|d| d.message == "Err1"));
+        assert!(diagnostics.iter().any(|d| d.message == "Err2"));
+        assert!(diagnostics.iter().any(|d| d.message == "Err3"));
     }
 
     #[test]


### PR DESCRIPTION
**💡 Improvement:**
Removed a completely unnecessary heap allocation in the cache manager test. Rather than mapping through the diagnostics, allocating cloned strings, collecting them into a `Vec<String>`, and then checking presence via `.contains()`, it now uses lazy iteration with `.any()`.

**🎯 Why:**
Intermediate collection instantiation (`Vec<String>`) just to check if specific string values exist is a known anti-pattern and negatively impacts performance with wasted heap allocations and clones. 

**📊 Impact:**
Eliminates 1 `Vec` allocation and 6 `String` allocations (3 from cloning and 3 from `.to_string()`) per test invocation without changing the core functionality or test semantics.

**🔬 Measurement:**
Tested via `cargo test -p tsuzulint_cache` to ensure tests continue to pass with the more optimal approach.

---
*PR created automatically by Jules for task [8092084878346832288](https://jules.google.com/task/8092084878346832288) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストはテストコードの内部改善を含んでおり、エンドユーザーに対する可視的な変更はありません。

* **Tests**
  * キャッシュ診断メッセージの検証ロジックを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->