### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unbounded File Reads

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }
@@ -189,7 +190,8 @@ fn generate_minimal_manifest(
     use tsuzulint_manifest::{IsolationLevel, RuleMetadata};
     use tsuzulint_registry::HashVerifier;
 
-    let wasm_content = std::fs::read(wasm_path).map_err(AddRuleError::WasmReadError)?;
+    let wasm_content = crate::utils::read_with_limit(wasm_path, 1024 * 1024 * 10)
+        .map_err(AddRuleError::WasmReadError)?;
     let sha256 = HashVerifier::compute(&wasm_content);
 
     Ok(tsuzulint_manifest::ExternalRuleManifest {
@@ -236,7 +238,8 @@ fn copy_plugin_files(
 
     std::fs::copy(wasm_path, &target_wasm).map_err(AddRuleError::CopyError)?;
 
-    let wasm_content = std::fs::read(&target_wasm).map_err(AddRuleError::WasmReadError)?;
+    let wasm_content = crate::utils::read_with_limit(&target_wasm, 1024 * 1024 * 10)
+        .map_err(AddRuleError::WasmReadError)?;
     let sha256 = tsuzulint_registry::HashVerifier::compute(&wasm_content);
 
     manifest.wasm = vec![Wasm::File {

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -49,3 +49,41 @@ pub fn read_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> std::io::Result<V
     }
     Ok(buffer)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"hello world").unwrap();
+        let content = read_to_string_with_limit(file.path(), 100).unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_exceeds_limit() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"hello world").unwrap();
+        let err = read_to_string_with_limit(file.path(), 5).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_read_with_limit_success() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"hello world").unwrap();
+        let content = read_with_limit(file.path(), 100).unwrap();
+        assert_eq!(content, b"hello world");
+    }
+
+    #[test]
+    fn test_read_with_limit_exceeds_limit() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"hello world").unwrap();
+        let err = read_with_limit(file.path(), 5).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+}

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -1,6 +1,8 @@
 //! CLI utility functions
 
 use miette::{IntoDiagnostic, Result};
+use std::io::Read;
+use std::path::Path;
 use tokio::runtime::Runtime;
 
 pub fn create_tokio_runtime() -> Result<Runtime> {
@@ -8,4 +10,42 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .enable_all()
         .build()
         .into_diagnostic()
+}
+
+pub fn read_to_string_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> std::io::Result<String> {
+    let file = std::fs::File::open(path)?;
+    if file.metadata()?.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "File exceeds size limit",
+        ));
+    }
+    let mut buffer = String::new();
+    file.take(limit + 1).read_to_string(&mut buffer)?;
+    if buffer.len() as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "File exceeds size limit",
+        ));
+    }
+    Ok(buffer)
+}
+
+pub fn read_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> std::io::Result<Vec<u8>> {
+    let file = std::fs::File::open(path)?;
+    if file.metadata()?.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "File exceeds size limit",
+        ));
+    }
+    let mut buffer = Vec::new();
+    file.take(limit + 1).read_to_end(&mut buffer)?;
+    if buffer.len() as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "File exceeds size limit",
+        ));
+    }
+    Ok(buffer)
 }

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -86,4 +86,20 @@ mod tests {
         let err = read_with_limit(file.path(), 5).unwrap_err();
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
+
+    #[test]
+    fn test_read_to_string_with_limit_buffer_len_exceeds_limit() {
+        if std::path::Path::new("/dev/zero").exists() {
+            let err = read_to_string_with_limit("/dev/zero", 10).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        }
+    }
+
+    #[test]
+    fn test_read_with_limit_buffer_len_exceeds_limit() {
+        if std::path::Path::new("/dev/zero").exists() {
+            let err = read_with_limit("/dev/zero", 10).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        }
+    }
 }

--- a/patch_tests_2.sh
+++ b/patch_tests_2.sh
@@ -1,0 +1,31 @@
+cat << 'INNER_EOF' >> crates/tsuzulint_cli/src/utils/mod.rs
+
+    #[test]
+    fn test_read_to_string_with_limit_buffer_len_exceeds_limit() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        // Since we can't easily mock metadata size < actual size locally without a pseudo file,
+        // we write less than limit to bypass the first metadata check
+        // then write more than limit directly to the file via another descriptor
+        // Actually, we can use a small limit and bypass metadata check by creating a file
+        // that's small, keeping the handle, appending more data from outside, and then reading.
+        // Even simpler: just test the coverage of the second error branch
+
+        use std::io::Write;
+        // Let's just create a file that's large, but mock or somehow hit that logic.
+        // Easiest way to hit the second error branch is to pass a limit smaller than the file,
+        // BUT the first check catches it.
+        // Wait, what if we use `/dev/zero`? /dev/zero has size 0, but infinite data.
+        if std::path::Path::new("/dev/zero").exists() {
+            let err = read_to_string_with_limit("/dev/zero", 10).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        }
+    }
+
+    #[test]
+    fn test_read_with_limit_buffer_len_exceeds_limit() {
+        if std::path::Path::new("/dev/zero").exists() {
+            let err = read_with_limit("/dev/zero", 10).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        }
+    }
+INNER_EOF

--- a/patch_tests_3.sh
+++ b/patch_tests_3.sh
@@ -1,0 +1,3 @@
+cat << 'INNER_EOF' >> crates/tsuzulint_cli/src/utils/mod.rs
+}
+INNER_EOF

--- a/patch_tests_4.sh
+++ b/patch_tests_4.sh
@@ -1,0 +1,2 @@
+sed -i 's/let mut file = tempfile::NamedTempFile::new().unwrap();//g' crates/tsuzulint_cli/src/utils/mod.rs
+sed -i 's/use std::io::Write;//g' crates/tsuzulint_cli/src/utils/mod.rs


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Unbounded file reads using `std::fs::read_to_string` and `std::fs::read` in `tsuzulint_cli` could lead to Memory Exhaustion (OOM) or Denial of Service (DoS) if large external or user-provided files (like WASM plugins or manifests) are processed.
🎯 Impact: An attacker could provide a malicious, extremely large file, causing the CLI application to consume excessive memory and crash.
🔧 Fix: Implemented `read_to_string_with_limit` and `read_with_limit` utilities in `tsuzulint_cli::utils` to enforce a strict memory limit (e.g. 1MB for configs, 10MB for WASM files) by checking file metadata and limiting the read stream via `.take()`. Replaced all vulnerable unbounded reads in `commands/rules.rs` and `config/editor.rs` with these bounded utilities.
✅ Verification: Ran `cargo fmt --all`, `make lint`, and `cargo test -p tsuzulint`. All checks pass.

---
*PR created automatically by Jules for task [10132567926545867298](https://jules.google.com/task/10132567926545867298) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チューンナップ**
  * マニフェストとWASMファイルの読み込みにサイズ制限を追加し、システム安定性を向上しました。マニフェストは1MiBまで、WASMファイルは10MiBまでの読み込みに制限されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->