### PR TITLE
⚡ Bolt: [performance improvement] Avoid unnecessary String allocation when checking Cow<str>

### DIFF
--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -461,7 +461,7 @@ mod tests {
         assert!(
             msg.contains("Refusing to modify configuration file because it is a symbolic link")
         );
-        assert!(msg.contains(&symlink_path.to_string_lossy().to_string()));
+        assert!(msg.contains(symlink_path.to_string_lossy().as_ref()));
 
         let target_content = std::fs::read(target_path).unwrap();
         assert!(


### PR DESCRIPTION
💡 **What**: Removed `.to_string()` and replaced it with `.as_ref()` when checking if `msg` contains `symlink_path.to_string_lossy()` inside `crates/tsuzulint_cli/src/config/editor.rs` test.
🎯 **Why**: `to_string_lossy()` produces a `Cow<'_, str>`. Calling `.to_string()` directly on it forces an unnecessary memory heap allocation to convert it to an owned `String`. `msg.contains()` accepts any string slice (`&str`), so converting to an owned `String` is unneeded and wastes resources.
📊 **Impact**: This avoids creating a new heap allocation during this string assertion check. Because this is within a test, it's mostly a micro-optimization and cleanup, but it implements idiomatic string borrowing mechanics in Rust for cleaner and technically faster execution. 
🔬 **Measurement**: Verify by running `cargo test --workspace --all-features` and observing the tests for `tsuzulint_cli` all pass. You can see the `to_string()` is gone in `crates/tsuzulint_cli/src/config/editor.rs` line 464.

---
*PR created automatically by Jules for task [11574220544697074941](https://jules.google.com/task/11574220544697074941) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * テストアサーション最適化により、内部パフォーマンスを向上

---

**注記**: このPRはユーザーに対する機能的な影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->