### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded file reads in CLI

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,7 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024).map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,7 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content = crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -4,7 +4,10 @@ use miette::{IntoDiagnostic, Result};
 use tokio::runtime::Runtime;
 
 /// Reads a file into a string with a size limit to prevent memory exhaustion
-pub fn read_to_string_with_limit(path: &std::path::Path, limit: u64) -> std::io::Result<String> {
+pub fn read_to_string_with_limit<P: AsRef<std::path::Path>>(
+    path: P,
+    limit: u64,
+) -> std::io::Result<String> {
     use std::io::Read;
 
     let file = std::fs::File::open(path)?;
@@ -13,7 +16,7 @@ pub fn read_to_string_with_limit(path: &std::path::Path, limit: u64) -> std::io:
     if metadata.len() > limit {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("File size exceeds limit of {} bytes", limit)
+            format!("File size exceeds limit of {} bytes", limit),
         ));
     }
 
@@ -23,7 +26,7 @@ pub fn read_to_string_with_limit(path: &std::path::Path, limit: u64) -> std::io:
     if content.len() as u64 > limit {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!("File content exceeds limit of {} bytes", limit)
+            format!("File content exceeds limit of {} bytes", limit),
         ));
     }
 
@@ -35,4 +38,30 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .enable_all()
         .build()
         .into_diagnostic()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hello world").unwrap();
+
+        let content = read_to_string_with_limit(tmp.path(), 100).unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_metadata_exceeded() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hello world").unwrap();
+
+        // Limit is 5, but file is 11 bytes
+        let err = read_to_string_with_limit(tmp.path(), 5).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("size exceeds limit"));
+    }
 }

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -3,6 +3,33 @@
 use miette::{IntoDiagnostic, Result};
 use tokio::runtime::Runtime;
 
+/// Reads a file into a string with a size limit to prevent memory exhaustion
+pub fn read_to_string_with_limit(path: &std::path::Path, limit: u64) -> std::io::Result<String> {
+    use std::io::Read;
+
+    let file = std::fs::File::open(path)?;
+    let metadata = file.metadata()?;
+
+    if metadata.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File size exceeds limit of {} bytes", limit)
+        ));
+    }
+
+    let mut content = String::new();
+    file.take(limit + 1).read_to_string(&mut content)?;
+
+    if content.len() as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File content exceeds limit of {} bytes", limit)
+        ));
+    }
+
+    Ok(content)
+}
+
 pub fn create_tokio_runtime() -> Result<Runtime> {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -64,4 +64,14 @@ mod tests {
         assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
         assert!(err.to_string().contains("size exceeds limit"));
     }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_to_string_with_limit_content_exceeded() {
+        // We need a file where metadata.len() is 0 but it has content.
+        // /dev/zero is perfect for this, but we only want to read up to limit + 1
+        let err = read_to_string_with_limit("/dev/zero", 5).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("content exceeds limit"));
+    }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The CLI was using unbounded `std::fs::read_to_string` to read user-provided configuration files and plugin manifests. This left the application vulnerable to Denial of Service (DoS) attacks via memory exhaustion (OOM), especially if an attacker provided an artificially large file or a pseudo-file (e.g., from `/dev/zero`) that reports a size of 0 but streams unbounded bytes.
🎯 **Impact:** An attacker could crash the CLI process by causing it to run out of memory.
🔧 **Fix:** 
1. Added a custom `read_to_string_with_limit` utility function in `crates/tsuzulint_cli/src/utils/mod.rs` to enforce a hard memory limit. This uses `.take(limit + 1)` during the read to handle pseudo-file bypasses.
2. Replaced `std::fs::read_to_string` with `crate::utils::read_to_string_with_limit` (with a 1MB limit) in `load_manifest` (`crates/tsuzulint_cli/src/commands/rules.rs`) and `update_config_with_plugin` (`crates/tsuzulint_cli/src/config/editor.rs`). Tests were left untouched as they operate on trusted fixtures.
✅ **Verification:**
1. Ran `cargo check -p tsuzulint` to ensure successful compilation.
2. Verified unit tests pass with `cargo test --workspace --all-features`.
3. Deleted temporary build artifacts.

---
*PR created automatically by Jules for task [4871276343034270936](https://jules.google.com/task/4871276343034270936) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Improvements**
  * ルールマニフェストとコンフィグファイルの読み込みにサイズ上限（1MiB）を追加。過度なメモリ消費を防ぎ、システムの安定性とセキュリティを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->