### PR TITLE
🦀 Ferris: [refactor] Remove unnecessary string allocation in config tests

### DIFF
--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -461,7 +461,7 @@ mod tests {
         assert!(
             msg.contains("Refusing to modify configuration file because it is a symbolic link")
         );
-        assert!(msg.contains(&symlink_path.to_string_lossy().to_string()));
+        assert!(msg.contains(symlink_path.to_string_lossy().as_ref()));
 
         let target_content = std::fs::read(target_path).unwrap();
         assert!(


### PR DESCRIPTION
💡 Improvement: Replaced `symlink_path.to_string_lossy().to_string()` with `symlink_path.to_string_lossy().as_ref()` in test assertions inside `crates/tsuzulint_cli/src/config/editor.rs`.

🦀 Why: `to_string_lossy()` returns a `Cow<str>`. Calling `.to_string()` on it consumes the `Cow` and forces an unnecessary heap allocation to create an owned `String`. By using `.as_ref()`, we cheaply borrow the `Cow` as a `&str`, which `msg.contains()` natively accepts, achieving the exact same result efficiently and idiomatically.

🔍 Verification:
- Ran `cargo test --workspace --all-features` successfully.
- Verified `make fmt-check` and `make lint` pass without errors.

---
*PR created automatically by Jules for task [11933057146474877105](https://jules.google.com/task/11933057146474877105) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト内部のコード最適化を実施しました。

**ユーザー向けの変更はありません。**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->