### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unbounded File Reads in CLI

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -45,3 +45,40 @@ pub fn read_to_string_with_limit(path: &Path, limit: u64) -> std::io::Result<Str
     }
     Ok(content)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"hello world").unwrap();
+        let content = read_to_string_with_limit(file.path(), 100).unwrap();
+        assert_eq!(content, "hello world");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_exceeds_metadata_limit() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"hello world").unwrap();
+        let err = read_to_string_with_limit(file.path(), 5).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds size limit"));
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_exceeds_read_limit() {
+        // We can simulate an issue where metadata lies or we just want to test the pseudo-file path
+        // Actually, since we check metadata first, testing the second check is tricky with regular files.
+        // But we can test it using /dev/zero on unix.
+        #[cfg(unix)]
+        {
+            let err = read_to_string_with_limit(Path::new("/dev/zero"), 5).unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+            assert!(err.to_string().contains("exceeds size limit"));
+        }
+    }
+}

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -1,6 +1,9 @@
 //! CLI utility functions
 
 use miette::{IntoDiagnostic, Result};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
 use tokio::runtime::Runtime;
 
 pub fn create_tokio_runtime() -> Result<Runtime> {
@@ -8,4 +11,37 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .enable_all()
         .build()
         .into_diagnostic()
+}
+
+/// Reads a file to a string, returning an error if its size exceeds the limit.
+pub fn read_to_string_with_limit(path: &Path, limit: u64) -> std::io::Result<String> {
+    let file = File::open(path)?;
+    let metadata = file.metadata()?;
+
+    if metadata.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "File {} exceeds size limit of {} bytes",
+                path.display(),
+                limit
+            ),
+        ));
+    }
+
+    let capacity = (metadata.len() as usize).min(limit as usize);
+    let mut content = String::with_capacity(capacity);
+    file.take(limit + 1).read_to_string(&mut content)?;
+
+    if content.len() as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "File {} exceeds size limit of {} bytes",
+                path.display(),
+                limit
+            ),
+        ));
+    }
+    Ok(content)
 }


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Unbounded file reads in `load_manifest` and configuration editor using `std::fs::read_to_string`. Maliciously large configuration or manifest files, or pseudo-files (like `/dev/zero`), could be read entirely into memory leading to Out-Of-Memory (OOM) crashes and Denial of Service (DoS) (CWE-400).
🎯 **Impact**: Potential application crash/DoS if pointed to an arbitrarily large file.
🔧 **Fix**: Introduced `crate::utils::read_to_string_with_limit` that performs bounded reads enforcing a 1MB limit. This explicitly checks metadata upfront and safely caps the maximum number of read bytes to `limit + 1`, successfully stopping the execution if limits are breached.
✅ **Verification**: Tests have been successfully run passing memory limits successfully.

---
*PR created automatically by Jules for task [7615061363107181703](https://jules.google.com/task/7615061363107181703) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ルールマニフェストと設定ファイルの読み込み時に、1MBのサイズ上限を設定し、過度に大きいファイルによるメモリ問題を防止するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->