### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unbounded file reads in CLI

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }
@@ -537,7 +538,11 @@ mod manifest_tests {
         assert!(target_dir.join("tsuzulint-rule.json").exists());
 
         let saved_manifest: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(target_dir.join("tsuzulint-rule.json")).unwrap(),
+            &crate::utils::read_to_string_with_limit(
+                target_dir.join("tsuzulint-rule.json"),
+                1024 * 1024,
+            )
+            .unwrap(),
         )
         .unwrap();
 
@@ -594,7 +599,11 @@ mod manifest_tests {
         assert!(result.is_ok());
 
         let saved_manifest: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(target_dir.join("tsuzulint-rule.json")).unwrap(),
+            &crate::utils::read_to_string_with_limit(
+                target_dir.join("tsuzulint-rule.json"),
+                1024 * 1024,
+            )
+            .unwrap(),
         )
         .unwrap();
 

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();
@@ -310,7 +311,7 @@ mod tests {
 
         update_config_with_plugin(&spec, alias, &manifest, Some(path.clone())).unwrap();
 
-        let content = std::fs::read_to_string(&path).unwrap();
+        let content = crate::utils::read_to_string_with_limit(&path, 1024 * 1024).unwrap();
         let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
 
         let rules = json["rules"].as_array().expect("rules should be an array");
@@ -348,7 +349,7 @@ mod tests {
 
         update_config_with_plugin(&spec, alias, &manifest, Some(path.clone())).unwrap();
 
-        let content = std::fs::read_to_string(&path).unwrap();
+        let content = crate::utils::read_to_string_with_limit(&path, 1024 * 1024).unwrap();
         let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
 
         let rules = json["rules"].as_array().expect("rules should be an array");
@@ -384,7 +385,7 @@ mod tests {
 
         update_config_with_plugin(&spec, alias, &manifest, Some(path.clone())).unwrap();
 
-        let content = std::fs::read_to_string(&path).unwrap();
+        let content = crate::utils::read_to_string_with_limit(&path, 1024 * 1024).unwrap();
         let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
 
         assert_eq!(json["options"]["existing"], true);
@@ -419,7 +420,7 @@ mod tests {
 
         update_config_with_plugin(&spec, alias, &manifest, Some(path.clone())).unwrap();
 
-        let content = std::fs::read_to_string(&path).unwrap();
+        let content = crate::utils::read_to_string_with_limit(&path, 1024 * 1024).unwrap();
         let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
 
         let rules = json["rules"].as_array().unwrap();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -39,3 +39,41 @@ pub fn read_to_string_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> std::io
 
     Ok(buffer)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_success() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "hello world").unwrap();
+        let path = file.path();
+
+        let result = read_to_string_with_limit(path, 100).unwrap();
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_read_metadata_limit_exceeded() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "hello world").unwrap(); // 11 bytes
+        let path = file.path();
+
+        let err = read_to_string_with_limit(path, 5).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds size limit"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_stream_limit_exceeded() {
+        // /dev/zero has 0 metadata length but infinite stream
+        let path = Path::new("/dev/zero");
+        let err = read_to_string_with_limit(path, 100).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("File stream exceeds size limit"));
+    }
+}

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -1,6 +1,9 @@
 //! CLI utility functions
 
 use miette::{IntoDiagnostic, Result};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
 use tokio::runtime::Runtime;
 
 pub fn create_tokio_runtime() -> Result<Runtime> {
@@ -8,4 +11,31 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .enable_all()
         .build()
         .into_diagnostic()
+}
+
+/// Reads a file to a string, enforcing a maximum size limit to prevent memory exhaustion.
+pub fn read_to_string_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> std::io::Result<String> {
+    let mut file = File::open(path)?;
+    let metadata = file.metadata()?;
+
+    // Check initial metadata size
+    if metadata.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File exceeds size limit of {} bytes", limit),
+        ));
+    }
+
+    // Check actual read size to prevent pseudo-file bypasses (like /dev/zero)
+    let mut buffer = String::new();
+    file.by_ref().take(limit + 1).read_to_string(&mut buffer)?;
+
+    if buffer.len() as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File stream exceeds size limit of {} bytes", limit),
+        ));
+    }
+
+    Ok(buffer)
 }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unbounded file reads via `std::fs::read_to_string` on potentially user-provided files (manifests/configs) could lead to memory exhaustion and Denial of Service (DoS).
🎯 **Impact:** An attacker could craft an excessively large (or infinite, via pseudo-files) configuration or manifest file, causing the CLI to exhaust available memory and crash.
🔧 **Fix:** Introduced a new bounded read utility `utils::read_to_string_with_limit` (with a safe 1MB default for JSON files) and replaced vulnerable calls to `std::fs::read_to_string` in `rules.rs` and `editor.rs`. The new function validates metadata bounds and actively enforces the limit during stream processing.
✅ **Verification:** Verified by running the test suite (`make test`), lint checks (`make lint`), and formatting checks (`make fmt-check`). All pass. Unit test cases already operate safely on localized fixtures.

---
*PR created automatically by Jules for task [4013322471127031750](https://jules.google.com/task/4013322471127031750) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ファイル読み込み機能を改善し、サイズチェック機能を追加しました。設定ファイルとマニフェストファイルの読み込み時に 1 MB のサイズ制限を実装することで、システムの安定性と信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->