### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unbounded file read memory exhaustion vulnerability

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -34,3 +34,49 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .build()
         .into_diagnostic()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_within_limit() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "hello").unwrap();
+        let content = read_to_string_with_limit(file.path(), 10).unwrap();
+        assert_eq!(content, "hello");
+    }
+
+    #[test]
+    fn test_read_exact_limit() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "hello").unwrap();
+        let content = read_to_string_with_limit(file.path(), 5).unwrap();
+        assert_eq!(content, "hello");
+    }
+
+    #[test]
+    fn test_read_exceeds_limit() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "hello world").unwrap();
+        let err = read_to_string_with_limit(file.path(), 5).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string()
+                .contains("File size exceeds limit of 5 bytes")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_pseudo_file_bounded() {
+        // /dev/zero is infinite. If the read is bounded correctly, it will
+        // hit the limit and return an error rather than looping infinitely.
+        let path = Path::new("/dev/zero");
+        let err = read_to_string_with_limit(path, 10).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds limit"));
+    }
+}

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -1,7 +1,32 @@
 //! CLI utility functions
 
 use miette::{IntoDiagnostic, Result};
+use std::io::Read;
+use std::path::Path;
 use tokio::runtime::Runtime;
+
+/// Reads up to `limit + 1` bytes from the file at `path`.
+/// Returns an error if the file exceeds `limit` bytes or cannot be read.
+pub fn read_to_string_with_limit(path: &Path, limit: u64) -> std::io::Result<String> {
+    let file = std::fs::File::open(path)?;
+    let capacity_hint = file.metadata().map(|m| m.len()).unwrap_or(0).min(limit) as usize;
+
+    let mut content = String::with_capacity(capacity_hint);
+    file.take(limit + 1).read_to_string(&mut content)?;
+
+    if content.len() as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "File size exceeds limit of {} bytes: {}",
+                limit,
+                path.display()
+            ),
+        ));
+    }
+
+    Ok(content)
+}
 
 pub fn create_tokio_runtime() -> Result<Runtime> {
     tokio::runtime::Builder::new_multi_thread()


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `std::fs::read_to_string` was used to load configuration files and manifests, making the CLI susceptible to memory exhaustion DoS if provided with overly large files or pseudo-files.
🎯 Impact: An attacker could crash the process or exhaust system resources by pointing the CLI at a maliciously large file or `/dev/zero`.
🔧 Fix: Implemented `read_to_string_with_limit` bounding the input to 1MB and replaced `std::fs::read_to_string`.
✅ Verification: Ran `cargo check`, `make test`, `make fmt-check`, and `make lint`.

---
*PR created automatically by Jules for task [15688307156815385802](https://jules.google.com/task/15688307156815385802) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * マニフェストファイルおよび設定ファイルの読み込み処理に最大ファイルサイズ制限（1 MiB）を導入しました。この制限を超えるサイズのファイルは読み込みが拒否され、エラーメッセージとともに処理が中断されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->