### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded file reads in tsuzulint_cli

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,7 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024).map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }
@@ -537,7 +537,7 @@ mod manifest_tests {
         assert!(target_dir.join("tsuzulint-rule.json").exists());
 
         let saved_manifest: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(target_dir.join("tsuzulint-rule.json")).unwrap(),
+            &crate::utils::read_to_string_with_limit(&target_dir.join("tsuzulint-rule.json"), 1024 * 1024).unwrap(),
         )
         .unwrap();
 
@@ -594,7 +594,7 @@ mod manifest_tests {
         assert!(result.is_ok());
 
         let saved_manifest: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(target_dir.join("tsuzulint-rule.json")).unwrap(),
+            &crate::utils::read_to_string_with_limit(&target_dir.join("tsuzulint-rule.json"), 1024 * 1024).unwrap(),
         )
         .unwrap();
 

--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }
@@ -537,7 +538,11 @@ mod manifest_tests {
         assert!(target_dir.join("tsuzulint-rule.json").exists());
 
         let saved_manifest: serde_json::Value = serde_json::from_str(
-            &crate::utils::read_to_string_with_limit(&target_dir.join("tsuzulint-rule.json"), 1024 * 1024).unwrap(),
+            &crate::utils::read_to_string_with_limit(
+                &target_dir.join("tsuzulint-rule.json"),
+                1024 * 1024,
+            )
+            .unwrap(),
         )
         .unwrap();
 
@@ -594,7 +599,11 @@ mod manifest_tests {
         assert!(result.is_ok());
 
         let saved_manifest: serde_json::Value = serde_json::from_str(
-            &crate::utils::read_to_string_with_limit(&target_dir.join("tsuzulint-rule.json"), 1024 * 1024).unwrap(),
+            &crate::utils::read_to_string_with_limit(
+                &target_dir.join("tsuzulint-rule.json"),
+                1024 * 1024,
+            )
+            .unwrap(),
         )
         .unwrap();
 

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,7 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content = crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();
@@ -310,7 +310,7 @@ mod tests {
 
         update_config_with_plugin(&spec, alias, &manifest, Some(path.clone())).unwrap();
 
-        let content = std::fs::read_to_string(&path).unwrap();
+        let content = crate::utils::read_to_string_with_limit(&path, 1024 * 1024).unwrap();
         let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
 
         let rules = json["rules"].as_array().expect("rules should be an array");
@@ -348,7 +348,7 @@ mod tests {
 
         update_config_with_plugin(&spec, alias, &manifest, Some(path.clone())).unwrap();
 
-        let content = std::fs::read_to_string(&path).unwrap();
+        let content = crate::utils::read_to_string_with_limit(&path, 1024 * 1024).unwrap();
         let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
 
         let rules = json["rules"].as_array().expect("rules should be an array");
@@ -384,7 +384,7 @@ mod tests {
 
         update_config_with_plugin(&spec, alias, &manifest, Some(path.clone())).unwrap();
 
-        let content = std::fs::read_to_string(&path).unwrap();
+        let content = crate::utils::read_to_string_with_limit(&path, 1024 * 1024).unwrap();
         let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
 
         assert_eq!(json["options"]["existing"], true);
@@ -419,7 +419,7 @@ mod tests {
 
         update_config_with_plugin(&spec, alias, &manifest, Some(path.clone())).unwrap();
 
-        let content = std::fs::read_to_string(&path).unwrap();
+        let content = crate::utils::read_to_string_with_limit(&path, 1024 * 1024).unwrap();
         let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
 
         let rules = json["rules"].as_array().unwrap();

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -1,5 +1,8 @@
 //! CLI utility functions
 
+use std::fs;
+use std::io::Read;
+use std::path::Path;
 use miette::{IntoDiagnostic, Result};
 use tokio::runtime::Runtime;
 
@@ -8,4 +11,34 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .enable_all()
         .build()
         .into_diagnostic()
+}
+
+/// Reads up to `limit` bytes from a file.
+/// Protects against memory exhaustion vulnerabilities from arbitrarily large files
+/// or pseudo-files like /dev/zero.
+pub fn read_to_string_with_limit(path: &Path, limit: u64) -> std::io::Result<String> {
+    let mut file = fs::File::open(path)?;
+    let meta = file.metadata()?;
+
+    // Check initial reported metadata length if it's a regular file
+    if meta.is_file() && meta.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File exceeds size limit of {} bytes", limit),
+        ));
+    }
+
+    // Read up to limit + 1 bytes to accurately detect if it's too large,
+    // which protects against /dev/zero and similar pseudo-files that report size 0
+    let mut buf = String::new();
+    let read_size = file.by_ref().take(limit + 1).read_to_string(&mut buf)?;
+
+    if read_size as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File exceeds size limit of {} bytes", limit),
+        ));
+    }
+
+    Ok(buf)
 }

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -1,9 +1,9 @@
 //! CLI utility functions
 
+use miette::{IntoDiagnostic, Result};
 use std::fs;
 use std::io::Read;
 use std::path::Path;
-use miette::{IntoDiagnostic, Result};
 use tokio::runtime::Runtime;
 
 pub fn create_tokio_runtime() -> Result<Runtime> {
@@ -67,7 +67,12 @@ mod tests {
 
         let result = read_to_string_with_limit(path, 4);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("exceeds size limit"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds size limit")
+        );
     }
 
     #[test]
@@ -78,6 +83,11 @@ mod tests {
         // It should then be caught by the limit + 1 byte read check.
         let result = read_to_string_with_limit(path, 10);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("exceeds size limit"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds size limit")
+        );
     }
 }

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -42,3 +42,42 @@ pub fn read_to_string_with_limit(path: &Path, limit: u64) -> std::io::Result<Str
 
     Ok(buf)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "hello").unwrap();
+        let path = temp_file.path();
+
+        let result = read_to_string_with_limit(path, 100).unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_exceeds_metadata_limit() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "123456789").unwrap();
+        let path = temp_file.path();
+
+        let result = read_to_string_with_limit(path, 4);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds size limit"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_to_string_with_limit_pseudo_file() {
+        let path = Path::new("/dev/zero");
+        // /dev/zero will report 0 size, so it will bypass the metadata check.
+        // It should then be caught by the limit + 1 byte read check.
+        let result = read_to_string_with_limit(path, 10);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeds size limit"));
+    }
+}


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `std::fs::read_to_string` loads files directly into memory endlessly, making the app vulnerable to memory exhaustion DoS if parsing pseudo-files like `/dev/zero` or maliciously large manifest/config files.
🎯 Impact: An attacker or a misconfigured filesystem with infinite pseudo-files could crash the application by depleting system memory entirely.
🔧 Fix: Implemented `crate::utils::read_to_string_with_limit` using `File::take(limit + 1)` limiting memory reads to 1MB bounds for configuration files.
✅ Verification: `cargo test` passing. Reviewed tests successfully ensuring limit constraints function properly.

---
*PR created automatically by Jules for task [3427149539910804218](https://jules.google.com/task/3427149539910804218) started by @simorgh3196*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/simorgh3196/tsuzulint/pull/357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 安全なファイル読み取り機能を追加し、読み込み時にサイズ上限の検出と制限を行います。
* **バグ修正**
  * マニフェストおよび設定ファイル読み込みで1MBのサイズ上限チェックと明確なエラーメッセージを導入し、極端に大きいファイルや擬似ファイルによるリソース問題を防止します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/357)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->