### PR TITLE
🛡️ Sentinel: [HIGH] Fix unbounded file reads in configurations and manifests

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -3,6 +3,9 @@
 use miette::{IntoDiagnostic, Result};
 use tokio::runtime::Runtime;
 
+pub mod safe_io;
+pub use safe_io::read_to_string_with_limit;
+
 pub fn create_tokio_runtime() -> Result<Runtime> {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/crates/tsuzulint_cli/src/utils/safe_io.rs
+++ b/crates/tsuzulint_cli/src/utils/safe_io.rs
@@ -1,0 +1,60 @@
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::Path;
+
+pub fn read_to_string_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> io::Result<String> {
+    let file = File::open(path)?;
+    let metadata = file.metadata()?;
+
+    if metadata.len() > limit {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("File exceeds size limit of {} bytes", limit),
+        ));
+    }
+
+    let mut content = String::new();
+    file.take(limit + 1).read_to_string(&mut content)?;
+
+    if content.len() as u64 > limit {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("File exceeds size limit of {} bytes", limit),
+        ));
+    }
+
+    Ok(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "hello").unwrap();
+
+        let content = read_to_string_with_limit(file.path(), 10).unwrap();
+        assert_eq!(content, "hello");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_exceeded() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "hello world").unwrap();
+
+        let result = read_to_string_with_limit(file.path(), 5);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_to_string_with_limit_dev_zero() {
+        // Test pseudo-files which have size 0 but produce infinite data.
+        let result = read_to_string_with_limit("/dev/zero", 5);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Memory exhaustion via unbounded file reads for manifests and config files.
🎯 Impact: Using excessively large files (or pseudo files) could crash the application by consuming available memory.
🔧 Fix: Introduced `read_to_string_with_limit` and replaced all susceptible `fs::read_to_string` instances when processing user-supplied config or rule manifests.
✅ Verification: Ran unit tests covering `safe_io` and existing manifest reading behavior successfully.

---
*PR created automatically by Jules for task [10153609701290486854](https://jules.google.com/task/10153609701290486854) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **リファクタリング**
  * 設定ファイルとマニフェストファイルの読み込み処理に最大サイズ制限を導入し、ファイル操作の安全性と信頼性を向上させました。予期しない大きなファイルによる問題を防ぎます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->