### PR TITLE
⚡ Bolt: [performance improvement] eliminate String clones in rule timing aggregation

### DIFF
--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -60,11 +60,11 @@ pub fn output_text(results: &[LintResult], timings: bool) {
 
 fn output_timings(results: &[LintResult]) {
     let mut total_duration = Duration::new(0, 0);
-    let mut rule_timings: HashMap<String, Duration> = HashMap::new();
+    let mut rule_timings: HashMap<&str, Duration> = HashMap::new();
 
     for result in results {
         for (rule, duration) in &result.timings {
-            *rule_timings.entry(rule.clone()).or_default() += *duration;
+            *rule_timings.entry(rule.as_str()).or_default() += *duration;
             total_duration += *duration;
         }
     }

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -18,6 +18,15 @@ pub(crate) fn count_displayable_issues(results: &[LintResult]) -> usize {
 }
 
 pub fn output_text(results: &[LintResult], timings: bool) {
+    let mut stdout = std::io::stdout();
+    let _ = output_text_to(&mut stdout, results, timings);
+}
+
+pub(crate) fn output_text_to<W: std::io::Write>(
+    mut writer: W,
+    results: &[LintResult],
+    timings: bool,
+) -> std::io::Result<()> {
     for result in results {
         let displayable_diags: Vec<_> = result
             .diagnostics
@@ -29,17 +38,18 @@ pub fn output_text(results: &[LintResult], timings: bool) {
             continue;
         }
 
-        println!("\n{}:", result.path.display());
+        writeln!(writer, "\n{}:", result.path.display())?;
         for diag in displayable_diags {
             let severity = match diag.severity {
                 Severity::Error => "error",
                 Severity::Warning => "warning",
                 Severity::Info => "info",
             };
-            println!(
+            writeln!(
+                writer,
                 "  {}:{} {} [{}]: {}",
                 diag.span.start, diag.span.end, severity, diag.rule_id, diag.message
-            );
+            )?;
         }
     }
 
@@ -47,18 +57,21 @@ pub fn output_text(results: &[LintResult], timings: bool) {
     let total_issues = count_displayable_issues(results);
     let cached = results.iter().filter(|r| r.from_cache).count();
 
-    println!();
-    println!(
+    writeln!(writer)?;
+    writeln!(
+        writer,
         "Checked {} files ({} from cache), found {} issues",
         total_files, cached, total_issues
-    );
+    )?;
 
     if timings {
-        output_timings(results);
+        output_timings_to(&mut writer, results)?;
     }
+
+    Ok(())
 }
 
-fn output_timings(results: &[LintResult]) {
+fn output_timings_to<W: std::io::Write>(mut writer: W, results: &[LintResult]) -> std::io::Result<()> {
     let mut total_duration = Duration::new(0, 0);
     let mut rule_timings: HashMap<&str, Duration> = HashMap::new();
 
@@ -70,9 +83,9 @@ fn output_timings(results: &[LintResult]) {
     }
 
     if !rule_timings.is_empty() {
-        println!("\nPerformance Timings:");
-        println!("{:<30} | {:<15} | {:<10}", "Rule", "Duration", "%");
-        println!("{:-<30}-+-{:-<15}-+-{:-<10}", "", "", "");
+        writeln!(writer, "\nPerformance Timings:")?;
+        writeln!(writer, "{:<30} | {:<15} | {:<10}", "Rule", "Duration", "%")?;
+        writeln!(writer, "{:-<30}-+-{:-<15}-+-{:-<10}", "", "", "")?;
 
         let mut sorted_timings: Vec<_> = rule_timings.into_iter().collect();
         sorted_timings.sort_by(|a, b| b.1.cmp(&a.1));
@@ -83,11 +96,13 @@ fn output_timings(results: &[LintResult]) {
             } else {
                 0.0
             };
-            println!("{:<30} | {:<15?} | {:<10.1}%", rule, duration, percentage);
+            writeln!(writer, "{:<30} | {:<15?} | {:<10.1}%", rule, duration, percentage)?;
         }
-        println!("{:-<30}-+-{:-<15}-+-{:-<10}", "", "", "");
-        println!("{:<30} | {:<15?}", "Total", total_duration);
+        writeln!(writer, "{:-<30}-+-{:-<15}-+-{:-<10}", "", "", "")?;
+        writeln!(writer, "{:<30} | {:<15?}", "Total", total_duration)?;
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -126,5 +141,44 @@ mod tests {
 
         // We only expect 1 displayable issue (the Certain one)
         assert_eq!(count_displayable_issues(&[result]), 1);
+    }
+
+    #[test]
+    fn test_output_text_to_basic() {
+        let mut buf = Vec::new();
+        let result = LintResult {
+            path: PathBuf::from("test.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings: HashMap::new(),
+        };
+
+        super::output_text_to(&mut buf, &[result], false).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("Checked 1 files (0 from cache), found 0 issues"));
+        assert!(!out.contains("Performance Timings"));
+    }
+
+    #[test]
+    fn test_output_text_to_with_timings() {
+        let mut buf = Vec::new();
+        let mut timings = HashMap::new();
+        timings.insert("rule-a".to_string(), std::time::Duration::from_millis(50));
+        timings.insert("rule-b".to_string(), std::time::Duration::from_millis(150));
+
+        let result = LintResult {
+            path: PathBuf::from("test.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings,
+        };
+
+        super::output_text_to(&mut buf, &[result], true).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("Checked 1 files (0 from cache), found 0 issues"));
+        assert!(out.contains("Performance Timings:"));
+        assert!(out.contains("rule-a"));
+        assert!(out.contains("rule-b"));
+        assert!(out.contains("Total"));
     }
 }

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -188,4 +188,48 @@ mod tests {
         assert!(out.contains("rule-b"));
         assert!(out.contains("Total"));
     }
+
+    #[test]
+    fn test_output_text_to_with_diagnostics() {
+        let mut buf = Vec::new();
+
+        let diag: Diagnostic = serde_json::from_value(serde_json::json!({
+            "rule_id": "rule-err",
+            "message": "this is an error",
+            "span": { "start": 10, "end": 20 },
+            "severity": "error",
+            "certainty": "certain"
+        })).unwrap();
+
+        let diag_warn: Diagnostic = serde_json::from_value(serde_json::json!({
+            "rule_id": "rule-warn",
+            "message": "this is a warning",
+            "span": { "start": 30, "end": 40 },
+            "severity": "warning",
+            "certainty": "certain"
+        })).unwrap();
+
+        let diag_info: Diagnostic = serde_json::from_value(serde_json::json!({
+            "rule_id": "rule-info",
+            "message": "this is info",
+            "span": { "start": 50, "end": 60 },
+            "severity": "info",
+            "certainty": "certain"
+        })).unwrap();
+
+        let result = LintResult {
+            path: PathBuf::from("test.md"),
+            diagnostics: vec![diag, diag_warn, diag_info],
+            from_cache: true,
+            timings: HashMap::new(),
+        };
+
+        super::output_text_to(&mut buf, &[result], false).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("test.md:"));
+        assert!(out.contains("10:20 error [rule-err]: this is an error"));
+        assert!(out.contains("30:40 warning [rule-warn]: this is a warning"));
+        assert!(out.contains("50:60 info [rule-info]: this is info"));
+        assert!(out.contains("Checked 1 files (1 from cache), found 3 issues"));
+    }
 }

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -71,7 +71,10 @@ pub(crate) fn output_text_to<W: std::io::Write>(
     Ok(())
 }
 
-fn output_timings_to<W: std::io::Write>(mut writer: W, results: &[LintResult]) -> std::io::Result<()> {
+fn output_timings_to<W: std::io::Write>(
+    mut writer: W,
+    results: &[LintResult],
+) -> std::io::Result<()> {
     let mut total_duration = Duration::new(0, 0);
     let mut rule_timings: HashMap<&str, Duration> = HashMap::new();
 
@@ -96,7 +99,11 @@ fn output_timings_to<W: std::io::Write>(mut writer: W, results: &[LintResult]) -
             } else {
                 0.0
             };
-            writeln!(writer, "{:<30} | {:<15?} | {:<10.1}%", rule, duration, percentage)?;
+            writeln!(
+                writer,
+                "{:<30} | {:<15?} | {:<10.1}%",
+                rule, duration, percentage
+            )?;
         }
         writeln!(writer, "{:-<30}-+-{:-<15}-+-{:-<10}", "", "", "")?;
         writeln!(writer, "{:<30} | {:<15?}", "Total", total_duration)?;

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -199,7 +199,8 @@ mod tests {
             "span": { "start": 10, "end": 20 },
             "severity": "error",
             "certainty": "certain"
-        })).unwrap();
+        }))
+        .unwrap();
 
         let diag_warn: Diagnostic = serde_json::from_value(serde_json::json!({
             "rule_id": "rule-warn",
@@ -207,7 +208,8 @@ mod tests {
             "span": { "start": 30, "end": 40 },
             "severity": "warning",
             "certainty": "certain"
-        })).unwrap();
+        }))
+        .unwrap();
 
         let diag_info: Diagnostic = serde_json::from_value(serde_json::json!({
             "rule_id": "rule-info",
@@ -215,7 +217,8 @@ mod tests {
             "span": { "start": 50, "end": 60 },
             "severity": "info",
             "certainty": "certain"
-        })).unwrap();
+        }))
+        .unwrap();
 
         let result = LintResult {
             path: PathBuf::from("test.md"),


### PR DESCRIPTION
💡 What: Changed the key type of the `rule_timings` hash map in `crates/tsuzulint_cli/src/output/text.rs` from `String` to `&str`, preventing `rule.clone()` inside the `.entry()` lookup loop.

🎯 Why: The previous code, `*rule_timings.entry(rule.clone()).or_default() += *duration`, forced a `String` allocation for every timing metric of every rule of every file linted. This was pure overhead, as the `&String` slice could just be borrowed from the `LintResult` directly.

📊 Impact: Reduces memory overhead and garbage collection pressure at the end of large lint runs. Eliminates `O(Files * Rules)` heap allocations.

🔬 Measurement: Run a large project lint with performance timings enabled and trace heap allocations, or observe reduced peak memory usage in CLI profiles. All existing functionality and outputs remain identical.

---
*PR created automatically by Jules for task [17336859400455150410](https://jules.google.com/task/17336859400455150410) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * テキスト出力を内部的に再構成し、出力の生成と書き込みがより安定・一貫的になりました。
* **表示改善**
  * ファイル別の診断表示とチェック済みファイルのサマリが整形されて出力されます。
  * 性能タイミング表示の集計・並び替えが改善され、タイミング表示の有効/無効を切替可能です。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->