### PR TITLE
⚡ Bolt: Remove unnecessary String clone in CLI timing output

### DIFF
--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -60,11 +60,11 @@ pub fn output_text(results: &[LintResult], timings: bool) {
 
 fn output_timings(results: &[LintResult]) {
     let mut total_duration = Duration::new(0, 0);
-    let mut rule_timings: HashMap<String, Duration> = HashMap::new();
+    let mut rule_timings: HashMap<&str, Duration> = HashMap::new();
 
     for result in results {
         for (rule, duration) in &result.timings {
-            *rule_timings.entry(rule.clone()).or_default() += *duration;
+            *rule_timings.entry(rule.as_str()).or_default() += *duration;
             total_duration += *duration;
         }
     }

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -97,6 +97,8 @@ mod tests {
     use std::path::PathBuf;
     use tsuzulint_core::{Diagnostic, LintResult};
 
+    use super::output_timings;
+
     #[test]
     fn test_count_displayable_issues() {
         let diag1: Diagnostic = serde_json::from_value(serde_json::json!({
@@ -126,5 +128,41 @@ mod tests {
 
         // We only expect 1 displayable issue (the Certain one)
         assert_eq!(count_displayable_issues(&[result]), 1);
+    }
+
+    #[test]
+    fn test_output_timings() {
+        let mut timings1 = HashMap::new();
+        timings1.insert("rule1".to_string(), std::time::Duration::from_millis(100));
+        timings1.insert("rule2".to_string(), std::time::Duration::from_millis(50));
+
+        let mut timings2 = HashMap::new();
+        timings2.insert("rule1".to_string(), std::time::Duration::from_millis(150));
+        timings2.insert("rule3".to_string(), std::time::Duration::from_millis(10));
+
+        let result1 = LintResult {
+            path: PathBuf::from("test1.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings: timings1,
+        };
+        let result2 = LintResult {
+            path: PathBuf::from("test2.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings: timings2,
+        };
+
+        // Just call it to ensure it doesn't panic and to get coverage on the lines
+        output_timings(&[result1, result2]);
+
+        // Also test with empty timings to hit the `!rule_timings.is_empty()` branch
+        let empty_result = LintResult {
+            path: PathBuf::from("test3.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings: HashMap::new(),
+        };
+        output_timings(&[empty_result]);
     }
 }


### PR DESCRIPTION
💡 **What:** 
Updated `text::output_timings` in `crates/tsuzulint_cli/src/output/text.rs` to use `&str` instead of `String` for the `rule_timings` HashMap key type. 

🎯 **Why:** 
The previous implementation used `HashMap::entry(rule.clone())` inside a loop where `rule` was already a borrowed string from `&result.timings`. This forced a heap allocation (`String` creation) on every single iteration of the loop, even if the rule already existed in the map. Using `&str` avoids these redundant allocations since the borrowed string easily outlives the scope of the function.

📊 **Impact:** 
Eliminates O(N) heap allocations during the timing aggregation loop, where N is the total number of rules executed across all linted files. Improves memory efficiency and slightly speeds up the text formatting phase, particularly noticeable on large codebases with many files and rules.

🔬 **Measurement:** 
Run the CLI over a large codebase with the `--timings` flag enabled. Memory profiling will show fewer `String` allocations originating from `text::output_timings`. Verified via `cargo test`, `make fmt-check`, and `make lint`.

---
*PR created automatically by Jules for task [1908884527841649273](https://jules.google.com/task/1908884527841649273) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * ルールタイミング計算の処理効率を向上させ、不要なメモリ割り当てを削減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->