### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unbounded file read vulnerabilities

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = crate::utils::read_to_string_with_limit(path, None).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, None)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,7 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, None).map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,7 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content = crate::utils::read_to_string_with_limit(&path_to_use, None).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -26,13 +26,13 @@ pub fn read_to_string_with_limit<P: AsRef<Path>>(
     let mut content = String::new();
 
     // Check metadata len first as a fast path
-    if let Ok(metadata) = file.metadata() {
-        if metadata.len() > limit as u64 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("File too large. Exceeds {} byte limit", limit),
-            ));
-        }
+    if let Ok(metadata) = file.metadata()
+        && metadata.len() > limit as u64
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File too large. Exceeds {} byte limit", limit),
+        ));
     }
 
     file.take((limit + 1) as u64).read_to_string(&mut content)?;

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -9,3 +9,70 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .build()
         .into_diagnostic()
 }
+
+use std::path::Path;
+
+/// Reads a file to a string with a size limit (default 1MB if none provided).
+/// Prevents memory exhaustion when parsing malicious or enormous config files/manifests.
+pub fn read_to_string_with_limit<P: AsRef<Path>>(
+    path: P,
+    limit_bytes: Option<usize>,
+) -> std::io::Result<String> {
+    use std::fs::File;
+    use std::io::Read;
+
+    let limit = limit_bytes.unwrap_or(1024 * 1024); // 1MB default
+    let file = File::open(path)?;
+    let mut content = String::new();
+
+    // Check metadata len first as a fast path
+    if let Ok(metadata) = file.metadata() {
+        if metadata.len() > limit as u64 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("File too large. Exceeds {} byte limit", limit),
+            ));
+        }
+    }
+
+    file.take((limit + 1) as u64).read_to_string(&mut content)?;
+
+    if content.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File too large. Exceeds {} byte limit", limit),
+        ));
+    }
+
+    Ok(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hello world").unwrap();
+        let res = read_to_string_with_limit(tmp.path(), Some(100)).unwrap();
+        assert_eq!(res, "hello world");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_exceeds_metadata() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hello world").unwrap();
+        let err = read_to_string_with_limit(tmp.path(), Some(5)).unwrap_err();
+        assert!(err.to_string().contains("File too large"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_to_string_with_limit_pseudo_file() {
+        // pseudo-file /dev/zero has size 0 in metadata but infinite content
+        let err = read_to_string_with_limit("/dev/zero", Some(10)).unwrap_err();
+        assert!(err.to_string().contains("File too large"));
+    }
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The CLI configuration parser and the manifest loader previously read entire files into memory using `std::fs::read_to_string` without enforcing size limits. This created a potential Denial of Service (DoS) vulnerability via memory exhaustion if the linter was pointed to a maliciously crafted or arbitrarily large file (e.g. pseudo-files like `/dev/zero`).
🎯 Impact: An attacker or a misconfigured workspace could crash the linter and potentially the host machine by consuming all available system memory during the config or manifest loading phase.
🔧 Fix: Implemented `read_to_string_with_limit` in `crates/tsuzulint_cli/src/utils/mod.rs` to enforce a 1MB bound on reads, combining a fast-path metadata check with a streaming size limit (`.take()`) to safeguard against pseudo-files. Replaced `std::fs::read_to_string` at vulnerable call-sites.
✅ Verification: `cargo test` confirms the test suite remains completely green. Unit tests specifically validated the pseudo-file protection logic.

---
*PR created automatically by Jules for task [17792855070825882946](https://jules.google.com/task/17792855070825882946) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ファイル読み込み時のサイズ制限チェック機能を追加し、大きすぎるファイルの処理を防止しました。デフォルトの上限は1MBです。

* **テスト**
  * サイズ制限機能の動作を検証するユニットテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->