### PR TITLE
⚡ Bolt: Prevent heap allocation in text output formatter

### DIFF
--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -60,11 +60,11 @@ pub fn output_text(results: &[LintResult], timings: bool) {
 
 fn output_timings(results: &[LintResult]) {
     let mut total_duration = Duration::new(0, 0);
-    let mut rule_timings: HashMap<String, Duration> = HashMap::new();
+    let mut rule_timings: HashMap<&str, Duration> = HashMap::new();
 
     for result in results {
         for (rule, duration) in &result.timings {
-            *rule_timings.entry(rule.clone()).or_default() += *duration;
+            *rule_timings.entry(rule.as_str()).or_default() += *duration;
             total_duration += *duration;
         }
     }

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -127,4 +127,24 @@ mod tests {
         // We only expect 1 displayable issue (the Certain one)
         assert_eq!(count_displayable_issues(&[result]), 1);
     }
+
+    #[test]
+    fn test_output_timings_coverage() {
+        use super::output_timings;
+        use std::time::Duration;
+
+        let mut timings = HashMap::new();
+        timings.insert("rule1".to_string(), Duration::from_millis(100));
+        timings.insert("rule2".to_string(), Duration::from_millis(200));
+
+        let result = LintResult {
+            path: PathBuf::from("test.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings,
+        };
+
+        // Just ensure it doesn't panic and we cover the newly modified code path.
+        output_timings(&[result]);
+    }
 }


### PR DESCRIPTION
💡 What: Changed the HashMap key type in the CLI `output_timings` formatter from `String` to `&str`.
🎯 Why: Iterating over `result.timings` and using `rule.clone()` inside the loop was causing unnecessary heap allocations for every timing entry, impacting performance on linting runs with many rules/files.
📊 Impact: Reduces memory allocations and CPU overhead during CLI text output generation.
🔬 Measurement: Verified with `cargo check` and `cargo test`, avoiding string cloning without affecting visual output or test correctness.

---
*PR created automatically by Jules for task [3916672632389899248](https://jules.google.com/task/3916672632389899248) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストは内部の最適化を含んでおり、エンドユーザー向けの機能変更はありません。

* **Chores**
  * パフォーマンスタイミング集計ロジックを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->