### PR TITLE
🛡️ Sentinel: [HIGH] Fix memory exhaustion DoS vulnerability

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }
@@ -537,7 +538,11 @@ mod manifest_tests {
         assert!(target_dir.join("tsuzulint-rule.json").exists());
 
         let saved_manifest: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(target_dir.join("tsuzulint-rule.json")).unwrap(),
+            &crate::utils::read_to_string_with_limit(
+                &target_dir.join("tsuzulint-rule.json"),
+                1024 * 1024,
+            )
+            .unwrap(),
         )
         .unwrap();
 
@@ -594,7 +599,11 @@ mod manifest_tests {
         assert!(result.is_ok());
 
         let saved_manifest: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(target_dir.join("tsuzulint-rule.json")).unwrap(),
+            &crate::utils::read_to_string_with_limit(
+                &target_dir.join("tsuzulint-rule.json"),
+                1024 * 1024,
+            )
+            .unwrap(),
         )
         .unwrap();
 

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -9,3 +9,77 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .build()
         .into_diagnostic()
 }
+
+/// Reads the contents of a file to a string with a maximum size limit.
+/// Protects against memory exhaustion vulnerabilities from arbitrarily large files.
+/// Includes safeguards against pseudo-files (like /dev/zero) and concurrently growing files.
+pub fn read_to_string_with_limit(path: &std::path::Path, limit: u64) -> std::io::Result<String> {
+    use std::fs::File;
+    use std::io::{Error, ErrorKind, Read};
+
+    let file = File::open(path)?;
+    let metadata = file.metadata()?;
+
+    // Fast path: Check metadata if available and reliable
+    if metadata.len() > limit {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!(
+                "File too large. Size {} exceeds limit {}",
+                metadata.len(),
+                limit
+            ),
+        ));
+    }
+
+    // Slow path: Read with a strict bound (limit + 1 to detect overflow)
+    // This protects against files where metadata.len() is 0 or inaccurate (e.g., /dev/zero or /proc files)
+    let mut buffer = String::new();
+    file.take(limit + 1).read_to_string(&mut buffer)?;
+
+    if buffer.len() as u64 > limit {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            format!("File too large. Content exceeds limit {}", limit),
+        ));
+    }
+
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "hello world").unwrap();
+
+        let result = read_to_string_with_limit(temp_file.path(), 100).unwrap();
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_exceeds_metadata() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "hello world").unwrap();
+
+        // Limit is 5, but file is 11 bytes. Should fail fast on metadata check.
+        let err = read_to_string_with_limit(temp_file.path(), 5).unwrap_err();
+        assert!(err.to_string().contains("File too large"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_read_to_string_with_limit_pseudo_file() {
+        // /dev/zero has metadata.len() == 0, but provides infinite bytes.
+        // The .take(limit + 1) should catch it.
+        let path = std::path::Path::new("/dev/zero");
+
+        let err = read_to_string_with_limit(path, 10).unwrap_err();
+        assert!(err.to_string().contains("Content exceeds limit"));
+    }
+}


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Unbounded file reads using `std::fs::read_to_string` in the CLI (`commands/rules.rs` and `config/editor.rs`) allowed for memory exhaustion Denial of Service (DoS) attacks if a maliciously large file or pseudo-file (like `/dev/zero`) was processed as a configuration or manifest.
🎯 **Impact:** An attacker could crash the process (OOM) by supplying a large configuration file or symlinking `/dev/zero`.
🔧 **Fix:** Implemented a new `read_to_string_with_limit` utility function in `utils/mod.rs` with a fast-path metadata check and a slow-path `.take(limit + 1)` bound (1MB limit). Replaced all instances of `std::fs::read_to_string` for external file parsing with this safe, bounded version.
✅ **Verification:** Added dedicated unit tests (including a unix-specific pseudo-file test) to verify limit enforcement. Ran all tests (`cargo test --workspace --all-features`), verified formatting, and passed all linters.

---
*PR created automatically by Jules for task [9117928936947434809](https://jules.google.com/task/9117928936947434809) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
- ファイル読み込み処理にサイズ制限を実装しました

## テスト
- ファイル読み込みサイズ制限機能の検証テストを追加しました
- ファイル読み込みおよび検証処理に関する新しいテストを追加しました
- プラグインファイルコピー時のハッシュ値計算検証テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->