### PR TITLE
⚡ Bolt: Prevent heap allocation in timing loop

### DIFF
--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -131,9 +131,9 @@ mod tests {
     #[test]
     fn test_output_timings() {
         use std::collections::HashMap;
+        use std::path::PathBuf;
         use std::time::Duration;
         use tsuzulint_core::LintResult;
-        use std::path::PathBuf;
 
         let mut timings1 = HashMap::new();
         timings1.insert("rule1".to_string(), Duration::from_millis(100));

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -60,11 +60,11 @@ pub fn output_text(results: &[LintResult], timings: bool) {
 
 fn output_timings(results: &[LintResult]) {
     let mut total_duration = Duration::new(0, 0);
-    let mut rule_timings: HashMap<String, Duration> = HashMap::new();
+    let mut rule_timings: HashMap<&str, Duration> = HashMap::new();
 
     for result in results {
         for (rule, duration) in &result.timings {
-            *rule_timings.entry(rule.clone()).or_default() += *duration;
+            *rule_timings.entry(rule.as_str()).or_default() += *duration;
             total_duration += *duration;
         }
     }

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -127,4 +127,39 @@ mod tests {
         // We only expect 1 displayable issue (the Certain one)
         assert_eq!(count_displayable_issues(&[result]), 1);
     }
+
+    #[test]
+    fn test_output_timings() {
+        use std::collections::HashMap;
+        use std::time::Duration;
+        use tsuzulint_core::LintResult;
+        use std::path::PathBuf;
+
+        let mut timings1 = HashMap::new();
+        timings1.insert("rule1".to_string(), Duration::from_millis(100));
+        timings1.insert("rule2".to_string(), Duration::from_millis(50));
+
+        let mut timings2 = HashMap::new();
+        timings2.insert("rule1".to_string(), Duration::from_millis(150));
+        timings2.insert("rule3".to_string(), Duration::from_millis(200));
+
+        let result1 = LintResult {
+            path: PathBuf::from("file1.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings: timings1,
+        };
+
+        let result2 = LintResult {
+            path: PathBuf::from("file2.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings: timings2,
+        };
+
+        let results = vec![result1, result2];
+
+        // This should not panic and should cover the logic.
+        super::output_timings(&results);
+    }
 }


### PR DESCRIPTION
💡 What: Changed the `rule_timings` HashMap key type from `String` to `&str` and updated the lookup to use `rule.as_str()` instead of `rule.clone()`.
🎯 Why: Inside the `output_timings` loop, `rule.clone()` was creating a new heap-allocated `String` on every iteration, even when the key already existed in the map. This is inefficient for performance timings aggregation over potentially many files.
📊 Impact: Reduces heap allocations directly proportional to the number of rules multiplied by the number of linted files.
🔬 Measurement: Run the lint CLI over a large codebase and measure memory allocation overhead. Covered by existing test suite.

---
*PR created automatically by Jules for task [3141363221731589588](https://jules.google.com/task/3141363221731589588) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * タイミング出力の内部パフォーマンスを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->