### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded file reads in CLI tools

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -1,6 +1,9 @@
 //! CLI utility functions
 
 use miette::{IntoDiagnostic, Result};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
 use tokio::runtime::Runtime;
 
 pub fn create_tokio_runtime() -> Result<Runtime> {
@@ -8,4 +11,66 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .enable_all()
         .build()
         .into_diagnostic()
+}
+
+/// Reads a file to a string with a size limit to prevent memory exhaustion.
+pub fn read_to_string_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> std::io::Result<String> {
+    let file = File::open(path)?;
+    let metadata = file.metadata()?;
+
+    // Check file size from metadata if available (prevents allocation attempt for huge regular files)
+    if metadata.is_file() && metadata.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File exceeds size limit of {} bytes", limit),
+        ));
+    }
+
+    let mut content = String::new();
+    // Read up to limit + 1 bytes. If we read limit + 1, it's too big (e.g. pseudo files where len=0)
+    file.take(limit + 1).read_to_string(&mut content)?;
+
+    if content.len() as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File exceeds size limit of {} bytes", limit),
+        ));
+    }
+
+    Ok(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_read_to_string_with_limit() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+
+        let content = "Hello, world!";
+        std::fs::write(&file_path, content).unwrap();
+
+        // Under limit
+        let result = read_to_string_with_limit(&file_path, 100).unwrap();
+        assert_eq!(result, content);
+
+        // Exact limit
+        let result = read_to_string_with_limit(&file_path, content.len() as u64).unwrap();
+        assert_eq!(result, content);
+
+        // Over limit
+        let err = read_to_string_with_limit(&file_path, (content.len() - 1) as u64).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_read_to_string_with_limit_pseudo_file() {
+        // /dev/zero reports 0 size but provides infinite bytes
+        let err = read_to_string_with_limit("/dev/zero", 100).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unbounded file reads in CLI tools (`crates/tsuzulint_cli`). The CLI utilized `std::fs::read_to_string` to load manifests and configuration files, which reads the entire file into memory without limits.
🎯 **Impact:** An attacker could cause a Denial of Service (DoS) via memory exhaustion by supplying an excessively large file or a pseudo-file (e.g., `/dev/zero` on Unix systems) that streams infinite data, crashing the linter process.
🔧 **Fix:** Replaced `std::fs::read_to_string` with a newly implemented `crate::utils::read_to_string_with_limit` utility. This utility safely enforces a 1MB memory limit using `Read::take(limit + 1)` to handle both huge regular files and pseudo-files that falsely report 0 bytes in metadata.
✅ **Verification:** Unit tests added for bounded read behavior (including `/dev/zero` edge cases). Run `cargo nextest run -p tsuzulint` to verify.

---
*PR created automatically by Jules for task [7939028322777382432](https://jules.google.com/task/7939028322777382432) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ルールマニフェストおよび設定ファイルの読み込み時に1MBの最大ファイルサイズ制限を導入。この制限により、指定されたサイズを超えるファイルはエラーで拒否されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->