### PR TITLE
🦀 Ferris: [performance improvement]

### DIFF
--- a/.jules/ferris.md
+++ b/.jules/ferris.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Optimize HashMap string keys
+**Learning:** In Rust, avoiding `HashMap::entry(key.clone())` with heap allocation is crucial for loop performance. Instead, preferring `&str` keys or `.get_mut()` with `.insert()` is optimal and prevents allocation on already existing entries. I optimized `crates/tsuzulint_cli/src/output/text.rs` to use `HashMap<&str, Duration>` instead of `HashMap<String, Duration>`.
+**Action:** Applied patch to text.rs and verified functionality.

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -95,6 +95,7 @@ mod tests {
     use super::count_displayable_issues;
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::time::Duration;
     use tsuzulint_core::{Diagnostic, LintResult};
 
     #[test]
@@ -126,5 +127,30 @@ mod tests {
 
         // We only expect 1 displayable issue (the Certain one)
         assert_eq!(count_displayable_issues(&[result]), 1);
+    }
+
+    #[test]
+    fn test_output_timings() {
+        let mut timings1 = HashMap::new();
+        timings1.insert("rule1".to_string(), Duration::from_millis(150));
+        timings1.insert("rule2".to_string(), Duration::from_millis(50));
+
+        let result1 = LintResult {
+            path: PathBuf::from("test1.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings: timings1,
+        };
+
+        let mut timings2 = HashMap::new();
+        timings2.insert("rule2".to_string(), Duration::from_millis(100));
+        let result2 = LintResult {
+            path: PathBuf::from("test2.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings: timings2,
+        };
+
+        super::output_timings(&[result1, result2]);
     }
 }

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -60,11 +60,11 @@ pub fn output_text(results: &[LintResult], timings: bool) {
 
 fn output_timings(results: &[LintResult]) {
     let mut total_duration = Duration::new(0, 0);
-    let mut rule_timings: HashMap<String, Duration> = HashMap::new();
+    let mut rule_timings: HashMap<&str, Duration> = HashMap::new();
 
     for result in results {
         for (rule, duration) in &result.timings {
-            *rule_timings.entry(rule.clone()).or_default() += *duration;
+            *rule_timings.entry(rule.as_str()).or_default() += *duration;
             total_duration += *duration;
         }
     }


### PR DESCRIPTION
💡 Improvement: Replaced `HashMap<String, Duration>` with `HashMap<&str, Duration>` in `output_timings` to avoid allocating new Strings inside the loop on every entry when computing timings.
🦀 Why: In Rust, calling `.entry(rule.clone())` allocates a new `String` on the heap for every element, even if the key already exists in the map. Switching to `&str` keys completely prevents this unnecessary allocation without breaking lifetime rules, acting as a zero-cost abstraction for looping structures.
🔍 Verification: Checked out changes via `make fmt-check`, `cargo clippy`, and `cargo test --workspace`. Performance outputs remain correct.

---
*PR created automatically by Jules for task [15327764319406436742](https://jules.google.com/task/15327764319406436742) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ルール集計処理のパフォーマンスを最適化しました。不要なメモリ割り当てを削減し、出力の効率が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->