### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/crates/tsuzulint_cli/src/output/json.rs
+++ b/crates/tsuzulint_cli/src/output/json.rs
@@ -20,12 +20,8 @@ pub(crate) fn output_json_to<W: std::io::Write>(
             })
         })
         .collect();
-    writeln!(
-        writer,
-        "{}",
-        serde_json::to_string_pretty(&output).into_diagnostic()?
-    )
-    .into_diagnostic()?;
+    serde_json::to_writer_pretty(&mut writer, &output).into_diagnostic()?;
+    writeln!(writer).into_diagnostic()?;
     Ok(())
 }
 


### PR DESCRIPTION
📚 Source: https://docs.rs/serde_json/latest/serde_json/fn.to_writer_pretty.html
💡 Insight: Writing directly to an IO stream prevents allocating the entire JSON payload in memory as an intermediate String before printing it.
🛠️ Change: Replaced `serde_json::to_string_pretty` + `writeln!` with `serde_json::to_writer_pretty` in `crates/tsuzulint_cli/src/output/json.rs`.
✨ Benefit: Lower memory footprint and reduced heap allocations when reporting a large number of diagnostics.

---
*PR created automatically by Jules for task [12814578256856191245](https://jules.google.com/task/12814578256856191245) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * JSON出力の処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->