### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded file reads in CLI

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,7 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content = crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -9,3 +9,33 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .build()
         .into_diagnostic()
 }
+
+/// Reads a file to a string with a size limit to prevent memory exhaustion
+/// vulnerabilities when reading untrusted input like configs or manifests.
+pub fn read_to_string_with_limit(path: &std::path::Path, limit: u64) -> std::io::Result<String> {
+    use std::io::Read;
+    let file = std::fs::File::open(path)?;
+    let metadata = file.metadata()?;
+
+    // Quick check based on metadata (can be bypassed by pseudo-files)
+    if metadata.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "File size exceeds memory exhaustion limit",
+        ));
+    }
+
+    // Read with a strict limit to protect against pseudo-files (like /dev/zero)
+    // that report 0 size but produce infinite output.
+    let mut content = String::with_capacity(metadata.len() as usize);
+    file.take(limit + 1).read_to_string(&mut content)?;
+
+    if content.len() as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "File content exceeds memory exhaustion limit",
+        ));
+    }
+
+    Ok(content)
+}

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -12,7 +12,10 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
 
 /// Reads a file to a string with a size limit to prevent memory exhaustion
 /// vulnerabilities when reading untrusted input like configs or manifests.
-pub fn read_to_string_with_limit<P: AsRef<std::path::Path>>(path: P, limit: u64) -> std::io::Result<String> {
+pub fn read_to_string_with_limit<P: AsRef<std::path::Path>>(
+    path: P,
+    limit: u64,
+) -> std::io::Result<String> {
     use std::io::Read;
     let file = std::fs::File::open(path)?;
     let metadata = file.metadata()?;

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -12,7 +12,7 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
 
 /// Reads a file to a string with a size limit to prevent memory exhaustion
 /// vulnerabilities when reading untrusted input like configs or manifests.
-pub fn read_to_string_with_limit(path: &std::path::Path, limit: u64) -> std::io::Result<String> {
+pub fn read_to_string_with_limit<P: AsRef<std::path::Path>>(path: P, limit: u64) -> std::io::Result<String> {
     use std::io::Read;
     let file = std::fs::File::open(path)?;
     let metadata = file.metadata()?;
@@ -38,4 +38,52 @@ pub fn read_to_string_with_limit(path: &std::path::Path, limit: u64) -> std::io:
     }
 
     Ok(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hello world").unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let result = read_to_string_with_limit(&path, 100);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_metadata_exceeded() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hello world").unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let result = read_to_string_with_limit(&path, 5);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("File size exceeds")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_to_string_with_limit_pseudo_file() {
+        // /dev/zero reports 0 size but produces infinite bytes, testing the inner read bounds
+        let path = std::path::Path::new("/dev/zero");
+        let result = read_to_string_with_limit(path, 10);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("File content exceeds")
+        );
+    }
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix unbounded file reads in CLI

🚨 Severity: CRITICAL
💡 Vulnerability: `tsuzulint_cli` used `std::fs::read_to_string` directly to read manifest and config files, which is vulnerable to memory exhaustion attacks. A maliciously crafted rule manifest or a pseudo-file (like `/dev/zero`) could cause the CLI to crash due to an out-of-memory error.
🎯 Impact: Denial of Service (DoS) by memory exhaustion when analyzing projects with untrusted configuration files or when running against malicious inputs.
🔧 Fix: Implemented `read_to_string_with_limit` in `tsuzulint_cli::utils` that caps file reads at 1MB and handles pseudo-files correctly by combining metadata checks with bounded reads (`take(limit + 1)`). Updated config and manifest reading logic to use this secure utility.
✅ Verification: Ran `cargo check` and `cargo test --workspace --all-features`. Verified compilation and tests pass.

---
*PR created automatically by Jules for task [196680307703835296](https://jules.google.com/task/196680307703835296) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * マニフェストファイルと設定ファイルの読み込み処理に1MBのサイズ制限を追加し、大規模なファイルの処理によるパフォーマンス低下を防止します。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/372)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->