### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unbounded file reads in CLI

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -1,7 +1,34 @@
 //! CLI utility functions
 
+use std::fs::File;
+use std::io::Read;
+
 use miette::{IntoDiagnostic, Result};
 use tokio::runtime::Runtime;
+
+pub fn read_to_string_with_limit<P: AsRef<std::path::Path>>(
+    path: P,
+    limit: u64,
+) -> std::io::Result<String> {
+    let file = File::open(path.as_ref())?;
+    let metadata = file.metadata()?;
+    if metadata.len() > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "file too large",
+        ));
+    }
+    let mut reader = std::io::Read::take(file, limit + 1);
+    let mut content = String::new();
+    reader.read_to_string(&mut content)?;
+    if content.len() as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "file too large",
+        ));
+    }
+    Ok(content)
+}
 
 pub fn create_tokio_runtime() -> Result<Runtime> {
     tokio::runtime::Builder::new_multi_thread()

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -36,3 +36,41 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .build()
         .into_diagnostic()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "hello").unwrap();
+        let path = temp_file.path().to_path_buf();
+
+        let content = read_to_string_with_limit(&path, 10).unwrap();
+        assert_eq!(content, "hello");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_metadata_too_large() {
+        let mut temp_file = NamedTempFile::new().unwrap();
+        write!(temp_file, "hello").unwrap();
+        let path = temp_file.path().to_path_buf();
+
+        let err = read_to_string_with_limit(&path, 3).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), "file too large");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_to_string_with_limit_dev_zero() {
+        let path = "/dev/zero";
+        // /dev/zero has size 0 but is infinite.
+        let err = read_to_string_with_limit(path, 10).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), "file too large");
+    }
+}


### PR DESCRIPTION
**Severity**: MEDIUM
**Vulnerability**: Unbounded file reads using `std::fs::read_to_string` could allow for memory exhaustion attacks via pseudo-files or dynamically growing files.
**Impact**: Application denial of service (OOM crashes) if pointing to malformed or malicious configurations.
**Fix**: Implemented and utilized a `read_to_string_with_limit` helper to safely bound memory allocations during file reads up to 1MB.
**Verification**: Ensured unit tests passed and correctly handled bounded I/O operations via `cargo test --workspace`.

---
*PR created automatically by Jules for task [4503070927821307891](https://jules.google.com/task/4503070927821307891) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * マニフェストおよび設定ファイル読み込み時のファイルサイズ制限を実装。1MBを超えるファイルの読み込みを検出できるようになり、システムの安定性が向上しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/374)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->