### PR TITLE
⚡ Bolt: [performance improvement] Reduce string allocations in output formatting

### DIFF
--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -130,8 +130,8 @@ mod tests {
 
     #[test]
     fn test_output_timings_execution() {
-        use std::time::Duration;
         use super::output_timings;
+        use std::time::Duration;
 
         let mut timings = HashMap::new();
         timings.insert("rule1".to_string(), Duration::from_millis(100));

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -60,11 +60,11 @@ pub fn output_text(results: &[LintResult], timings: bool) {
 
 fn output_timings(results: &[LintResult]) {
     let mut total_duration = Duration::new(0, 0);
-    let mut rule_timings: HashMap<String, Duration> = HashMap::new();
+    let mut rule_timings: HashMap<&str, Duration> = HashMap::new();
 
     for result in results {
         for (rule, duration) in &result.timings {
-            *rule_timings.entry(rule.clone()).or_default() += *duration;
+            *rule_timings.entry(rule.as_str()).or_default() += *duration;
             total_duration += *duration;
         }
     }

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -127,4 +127,24 @@ mod tests {
         // We only expect 1 displayable issue (the Certain one)
         assert_eq!(count_displayable_issues(&[result]), 1);
     }
+
+    #[test]
+    fn test_output_timings_execution() {
+        use std::time::Duration;
+        use super::output_timings;
+
+        let mut timings = HashMap::new();
+        timings.insert("rule1".to_string(), Duration::from_millis(100));
+        timings.insert("rule2".to_string(), Duration::from_millis(50));
+
+        let result = LintResult {
+            path: PathBuf::from("test.md"),
+            diagnostics: vec![],
+            from_cache: false,
+            timings,
+        };
+
+        // Output to stdout, we just test it executes without panicking and covers the modified lines
+        output_timings(&[result]);
+    }
 }


### PR DESCRIPTION
💡 **What**: Replaced `HashMap<String, Duration>` with `HashMap<&str, Duration>` in `output_timings` to use slice references for rule keys.

🎯 **Why**: When iterating over the linting timings, the `.entry()` API was called with `rule.clone()`. Because this was inside a loop, it forced a brand new heap-allocated `String` on *every single iteration*, even if the rule already existed in the map.

📊 **Impact**: Reduces peak memory allocation and slightly improves execution time during the final output aggregation step by completely eliminating redundant `String` allocations.

🔬 **Measurement**: Verified by ensuring the output formatting tests still pass. The performance improvement is structural (avoiding O(N) heap allocations where N is the total number of rules fired across all files).

---
*PR created automatically by Jules for task [15876321453197558759](https://jules.google.com/task/15876321453197558759) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * パフォーマンス計測の処理を最適化しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/375)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->