### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unbounded file reads in config/manifest loading

### DIFF
--- a/crates/tsuzulint_cli/src/commands/rules.rs
+++ b/crates/tsuzulint_cli/src/commands/rules.rs
@@ -177,7 +177,8 @@ fn find_manifest(wasm_path: &Path) -> Option<PathBuf> {
 }
 
 fn load_manifest(path: &Path) -> Result<tsuzulint_manifest::ExternalRuleManifest, AddRuleError> {
-    let content = std::fs::read_to_string(path).map_err(AddRuleError::ManifestReadError)?;
+    let content = crate::utils::read_to_string_with_limit(path, 1024 * 1024)
+        .map_err(AddRuleError::ManifestReadError)?;
 
     tsuzulint_manifest::validate_manifest(&content).map_err(AddRuleError::ManifestParseError)
 }

--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,8 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -26,3 +26,26 @@ pub fn read_to_string_with_limit<P: AsRef<std::path::Path>>(
     }
     Ok(buffer)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"hello").unwrap();
+        let s = read_to_string_with_limit(tmp.path(), 100).unwrap();
+        assert_eq!(s, "hello");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_exceeds() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"123456789").unwrap();
+        let err = read_to_string_with_limit(tmp.path(), 4).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), "File too large");
+    }
+}

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -9,3 +9,20 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .build()
         .into_diagnostic()
 }
+
+pub fn read_to_string_with_limit<P: AsRef<std::path::Path>>(
+    path: P,
+    max_size: u64,
+) -> std::io::Result<String> {
+    use std::io::Read;
+    let file = std::fs::File::open(path)?;
+    let mut buffer = String::new();
+    file.take(max_size + 1).read_to_string(&mut buffer)?;
+    if buffer.len() as u64 > max_size {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "File too large",
+        ));
+    }
+    Ok(buffer)
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix unbounded file reads in config/manifest loading

Severity: CRITICAL
Vulnerability: `std::fs::read_to_string` loads the entire file into memory which can be exploited by passing very large configuration or manifest files to cause an Out-Of-Memory (OOM) / Memory Exhaustion denial of service.
Impact: Attackers providing crafted repositories or configuration paths could crash the linter.
Fix: Introduced a bounded `read_to_string_with_limit` helper (default 1MB) and replaced `std::fs::read_to_string` in `tsuzulint_cli`.
Verification: Ran tests to ensure file loading behaviour works as expected with normal files.

---
*PR created automatically by Jules for task [18291540021780030571](https://jules.google.com/task/18291540021780030571) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * マニフェストおよび設定ファイルの読み込み時にファイルサイズ制限（1MB）を導入しました。1MBを超えるファイルはエラーとなります。これにより、メモリ使用量の管理が改善され、より安定したパフォーマンスが実現されます。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/376)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->