### PR TITLE
⚡ Bolt: Prevent string allocation in text output formatter

### DIFF
--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -95,6 +95,7 @@ mod tests {
     use super::count_displayable_issues;
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use std::time::Duration;
     use tsuzulint_core::{Diagnostic, LintResult};
 
     #[test]
@@ -126,5 +127,38 @@ mod tests {
 
         // We only expect 1 displayable issue (the Certain one)
         assert_eq!(count_displayable_issues(&[result]), 1);
+    }
+
+    #[test]
+    fn test_output_text_with_timings() {
+        let diag1: Diagnostic = serde_json::from_value(serde_json::json!({
+            "rule_id": "rule1",
+            "message": "error",
+            "span": { "start": 0, "end": 5 },
+            "severity": "error",
+            "certainty": "certain"
+        }))
+        .unwrap();
+
+        let mut timings = HashMap::new();
+        timings.insert("rule1".to_string(), Duration::from_millis(10));
+        timings.insert("rule2".to_string(), Duration::from_millis(20));
+
+        let result = LintResult {
+            path: PathBuf::from("test.md"),
+            diagnostics: vec![diag1],
+            from_cache: false,
+            timings,
+        };
+
+        let empty_result = LintResult {
+            path: PathBuf::from("empty.md"),
+            diagnostics: vec![],
+            from_cache: true,
+            timings: HashMap::new(),
+        };
+
+        // Just call it to ensure it doesn't panic and we hit the lines for coverage
+        super::output_text(&[result, empty_result], true);
     }
 }

--- a/crates/tsuzulint_cli/src/output/text.rs
+++ b/crates/tsuzulint_cli/src/output/text.rs
@@ -60,11 +60,11 @@ pub fn output_text(results: &[LintResult], timings: bool) {
 
 fn output_timings(results: &[LintResult]) {
     let mut total_duration = Duration::new(0, 0);
-    let mut rule_timings: HashMap<String, Duration> = HashMap::new();
+    let mut rule_timings: HashMap<&str, Duration> = HashMap::new();
 
     for result in results {
         for (rule, duration) in &result.timings {
-            *rule_timings.entry(rule.clone()).or_default() += *duration;
+            *rule_timings.entry(rule.as_str()).or_default() += *duration;
             total_duration += *duration;
         }
     }


### PR DESCRIPTION
💡 What:
Replaced the `String` key in the `rule_timings` HashMap with a `&str` reference in `crates/tsuzulint_cli/src/output/text.rs`.

🎯 Why:
Inside the `output_timings` loop, `*rule_timings.entry(rule.clone()).or_default() += *duration;` was forcing a heap allocation on every single iteration just to do a map lookup. By changing the map's key type to `&str` and using `rule.as_str()`, we borrow the string directly from the existing `results` slice.

📊 Impact:
Saves one `String` heap allocation per rule timing result processed during CLI text output aggregation, reducing memory pressure and slightly improving execution speed, especially when analyzing large projects with many rules.

🔬 Measurement:
No regressions introduced; verified via `cargo check` and `cargo test --workspace`. Performance timings can still be output successfully with the `--timings` flag.

---
*PR created automatically by Jules for task [3174241252842847800](https://jules.google.com/task/3174241252842847800) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 変更内容

* **Refactor**
  * CLIのタイミング出力処理を内部的に効率化し、メモリ使用を改善しました。
* **Tests**
  * タイミング出力が正常に動作することを確認する単体テストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/377)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->