### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unbounded config file read

### DIFF
--- a/crates/tsuzulint_cli/src/config/editor.rs
+++ b/crates/tsuzulint_cli/src/config/editor.rs
@@ -40,7 +40,9 @@ pub fn update_config_with_plugin(
         ));
     }
 
-    let content = std::fs::read_to_string(&path_to_use).into_diagnostic()?;
+    // Use bounded read to prevent memory exhaustion (e.g. via /dev/zero)
+    let content =
+        crate::utils::read_to_string_with_limit(&path_to_use, 1024 * 1024).into_diagnostic()?;
 
     let parse_options = ParseOptions::default();
     let collect_options = CollectOptions::default();

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -18,13 +18,13 @@ pub fn read_to_string_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> std::io
     let file = File::open(path.as_ref())?;
 
     // Check metadata first if possible
-    if let Ok(metadata) = file.metadata() {
-        if metadata.len() > limit {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("File too large (exceeds {} bytes)", limit),
-            ));
-        }
+    if let Ok(metadata) = file.metadata()
+        && metadata.len() > limit
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File too large (exceeds {} bytes)", limit),
+        ));
     }
 
     // Read with explicit limit to protect against pseudo-files (/dev/zero)

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -40,3 +40,40 @@ pub fn read_to_string_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> std::io
 
     Ok(content)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_to_string_with_limit_success() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "Hello, World!").unwrap();
+        let content = read_to_string_with_limit(file.path(), 100).unwrap();
+        assert_eq!(content, "Hello, World!");
+    }
+
+    #[test]
+    fn test_read_to_string_with_limit_exceeds_metadata() {
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "Hello, World!").unwrap();
+        let result = read_to_string_with_limit(file.path(), 5);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds 5 bytes"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_read_to_string_with_limit_pseudo_file() {
+        // /dev/zero has metadata length 0, but reads forever
+        let result = read_to_string_with_limit("/dev/zero", 10);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds 10 bytes"));
+    }
+}

--- a/crates/tsuzulint_cli/src/utils/mod.rs
+++ b/crates/tsuzulint_cli/src/utils/mod.rs
@@ -1,6 +1,9 @@
 //! CLI utility functions
 
 use miette::{IntoDiagnostic, Result};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
 use tokio::runtime::Runtime;
 
 pub fn create_tokio_runtime() -> Result<Runtime> {
@@ -8,4 +11,32 @@ pub fn create_tokio_runtime() -> Result<Runtime> {
         .enable_all()
         .build()
         .into_diagnostic()
+}
+
+/// Reads a file to a string with a maximum size limit to prevent memory exhaustion
+pub fn read_to_string_with_limit<P: AsRef<Path>>(path: P, limit: u64) -> std::io::Result<String> {
+    let file = File::open(path.as_ref())?;
+
+    // Check metadata first if possible
+    if let Ok(metadata) = file.metadata() {
+        if metadata.len() > limit {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("File too large (exceeds {} bytes)", limit),
+            ));
+        }
+    }
+
+    // Read with explicit limit to protect against pseudo-files (/dev/zero)
+    let mut content = String::new();
+    let read_count = file.take(limit + 1).read_to_string(&mut content)?;
+
+    if read_count as u64 > limit {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("File too large (exceeds {} bytes)", limit),
+        ));
+    }
+
+    Ok(content)
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `update_config_with_plugin` function in `crates/tsuzulint_cli/src/config/editor.rs` reads the configuration file into memory using `std::fs::read_to_string` without any bounds checking. This could allow pseudo-files like `/dev/zero` or excessively large files to cause memory exhaustion (Out-Of-Memory) issues.
🎯 Impact: Denial of Service (DoS) via memory exhaustion when updating configuration files.
🔧 Fix: Created a utility function `read_to_string_with_limit` in `crates/tsuzulint_cli/src/utils/mod.rs` to securely read files with a maximum size limit, strictly limiting the `Read::take()` behavior to protect against pseudo-files. Updated `config/editor.rs` to utilize this function and enforce a 1MB limit.
✅ Verification: Ensure `cargo test -p tsuzulint` executes successfully, indicating the change has not broken the existing tests.

---
*PR created automatically by Jules for task [3884593221195372581](https://jules.google.com/task/3884593221195372581) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 設定ファイルの読み込みが安全になり、大きすぎるまたは特殊なファイルによる無限読み込みや不安定動作を防止します。
  * 読み込み時のエラー検出とハンドリングが改善されました。

* **新機能**
  * 読み込み時にサイズ上限を設ける仕組みを追加し、予期せぬ大容量入力を防ぎます。

* **テスト**
  * サイズ制限や特殊ファイルに関するユニットテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/378)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->