### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/crates/tsuzulint_cli/src/output/json.rs
+++ b/crates/tsuzulint_cli/src/output/json.rs
@@ -20,12 +20,8 @@ pub(crate) fn output_json_to<W: std::io::Write>(
             })
         })
         .collect();
-    writeln!(
-        writer,
-        "{}",
-        serde_json::to_string_pretty(&output).into_diagnostic()?
-    )
-    .into_diagnostic()?;
+    serde_json::to_writer_pretty(&mut writer, &output).into_diagnostic()?;
+    writeln!(writer).into_diagnostic()?;
     Ok(())
 }
 


### PR DESCRIPTION
📚 **Source:** [serde_json documentation](https://docs.rs/serde_json/latest/serde_json/fn.to_writer_pretty.html)

💡 **Insight:** According to the `serde_json` documentation, serializing a JSON value to a `String` via `to_string` or `to_string_pretty` forces a heap allocation for the entire serialized content. When outputting to an I/O stream (like `stdout`), it's recommended to use `to_writer` or `to_writer_pretty` to stream the output bytes directly.

🛠️ **Change:** Refactored `output_json_to` in `crates/tsuzulint_cli/src/output/json.rs` to replace the intermediate `serde_json::to_string_pretty(&output)` and `writeln!` macro. Instead, it now uses `serde_json::to_writer_pretty(&mut writer, &output)` directly on the writer, followed by an explicit `writeln!(writer)` to append the trailing newline.

✨ **Benefit:** **Efficiency Gain.** By streaming the JSON output directly to the writer, we bypass a large, memory-intensive heap allocation of a potentially massive `String` (especially in cases with a high volume of diagnostics), resulting in a lower memory footprint and improved execution speed during CLI output.

---
*PR created automatically by Jules for task [2491681794841169809](https://jules.google.com/task/2491681794841169809) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * JSON出力の処理を最適化し、シリアライゼーション効率を向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/379)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->