### PR TITLE
⚡ Bolt: prevent String allocation in timings HashMap lookups

### DIFF
--- a/crates/tsuzulint_core/src/file_linter.rs
+++ b/crates/tsuzulint_core/src/file_linter.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use tracing::{debug, warn};
 use tsuzulint_ast::AstArena;
 use tsuzulint_cache::CacheManager;
@@ -166,7 +166,12 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
                     Err(e) => warn!("Rule '{}' failed: {}", rule, e),
                 }
                 if timings_enabled {
-                    *timings.entry(rule.to_string()).or_insert(Duration::ZERO) += start.elapsed();
+                    let elapsed = start.elapsed();
+                    if let Some(d) = timings.get_mut(*rule) {
+                        *d += elapsed;
+                    } else {
+                        timings.insert(rule.to_string(), elapsed);
+                    }
                 }
             } else {
                 let ast_raw = to_raw_value(&ast, "AST")?;
@@ -183,8 +188,12 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
                         Err(e) => warn!("Rule '{}' failed: {}", rule, e),
                     }
                     if timings_enabled {
-                        *timings.entry(rule.to_string()).or_insert(Duration::ZERO) +=
-                            start.elapsed();
+                        let elapsed = start.elapsed();
+                        if let Some(d) = timings.get_mut(*rule) {
+                            *d += elapsed;
+                        } else {
+                            timings.insert(rule.to_string(), elapsed);
+                        }
                     }
                 }
             }
@@ -211,8 +220,12 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
                                 Err(e) => warn!("Rule '{}' failed: {}", rule, e),
                             }
                             if timings_enabled {
-                                *timings.entry(rule.to_string()).or_insert(Duration::ZERO) +=
-                                    start.elapsed();
+                                let elapsed = start.elapsed();
+                                if let Some(d) = timings.get_mut(*rule) {
+                                    *d += elapsed;
+                                } else {
+                                    timings.insert(rule.to_string(), elapsed);
+                                }
                             }
                         } else if let Ok(node_raw) = to_raw_value(node, "block node") {
                             // Serialize request once for all rules running on this block
@@ -231,9 +244,12 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
                                             Err(e) => warn!("Rule '{}' failed: {}", rule, e),
                                         }
                                         if timings_enabled {
-                                            *timings
-                                                .entry(rule.to_string())
-                                                .or_insert(Duration::ZERO) += start.elapsed();
+                                            let elapsed = start.elapsed();
+                                            if let Some(d) = timings.get_mut(*rule) {
+                                                *d += elapsed;
+                                            } else {
+                                                timings.insert(rule.to_string(), elapsed);
+                                            }
                                         }
                                     }
                                 }
@@ -281,9 +297,12 @@ pub fn lint_file_internal(ctx: &mut LintContext<'_>) -> Result<LintResult, Linte
         let start = Instant::now();
         native_diagnostics.extend(rule.lint(&native_ctx));
         if timings_enabled {
-            *timings
-                .entry(rule_name.to_string())
-                .or_insert(Duration::ZERO) += start.elapsed();
+            let elapsed = start.elapsed();
+            if let Some(d) = timings.get_mut(rule_name) {
+                *d += elapsed;
+            } else {
+                timings.insert(rule_name.to_string(), elapsed);
+            }
         }
     }
 


### PR DESCRIPTION
💡 What: Replaced `timings.entry(rule.to_string()).or_insert(...)` with a `get_mut` followed by an `insert` in the file linter logic.
🎯 Why: In the hot loop for AST node visitation and rule execution, creating the key string caused an unnecessary heap allocation on every single iteration, even if the rule already existed in the `timings` HashMap.
📊 Impact: Completely eliminates string allocations for profiling cache hits across thousands of nodes per file, reducing the overhead of timings collection.
🔬 Measurement: Verified with `cargo test -p tsuzulint_core` that semantics remained unchanged and no additional errors were introduced.

---
*PR created automatically by Jules for task [11228085655851612491](https://jules.google.com/task/11228085655851612491) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ルール実行時のタイミング計測ロジックを最適化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/381)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->