### PR TITLE
🦀 Ferris: [refactor] Remove expect() and unwrap() from native rules

### DIFF
--- a/crates/tsuzulint_core/src/native_rules/rules/no_mixed_zenkaku_hankaku_alphabet.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/no_mixed_zenkaku_hankaku_alphabet.rs
@@ -134,8 +134,12 @@ mod tests {
         let mut paragraphs = Vec::with_capacity(texts.len());
         for text in texts {
             // Advance past any whitespace/separator bytes in `source`.
-            while !source[cursor..].starts_with(*text) {
-                cursor += source[cursor..].chars().next().unwrap().len_utf8();
+            while cursor < source.len() && !source[cursor..].starts_with(*text) {
+                if let Some(ch) = source[cursor..].chars().next() {
+                    cursor += ch.len_utf8();
+                } else {
+                    break;
+                }
             }
             let start = cursor;
             let end = start + text.len();

--- a/crates/tsuzulint_core/src/native_rules/rules/sentence_length.rs
+++ b/crates/tsuzulint_core/src/native_rules/rules/sentence_length.rs
@@ -173,12 +173,12 @@ fn strip_urls(text: &str) -> String {
             i += url_end;
             continue;
         }
-        let ch = text[i..]
-            .chars()
-            .next()
-            .expect("i is a valid char boundary");
-        out.push(ch);
-        i += ch.len_utf8();
+        if let Some(ch) = text[i..].chars().next() {
+            out.push(ch);
+            i += ch.len_utf8();
+        } else {
+            break;
+        }
     }
     out
 }


### PR DESCRIPTION
💡 Improvement: Safely unwrapped `chars().next()` in `sentence_length.rs` and `no_mixed_zenkaku_hankaku_alphabet.rs` by replacing `expect()` and `unwrap()` with `if let Some(ch) = ...`.
🦀 Why: Idiomatic Rust prohibits using `unwrap()` or `expect()` inside library code to prevent runtime panics. String index traversals, even if provably safe via bounds, should use safe pattern matching for maintainability.
🔍 Verification: `cargo check`, `cargo test`, and `cargo clippy` pass cleanly.

---
*PR created automatically by Jules for task [4483190292486642964](https://jules.google.com/task/4483190292486642964) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
  * テキスト解析処理における境界条件とエッジケースでの安全性を強化しました。予期しない入力や不正な状況に遭遇した場合のクラッシュを防止し、ツール全体の安定性が向上しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/382)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->