### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/crates/tsuzulint_cli/src/output/sarif.rs
+++ b/crates/tsuzulint_cli/src/output/sarif.rs
@@ -4,7 +4,55 @@ use miette::{IntoDiagnostic, Result};
 use tsuzulint_core::LintResult;
 
 pub fn output_sarif(results: &[LintResult]) -> Result<()> {
-    let sarif_output = tsuzulint_core::generate_sarif(results).into_diagnostic()?;
-    println!("{}", sarif_output);
+    let stdout = std::io::stdout();
+    let locked = stdout.lock();
+    let buf_writer = std::io::BufWriter::new(locked);
+    output_sarif_to(results, buf_writer)
+}
+
+pub(crate) fn output_sarif_to<W: std::io::Write>(
+    results: &[LintResult],
+    mut writer: W,
+) -> Result<()> {
+    tsuzulint_core::generate_sarif_to(results, &mut writer).into_diagnostic()?;
+    writeln!(writer).into_diagnostic()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use tsuzulint_core::{Diagnostic, LintResult};
+
+    #[test]
+    fn test_sarif_output_to() {
+        let diag: Diagnostic = serde_json::from_value(serde_json::json!({
+            "rule_id": "test-rule",
+            "message": "msg",
+            "span": { "start": 0, "end": 5 },
+            "severity": "warning",
+            "certainty": "heuristic",
+            "metadata": {"foo": "bar"}
+        }))
+        .unwrap();
+
+        let result = LintResult {
+            path: PathBuf::from("test.md"),
+            diagnostics: vec![diag],
+            from_cache: false,
+            timings: HashMap::new(),
+        };
+
+        let mut buf = Vec::new();
+        super::output_sarif_to(&[result], &mut buf).unwrap();
+
+        let json_str = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+
+        // Verify valid SARIF JSON
+        assert_eq!(parsed["version"], "2.1.0");
+        let run = &parsed["runs"][0];
+        assert_eq!(run["tool"]["driver"]["name"], "tsuzulint");
+    }
 }

--- a/crates/tsuzulint_cli/src/output/sarif.rs
+++ b/crates/tsuzulint_cli/src/output/sarif.rs
@@ -16,6 +16,7 @@ pub(crate) fn output_sarif_to<W: std::io::Write>(
 ) -> Result<()> {
     tsuzulint_core::generate_sarif_to(results, &mut writer).into_diagnostic()?;
     writeln!(writer).into_diagnostic()?;
+    writer.flush().into_diagnostic()?;
     Ok(())
 }
 

--- a/crates/tsuzulint_core/src/fixer.rs
+++ b/crates/tsuzulint_core/src/fixer.rs
@@ -100,7 +100,7 @@ pub(crate) fn filter_overlapping_fixes(mut fixes: Vec<&Fix>) -> Vec<&Fix> {
     }
 
     // Sort by span.start in descending order (apply from end to beginning)
-    fixes.sort_by(|a, b| b.span.start.cmp(&a.span.start));
+    fixes.sort_by_key(|b| std::cmp::Reverse(b.span.start));
 
     let mut result: Vec<&Fix> = Vec::with_capacity(fixes.len());
 

--- a/crates/tsuzulint_core/src/formatters/mod.rs
+++ b/crates/tsuzulint_core/src/formatters/mod.rs
@@ -2,4 +2,4 @@
 
 pub mod sarif;
 
-pub use sarif::generate_sarif;
+pub use sarif::{generate_sarif, generate_sarif_to};

--- a/crates/tsuzulint_core/src/formatters/sarif.rs
+++ b/crates/tsuzulint_core/src/formatters/sarif.rs
@@ -22,6 +22,15 @@ pub fn generate_sarif(results: &[LintResult]) -> Result<String, serde_json::Erro
     serde_json::to_string_pretty(&sarif_log)
 }
 
+/// Generates SARIF output from lint results and streams it to a writer
+pub fn generate_sarif_to<W: std::io::Write>(
+    results: &[LintResult],
+    writer: W,
+) -> Result<(), serde_json::Error> {
+    let sarif_log = SarifLog::from_results(results);
+    serde_json::to_writer_pretty(writer, &sarif_log)
+}
+
 /// Root SARIF log structure
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/tsuzulint_core/src/lib.rs
+++ b/crates/tsuzulint_core/src/lib.rs
@@ -53,7 +53,7 @@ pub use context::{CodeBlockInfo, DocumentStructure, HeadingInfo, LineInfo, LinkI
 pub use error::LinterError;
 pub use fix::{DependencyGraph, FixCoordinator, FixResult};
 pub use fixer::{FixerResult, apply_fixes_to_content, apply_fixes_to_file};
-pub use formatters::generate_sarif;
+pub use formatters::{generate_sarif, generate_sarif_to};
 pub use linter::{LintFilesResult, Linter};
 pub use pool::{PluginHostPool, PooledHost};
 pub use result::LintResult;

--- a/test_sarif_writer.sh
+++ b/test_sarif_writer.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+# Build
+make test

--- a/test_sarif_writer.sh
+++ b/test_sarif_writer.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-# Build
-make test


### PR DESCRIPTION
**📚 Source:** `serde_json` [Serialization Documentation](https://docs.rs/serde_json/latest/serde_json/fn.to_writer.html)

**💡 Insight:** When generating large JSON structures (like extensive SARIF logs for a codebase), `serde_json::to_string` requires the allocation of a single, continuous String buffer that holds the entire payload in memory. `serde_json` provides `to_writer` and `to_writer_pretty` specifically to stream directly to I/O without this intermediary allocation overhead.

**🛠️ Change:** 
- Modified `tsuzulint_core` to expose a `generate_sarif_to` method taking an `io::Write`.
- Refactored `tsuzulint_cli`'s SARIF output module to stream output to `std::io::stdout()`.
- Implemented `BufWriter` around the `stdout.lock()` to avoid constant terminal lock overhead.

**✨ Benefit:** Significantly reduced memory spikes when running the linter with SARIF output, especially on large codebases with numerous diagnostics. It's the idiomatic way to handle streaming large JSON results in Rust.

---
*PR created automatically by Jules for task [8513020270721676048](https://jules.google.com/task/8513020270721676048) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス改善**
  * SARIF 出力がバッファリングされ、出力の安定性と効率が向上しました。

* **新機能**
  * SARIFを書き出すための出力先指定が可能になりました（拡張された出力経路）。

* **バグ修正**
  * 修正適用やコードアクションの対象順が安定するよう並び替え処理を改善しました。

* **テスト**
  * SARIF 出力の正当性を確認するユニットテストと実行スクリプトを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/383)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->