### PR TITLE
🎓 Scholar: serde_json and blake3 usage improvement

### DIFF
--- a/crates/tsuzulint_core/src/config.rs
+++ b/crates/tsuzulint_core/src/config.rs
@@ -323,8 +323,6 @@ impl LinterConfig {
 
     /// Computes a hash of the configuration for cache invalidation.
     pub fn hash(&self) -> Result<[u8; 32], LinterError> {
-        let json = serde_json::to_string(self)
-            .map_err(|e| LinterError::Internal(format!("Failed to serialize config: {}", e)))?;
         // Mix the tsuzulint crate version into the hash so that native rule
         // behaviour changes between binary versions invalidate the cache.
         // Native rule versions are not tracked in the per-rule
@@ -335,7 +333,12 @@ impl LinterConfig {
         let mut hasher = blake3::Hasher::new();
         hasher.update(env!("CARGO_PKG_VERSION").as_bytes());
         hasher.update(b"\0");
-        hasher.update(json.as_bytes());
+
+        // Serialize the configuration directly to the hasher using the `std::io::Write` trait,
+        // avoiding a large heap allocation for the resulting JSON string.
+        serde_json::to_writer(&mut hasher, self)
+            .map_err(|e| LinterError::Internal(format!("Failed to serialize config: {}", e)))?;
+
         Ok(hasher.finalize().into())
     }
 }


### PR DESCRIPTION
📚 Source: https://docs.rs/blake3/latest/blake3/struct.Hasher.html#impl-Write-for-Hasher and https://docs.rs/serde_json/latest/serde_json/fn.to_writer.html
💡 Insight: `blake3::Hasher` implements the `std::io::Write` trait. `serde_json` provides `to_writer` which accepts any `std::io::Write`. Previously, the code was calling `serde_json::to_string` to create a large string in memory just to call `.as_bytes()` and feed it into the hasher.
🛠️ Change: Modified `LinterConfig::hash` in `crates/tsuzulint_core/src/config.rs` to stream the JSON serialization directly into the `blake3::Hasher`.
✨ Benefit: Efficiency/Performance. Eliminates the allocation of a potentially large JSON `String` on the heap when computing the configuration hash.

---
*PR created automatically by Jules for task [17787069387583690366](https://jules.google.com/task/17787069387583690366) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 設定のハッシュ計算処理を最適化し、パフォーマンスを改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/389)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->