### PR TITLE
ci(msrv): pin rust-toolchain by branch ref, set MSRV via toolchain input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.0
+      # Pin the *action* to a branch ref (not the `@1.94.0` version tag) so Dependabot
+      # doesn't bump it to the newest tag (e.g. a not-yet-released Rust). The MSRV is
+      # selected explicitly via `toolchain` — keep it in sync with `rust-version` in the
+      # root Cargo.toml `[workspace.package]`.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.94.0"
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --workspace
 


### PR DESCRIPTION
## Pin the MSRV job's `rust-toolchain` by branch ref (fixes the #3 class of issue)

`dtolnay/rust-toolchain@1.94.0` referenced a **version tag** of the action, so Dependabot's github-actions updater bumped it to the newest tag — **`@1.100.0`** (a Rust release that doesn't exist yet) in #3. That pulls a non-existent toolchain *and* silently moves our MSRV.

### Fix
```yaml
- uses: dtolnay/rust-toolchain@master   # branch ref → Dependabot won't version-bump it
  with:
    toolchain: "1.94.0"                  # MSRV selected explicitly; sync with Cargo.toml rust-version
```
Separates the **action version** (`master` — gets fixes, no Dependabot churn) from the **Rust toolchain** (`1.94.0` — our MSRV). The other jobs already use `@stable` (a branch ref), which Dependabot leaves alone — that's why only the MSRV job was hit.

When the rolling MSRV advances (latest stable − 2), bump `toolchain` here and `rust-version` in `Cargo.toml` together.

Supersedes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
