### PR TITLE
M1c-1: rule-facing diagnostic model + zero-copy NodeRef

### DIFF
--- a/crates/tzlint_ast/src/lib.rs
+++ b/crates/tzlint_ast/src/lib.rs
@@ -377,6 +377,23 @@ impl ArchivedAst {
     }
 }
 
+// ── Archive bridge ───────────────────────────────────────────────────────────────────
+// The one place that serializes/accesses the frozen archive, so the rkyv configuration
+// (pinned little-endian, 32-bit pointers, bytecheck) stays centralized here.
+
+/// Serialize an [`Ast`] into its frozen archive. The returned buffer is correctly aligned
+/// for [`access`].
+pub fn to_archive(ast: &Ast) -> Result<rkyv::util::AlignedVec, rkyv::rancor::Error> {
+    rkyv::to_bytes::<rkyv::rancor::Error>(ast)
+}
+
+/// Access an archived [`Ast`] in place (zero-copy), validating the bytes (`bytecheck`) so a
+/// malformed or misaligned buffer is a recoverable `Err`, never UB. Use this for any bytes
+/// the current process did not just produce with [`to_archive`].
+pub fn access(bytes: &[u8]) -> Result<&ArchivedAst, rkyv::rancor::Error> {
+    rkyv::access::<ArchivedAst, rkyv::rancor::Error>(bytes)
+}
+
 // ── Frozen-layout guards ─────────────────────────────────────────────────────────────
 // Compile-time assertions on the archived layout. These fail the build (not just a test)
 // if a field type or order changes the size/alignment of the frozen records.
@@ -547,5 +564,15 @@ mod tests {
             bytes.len(),
             bytes.as_slice(),
         );
+    }
+
+    #[test]
+    fn archive_bridge_roundtrips() {
+        let ast = canonical_ast();
+        let bytes = to_archive(&ast).unwrap();
+        let archived = access(&bytes).unwrap();
+        assert_eq!(archived.root(), NodeId(0));
+        assert_eq!(archived.len(), 3);
+        assert_eq!(archived.text(), "Hi");
     }
 }

--- a/crates/tzlint_ast/src/lib.rs
+++ b/crates/tzlint_ast/src/lib.rs
@@ -575,4 +575,16 @@ mod tests {
         assert_eq!(archived.len(), 3);
         assert_eq!(archived.text(), "Hi");
     }
+
+    #[test]
+    fn span_and_archive_size_helpers() {
+        assert_eq!(Span::new(2, 7).len(), 5);
+        assert_eq!(Span::new(7, 2).len(), 0); // inverted → saturating 0
+        assert!(Span::new(3, 3).is_empty());
+        assert!(!Span::new(3, 4).is_empty());
+
+        let bytes = to_archive(&canonical_ast()).unwrap();
+        let archived = access(&bytes).unwrap();
+        assert!(!archived.is_empty());
+    }
 }

--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -134,6 +134,8 @@ mod tests {
         assert_eq!(id.as_str(), "sentence-length");
         assert_eq!(id.to_string(), "sentence-length");
         assert_eq!(RuleId::new(String::from("acme/x")).as_str(), "acme/x");
+        // From<String> (owned) as well as From<&str> above.
+        assert_eq!(RuleId::from(String::from("acme/y")).as_str(), "acme/y");
     }
 
     #[test]

--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -1,0 +1,166 @@
+//! The diagnostic model rules emit and the engine aggregates.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use tzlint_ast::Span;
+
+/// A rule identifier.
+///
+/// Lowercase kebab-case; native rules use a bare id (`sentence-length`), plugin rules are
+/// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
+/// greppable, stable, and used verbatim in config keys and the cache key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RuleId(String);
+
+impl RuleId {
+    /// Wrap an id string.
+    pub fn new(id: impl Into<String>) -> Self {
+        RuleId(id.into())
+    }
+    /// The id as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl core::fmt::Display for RuleId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for RuleId {
+    fn from(s: &str) -> Self {
+        RuleId(s.into())
+    }
+}
+
+impl From<String> for RuleId {
+    fn from(s: String) -> Self {
+        RuleId(s)
+    }
+}
+
+/// Diagnostic severity, declared most-to-least severe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+/// A suggested edit: replace the bytes at `span` (absolute into `Ast.text`) with
+/// `replacement`. A pure deletion uses an empty `replacement`; a pure insertion uses an
+/// empty `span`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Fix {
+    pub span: Span,
+    pub replacement: String,
+}
+
+impl Fix {
+    /// Replace `span` with `replacement`.
+    pub fn replace(span: Span, replacement: impl Into<String>) -> Self {
+        Fix {
+            span,
+            replacement: replacement.into(),
+        }
+    }
+    /// Delete the bytes at `span`.
+    pub fn delete(span: Span) -> Self {
+        Fix {
+            span,
+            replacement: String::new(),
+        }
+    }
+}
+
+/// One reported problem: attributed to a rule, located at an absolute byte [`Span`], with
+/// zero or more suggested [`Fix`]es.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub rule_id: RuleId,
+    pub severity: Severity,
+    pub message: String,
+    pub span: Span,
+    pub fixes: Vec<Fix>,
+}
+
+impl Diagnostic {
+    /// A diagnostic with no fixes.
+    pub fn new(
+        rule_id: impl Into<RuleId>,
+        severity: Severity,
+        span: Span,
+        message: impl Into<String>,
+    ) -> Self {
+        Diagnostic {
+            rule_id: rule_id.into(),
+            severity,
+            message: message.into(),
+            span,
+            fixes: Vec::new(),
+        }
+    }
+
+    /// Attach a [`Fix`] (builder style).
+    #[must_use]
+    pub fn with_fix(mut self, fix: Fix) -> Self {
+        self.fixes.push(fix);
+        self
+    }
+
+    /// The stable within-file ordering key: `(span.start, span.end, rule_id, message)`.
+    /// Output is sorted by `(file_path, …this key)` so it is independent of scheduling.
+    pub fn sort_key(&self) -> (u32, u32, &str, &str) {
+        (
+            self.span.start,
+            self.span.end,
+            self.rule_id.as_str(),
+            self.message.as_str(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rule_id_roundtrips() {
+        let id = RuleId::from("sentence-length");
+        assert_eq!(id.as_str(), "sentence-length");
+        assert_eq!(id.to_string(), "sentence-length");
+        assert_eq!(RuleId::new(String::from("acme/x")).as_str(), "acme/x");
+    }
+
+    #[test]
+    fn severity_orders_most_severe_first() {
+        assert!(Severity::Error < Severity::Warning);
+        assert!(Severity::Warning < Severity::Info);
+        assert!(Severity::Info < Severity::Hint);
+    }
+
+    #[test]
+    fn fix_constructors() {
+        assert_eq!(Fix::delete(Span::new(1, 4)).replacement, "");
+        let f = Fix::replace(Span::new(1, 4), "x");
+        assert_eq!(f.span, Span::new(1, 4));
+        assert_eq!(f.replacement, "x");
+    }
+
+    #[test]
+    fn diagnostic_builder_and_sort_key() {
+        let d = Diagnostic::new(
+            "max-comma",
+            Severity::Warning,
+            Span::new(5, 9),
+            "too many commas",
+        )
+        .with_fix(Fix::delete(Span::new(8, 9)));
+        assert_eq!(d.fixes.len(), 1);
+        assert_eq!(d.sort_key(), (5, 9, "max-comma", "too many commas"));
+    }
+}

--- a/crates/tzlint_pdk/src/lib.rs
+++ b/crates/tzlint_pdk/src/lib.rs
@@ -1,8 +1,22 @@
 //! `tzlint_pdk` — the rule-author SDK (Plugin Development Kit).
 //!
-//! Provides the ergonomic, zero-copy `NodeRef<'ast>` facade over the archived AST, the
-//! `Rule`/`RuleMeta`/`Context`/`Diagnostic`/`Fix` surface, authoring macros, and a test
-//! harness. v1 ships a single Rust PDK; the ABI is frozen and documented so future
-//! TS/AssemblyScript PDKs can be added without redesign.
+//! Provides the ergonomic, zero-copy [`NodeRef`] cursor over the archived AST and the
+//! diagnostic model rules produce ([`Diagnostic`], [`Fix`], [`Severity`], [`RuleId`]) plus
+//! [`RuleMeta`]. v1 ships a single Rust PDK; the surface is `no_std` (alloc) so it can sit
+//! on the `wasm32` guest side of the plugin ABI.
 //!
-//! TODO(M3): define the PDK surface against the frozen `abi-spec.md` calling convention.
+//! Landed in M1c-1: the diagnostic model + `NodeRef` facade + `RuleMeta`. The `Rule` trait
+//! and `Context` land with the engine (M1c-2); the frozen plugin ABI calling convention is
+//! M3 (see `abi-spec.md`).
+
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+mod diagnostic;
+mod meta;
+mod node;
+
+pub use diagnostic::{Diagnostic, Fix, RuleId, Severity};
+pub use meta::RuleMeta;
+pub use node::{Children, NodeRef};

--- a/crates/tzlint_pdk/src/meta.rs
+++ b/crates/tzlint_pdk/src/meta.rs
@@ -1,0 +1,60 @@
+//! Rule metadata the engine uses to schedule a rule.
+
+use alloc::vec::Vec;
+
+use tzlint_ast::NodeKind;
+
+use crate::{RuleId, Severity};
+
+/// Static metadata describing a rule: its id, the [`NodeKind`]s it wants to visit, and its
+/// default severity.
+///
+/// The engine applies the `node_kinds` filter itself (a rule is invoked only at matching
+/// nodes), so a rule cannot silently observe nothing because it forgot to filter. A
+/// cross-node rule registers for [`NodeKind::ROOT`] and walks its subtree via `NodeRef`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleMeta {
+    pub id: RuleId,
+    pub node_kinds: Vec<NodeKind>,
+    pub default_severity: Severity,
+}
+
+impl RuleMeta {
+    /// Build metadata for a rule.
+    pub fn new(
+        id: impl Into<RuleId>,
+        default_severity: Severity,
+        node_kinds: impl Into<Vec<NodeKind>>,
+    ) -> Self {
+        RuleMeta {
+            id: id.into(),
+            default_severity,
+            node_kinds: node_kinds.into(),
+        }
+    }
+
+    /// Whether this rule wants to visit `kind`.
+    pub fn visits(&self, kind: NodeKind) -> bool {
+        self.node_kinds.contains(&kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn visits_only_registered_kinds() {
+        let meta = RuleMeta::new(
+            "sentence-length",
+            Severity::Warning,
+            vec![NodeKind::PARAGRAPH, NodeKind::HEADING],
+        );
+        assert!(meta.visits(NodeKind::PARAGRAPH));
+        assert!(meta.visits(NodeKind::HEADING));
+        assert!(!meta.visits(NodeKind::TEXT));
+        assert_eq!(meta.default_severity, Severity::Warning);
+        assert_eq!(meta.id.as_str(), "sentence-length");
+    }
+}

--- a/crates/tzlint_pdk/src/node.rs
+++ b/crates/tzlint_pdk/src/node.rs
@@ -1,0 +1,191 @@
+//! [`NodeRef`] — an ergonomic, zero-copy cursor over the archived AST.
+
+use tzlint_ast::{ArchivedAst, ArchivedNode, NodeId, NodeKind, Span};
+
+/// A lightweight, copyable cursor into an [`ArchivedAst`].
+///
+/// Every accessor reads the archived data **in place** — no allocation and no per-node
+/// deserialize (which is forbidden in the hot path). Navigation follows the frozen
+/// `first_child` / `next_sibling` / `parent` links.
+#[derive(Clone, Copy)]
+pub struct NodeRef<'ast> {
+    ast: &'ast ArchivedAst,
+    id: NodeId,
+    node: &'ast ArchivedNode,
+}
+
+impl<'ast> NodeRef<'ast> {
+    /// A cursor at `id`, or `None` if `id` is out of range.
+    pub fn at(ast: &'ast ArchivedAst, id: NodeId) -> Option<Self> {
+        ast.node(id).map(|node| NodeRef { ast, id, node })
+    }
+
+    /// A cursor at the document root, or `None` if the tree is empty.
+    pub fn root(ast: &'ast ArchivedAst) -> Option<Self> {
+        Self::at(ast, ast.root())
+    }
+
+    /// This node's id.
+    pub fn id(&self) -> NodeId {
+        self.id
+    }
+
+    /// This node's kind.
+    pub fn kind(&self) -> NodeKind {
+        self.node.kind()
+    }
+
+    /// This node's absolute byte span.
+    pub fn span(&self) -> Span {
+        self.node.span()
+    }
+
+    /// The source text this node covers (empty if the span is somehow out of range).
+    pub fn text(&self) -> &'ast str {
+        self.ast.text_of(self.node.span()).unwrap_or("")
+    }
+
+    /// The parent node, or `None` for the root (whose parent is itself).
+    pub fn parent(&self) -> Option<NodeRef<'ast>> {
+        if self.id == self.ast.root() {
+            None
+        } else {
+            Self::at(self.ast, self.node.parent())
+        }
+    }
+
+    /// The first child, if any.
+    pub fn first_child(&self) -> Option<NodeRef<'ast>> {
+        self.node.first_child().and_then(|c| Self::at(self.ast, c))
+    }
+
+    /// The next sibling, if any.
+    pub fn next_sibling(&self) -> Option<NodeRef<'ast>> {
+        self.node.next_sibling().and_then(|c| Self::at(self.ast, c))
+    }
+
+    /// An iterator over the direct children, in order.
+    pub fn children(&self) -> Children<'ast> {
+        Children {
+            next: self.first_child(),
+        }
+    }
+}
+
+/// Two cursors are equal when they point at the same node of the same archive.
+impl PartialEq for NodeRef<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && core::ptr::eq(self.ast, other.ast)
+    }
+}
+impl Eq for NodeRef<'_> {}
+
+impl core::fmt::Debug for NodeRef<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NodeRef")
+            .field("id", &self.id)
+            .field("kind", &self.kind())
+            .finish()
+    }
+}
+
+/// Iterator over a node's direct children (see [`NodeRef::children`]).
+#[derive(Clone)]
+pub struct Children<'ast> {
+    next: Option<NodeRef<'ast>>,
+}
+
+impl<'ast> Iterator for Children<'ast> {
+    type Item = NodeRef<'ast>;
+    fn next(&mut self) -> Option<Self::Item> {
+        let current = self.next?;
+        self.next = current.next_sibling();
+        Some(current)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use tzlint_ast::{Ast, Node, OptionNodeId};
+
+    /// `# Hi\n\nbody` → Root → [Heading → Text("Hi"), Paragraph → Text("body")].
+    fn sample() -> Ast {
+        let nodes = vec![
+            Node {
+                kind: NodeKind::ROOT,
+                span: Span::new(0, 10),
+                parent: NodeId(0),
+                first_child: OptionNodeId::some(NodeId(1)),
+                next_sibling: OptionNodeId::NONE,
+            },
+            Node {
+                kind: NodeKind::HEADING,
+                span: Span::new(0, 4), // "# Hi"
+                parent: NodeId(0),
+                first_child: OptionNodeId::some(NodeId(2)),
+                next_sibling: OptionNodeId::some(NodeId(3)),
+            },
+            Node {
+                kind: NodeKind::TEXT,
+                span: Span::new(2, 4), // "Hi"
+                parent: NodeId(1),
+                first_child: OptionNodeId::NONE,
+                next_sibling: OptionNodeId::NONE,
+            },
+            Node {
+                kind: NodeKind::PARAGRAPH,
+                span: Span::new(6, 10), // "body"
+                parent: NodeId(0),
+                first_child: OptionNodeId::some(NodeId(4)),
+                next_sibling: OptionNodeId::NONE,
+            },
+            Node {
+                kind: NodeKind::TEXT,
+                span: Span::new(6, 10), // "body"
+                parent: NodeId(3),
+                first_child: OptionNodeId::NONE,
+                next_sibling: OptionNodeId::NONE,
+            },
+        ];
+        Ast {
+            nodes,
+            text: alloc::string::String::from("# Hi\n\nbody"),
+            root: NodeId(0),
+        }
+    }
+
+    #[test]
+    fn navigates_the_archive_in_place() {
+        let bytes = tzlint_ast::to_archive(&sample()).unwrap();
+        let ast = tzlint_ast::access(&bytes).unwrap();
+
+        let root = NodeRef::root(ast).unwrap();
+        assert_eq!(root.kind(), NodeKind::ROOT);
+        assert_eq!(root.parent(), None); // root's parent is itself → None
+
+        let kids: alloc::vec::Vec<_> = root.children().map(|c| c.kind()).collect();
+        assert_eq!(kids, vec![NodeKind::HEADING, NodeKind::PARAGRAPH]);
+
+        let heading = root.first_child().unwrap();
+        assert_eq!(heading.text(), "# Hi");
+        let para = heading.next_sibling().unwrap();
+        assert_eq!(para.kind(), NodeKind::PARAGRAPH);
+        assert_eq!(para.text(), "body");
+        assert_eq!(para.next_sibling(), None);
+
+        // child → text, and back up to the parent heading.
+        let hi = heading.first_child().unwrap();
+        assert_eq!(hi.kind(), NodeKind::TEXT);
+        assert_eq!(hi.text(), "Hi");
+        assert_eq!(hi.parent().unwrap().id(), heading.id());
+    }
+
+    #[test]
+    fn out_of_range_id_is_none() {
+        let bytes = tzlint_ast::to_archive(&sample()).unwrap();
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        assert!(NodeRef::at(ast, NodeId(99)).is_none());
+    }
+}

--- a/crates/tzlint_pdk/src/node.rs
+++ b/crates/tzlint_pdk/src/node.rs
@@ -188,4 +188,23 @@ mod tests {
         let ast = tzlint_ast::access(&bytes).unwrap();
         assert!(NodeRef::at(ast, NodeId(99)).is_none());
     }
+
+    #[test]
+    fn span_equality_and_debug() {
+        let bytes = tzlint_ast::to_archive(&sample()).unwrap();
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        let root = NodeRef::root(ast).unwrap();
+        let heading = root.first_child().unwrap();
+        let para = heading.next_sibling().unwrap();
+
+        assert_eq!(heading.span(), Span::new(0, 4));
+
+        // Equality is same-node-of-same-archive.
+        assert_eq!(heading, NodeRef::at(ast, NodeId(1)).unwrap());
+        assert_ne!(heading, para);
+
+        let shown = alloc::format!("{heading:?}");
+        assert!(shown.contains("NodeRef"), "{shown}");
+        assert!(shown.contains("NodeId(1)"), "{shown}"); // the heading's id
+    }
 }


### PR DESCRIPTION
## M1c-1 — rule-facing diagnostic model + zero-copy `NodeRef`

First half of **M1c** (split for reviewability; the engine + autofix follow in M1c-2). Builds on the frozen AST (#1) and the parser (#5).

### `tzlint_pdk` — the rule-authoring surface
- **Diagnostic model**: `RuleId` (lowercase kebab-case; a public contract used in config/cache keys), `Severity` (Error/Warning/Info/Hint), `Fix` (`replace`/`delete`, absolute byte span), `Diagnostic` (rule_id/severity/message/span/fixes + a **stable within-file sort key** `(span.start, span.end, rule_id, message)`), and `RuleMeta` (id + the `node_kinds` the engine filters on + default severity).
- **`NodeRef<'ast>`**: a copyable, **zero-copy** cursor over the archived AST — `kind`/`span`/`text`/`parent`/`first_child`/`next_sibling`/`children`, all reading in place (no per-node deserialize, per the frozen-AST design). Equality is same-node-of-same-archive.
- `no_std` (alloc) and **builds for `wasm32`** — it sits on the guest side of the future plugin ABI.

### `tzlint_ast` — archive bridge
- `to_archive(&Ast) -> AlignedVec` (serialize) and `access(&[u8]) -> &ArchivedAst` (checked, in-place via bytecheck). The single centralized rkyv entry point, so the pinned-LE/32-bit/bytecheck config stays in one place.

### Deferred to M1c-2
The `Rule` trait, `Context`, the single-traversal multi-visitor engine, and autofix (sort + conflict resolution + fixpoint).

### Verification
`cargo fmt --check`, `clippy -D warnings`, nextest (41 workspace), doctests, and `wasm32` build of `tzlint_ast` + `tzlint_pdk` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ルール定義用の診断・メタデータ・ノード走査APIを追加しました
  * AST（抽象構文木）のアーカイブ化とゼロコピー参照機能を実装しました
  * プラグイン開発キットの公開インターフェースを整備し、ルール実装の基盤を確立しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simorgh3196/tsuzulint/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->