### PR TITLE
M1c-2: single-traversal engine + autofix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ version = "0.0.0"
 dependencies = [
  "markdown",
  "tzlint_ast",
+ "tzlint_pdk",
 ]
 
 [[package]]

--- a/crates/tzlint_ast/src/lib.rs
+++ b/crates/tzlint_ast/src/lib.rs
@@ -405,9 +405,13 @@ impl ArchivedAst {
 // The one place that serializes/accesses the frozen archive, so the rkyv configuration
 // (pinned little-endian, 32-bit pointers, bytecheck) stays centralized here.
 
+/// The aligned byte buffer produced by [`to_archive`]. Re-exported so consumers (the cache,
+/// the CLI) can name and store an archive without depending on rkyv directly.
+pub use rkyv::util::AlignedVec;
+
 /// Serialize an [`Ast`] into its frozen archive. The returned buffer is correctly aligned
 /// for [`access`].
-pub fn to_archive(ast: &Ast) -> Result<rkyv::util::AlignedVec, rkyv::rancor::Error> {
+pub fn to_archive(ast: &Ast) -> Result<AlignedVec, rkyv::rancor::Error> {
     rkyv::to_bytes::<rkyv::rancor::Error>(ast)
 }
 

--- a/crates/tzlint_core/Cargo.toml
+++ b/crates/tzlint_core/Cargo.toml
@@ -13,4 +13,5 @@ workspace = true
 
 [dependencies]
 tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 markdown = { workspace = true }

--- a/crates/tzlint_core/src/engine.rs
+++ b/crates/tzlint_core/src/engine.rs
@@ -1,0 +1,169 @@
+//! The single-traversal, multi-visitor lint engine.
+
+use tzlint_ast::ArchivedAst;
+use tzlint_pdk::{Context, Diagnostic, NodeRef, Rule};
+
+/// The lint engine. Stateless for now (config/rule-registry land later); the one dispatch
+/// entry point for CLI, LSP, native, and (future) plugin rules.
+pub struct Engine;
+
+impl Engine {
+    /// Lint an archived AST with `rules`, returning diagnostics in the stable total order
+    /// `(span.start, span.end, rule_id, message)` — independent of traversal/scheduling.
+    ///
+    /// Native rules share **one** pre-order traversal: the AST is walked once and, at each
+    /// node, only the rules whose [`node_kinds`](tzlint_pdk::RuleMeta) include that node's
+    /// kind are invoked. Each rule keeps its own [`Context`] across the walk; every rule's
+    /// `finish` runs once afterwards. The walk is iterative, so even a deeply nested tree
+    /// cannot overflow the stack here.
+    #[must_use]
+    pub fn lint(ast: &ArchivedAst, rules: &[&dyn Rule]) -> Vec<Diagnostic> {
+        // One context per rule (rule-scoped accumulation).
+        let mut contexts: Vec<Context> = rules
+            .iter()
+            .map(|rule| {
+                let meta = rule.meta();
+                Context::new(ast, meta.id.clone(), meta.default_severity)
+            })
+            .collect();
+
+        // Single pre-order walk; dispatch each node to the rules that registered its kind.
+        if let Some(root) = NodeRef::root(ast) {
+            let mut stack = vec![root];
+            while let Some(node) = stack.pop() {
+                let kind = node.kind();
+                for (rule, cx) in rules.iter().zip(contexts.iter_mut()) {
+                    if rule.meta().visits(kind) {
+                        rule.check(node, cx);
+                    }
+                }
+                // Push children reversed so they pop in document order.
+                let children: Vec<NodeRef> = node.children().collect();
+                for child in children.into_iter().rev() {
+                    stack.push(child);
+                }
+            }
+        }
+
+        // Cross-node finalize, then aggregate and sort into the stable total order.
+        for (rule, cx) in rules.iter().zip(contexts.iter_mut()) {
+            rule.finish(cx);
+        }
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+        for cx in contexts {
+            diagnostics.extend(cx.into_diagnostics());
+        }
+        diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
+        diagnostics
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+    use tzlint_ast::{NodeKind, Span};
+    use tzlint_pdk::{RuleMeta, Severity};
+
+    /// Reports `message` at every node of `kind`.
+    struct FlagKind {
+        meta: RuleMeta,
+        message: &'static str,
+    }
+    impl FlagKind {
+        fn new(id: &str, kind: NodeKind, message: &'static str) -> Self {
+            FlagKind {
+                meta: RuleMeta::new(id, Severity::Warning, vec![kind]),
+                message,
+            }
+        }
+    }
+    impl Rule for FlagKind {
+        fn meta(&self) -> &RuleMeta {
+            &self.meta
+        }
+        fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+            cx.report(node.span(), self.message);
+        }
+    }
+
+    /// A document-level rule: registers for no node kind, then in `finish` walks the whole
+    /// tree from `cx.ast()` (the subtree-self-traversal pattern) and reports the count once.
+    /// State lives in locals, never in `&self`.
+    struct CountNodes {
+        meta: RuleMeta,
+    }
+    impl Rule for CountNodes {
+        fn meta(&self) -> &RuleMeta {
+            &self.meta
+        }
+        fn check<'ast>(&self, _node: NodeRef<'ast>, _cx: &mut Context<'ast>) {}
+        fn finish<'ast>(&self, cx: &mut Context<'ast>) {
+            let mut count = 0u32;
+            let mut stack: Vec<NodeRef> = NodeRef::root(cx.ast()).into_iter().collect();
+            while let Some(node) = stack.pop() {
+                count += 1;
+                stack.extend(node.children());
+            }
+            cx.report(Span::new(0, 0), format!("{count} nodes"));
+        }
+    }
+
+    fn archive(src: &str) -> tzlint_ast::AlignedVec {
+        tzlint_ast::to_archive(&parse(src).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn dispatches_only_to_registered_kinds() {
+        // "# H\n\nbody" → Root, Heading, Text("H"), Paragraph, Text("body").
+        let bytes = archive("# H\n\nbody");
+        let ast = tzlint_ast::access(&bytes).unwrap();
+
+        let text_rule = FlagKind::new("flag-text", NodeKind::TEXT, "text");
+        let heading_rule = FlagKind::new("flag-heading", NodeKind::HEADING, "heading");
+        let diags = Engine::lint(ast, &[&text_rule, &heading_rule]);
+
+        // 2 Text nodes + 1 Heading = 3 diagnostics.
+        assert_eq!(diags.len(), 3);
+        assert_eq!(diags.iter().filter(|d| d.message == "text").count(), 2);
+        assert_eq!(diags.iter().filter(|d| d.message == "heading").count(), 1);
+    }
+
+    #[test]
+    fn output_is_in_stable_sorted_order() {
+        let bytes = archive("# H\n\nbody");
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        // Two rules over the same kind produce diagnostics at the same spans; sorting must
+        // be deterministic by (start, end, rule_id, message).
+        let a = FlagKind::new("a-rule", NodeKind::TEXT, "msg");
+        let b = FlagKind::new("b-rule", NodeKind::TEXT, "msg");
+        let diags = Engine::lint(ast, &[&b, &a]); // pass b first on purpose
+        let keys: Vec<_> = diags
+            .iter()
+            .map(|d| (d.span.start, d.rule_id.as_str()))
+            .collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted, "diagnostics must come out sorted");
+    }
+
+    #[test]
+    fn finish_emits_a_document_level_diagnostic() {
+        let bytes = archive("# H\n\nbody");
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        let counter = CountNodes {
+            meta: RuleMeta::new("count", Severity::Info, Vec::<NodeKind>::new()),
+        };
+        let diags = Engine::lint(ast, &[&counter]);
+        // `finish` walks the whole tree: Root + Heading + Text + Paragraph + Text = 5.
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].message, "5 nodes");
+    }
+
+    #[test]
+    fn no_rules_yields_no_diagnostics() {
+        let bytes = archive("text");
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        assert!(Engine::lint(ast, &[]).is_empty());
+    }
+}

--- a/crates/tzlint_core/src/engine.rs
+++ b/crates/tzlint_core/src/engine.rs
@@ -69,7 +69,7 @@ impl Engine {
 mod tests {
     use super::*;
     use crate::parse;
-    use tzlint_ast::{NodeKind, Span};
+    use tzlint_ast::{Ast, NodeId, NodeKind, Span};
     use tzlint_pdk::{RuleMeta, Severity};
 
     /// Reports `message` at every node of `kind`.
@@ -94,9 +94,10 @@ mod tests {
         }
     }
 
-    /// A document-level rule: registers for no node kind, then in `finish` walks the whole
-    /// tree from `cx.ast()` (the subtree-self-traversal pattern) and reports the count once.
-    /// State lives in locals, never in `&self`.
+    /// A document-level rule: registers for `ROOT` (its `check` is a no-op — the work is
+    /// cross-node), then in `finish` walks the whole tree from `cx.ast()` (the
+    /// subtree-self-traversal pattern) and reports the count once. State lives in locals,
+    /// never in `&self`.
     struct CountNodes {
         meta: RuleMeta,
     }
@@ -159,10 +160,11 @@ mod tests {
         let bytes = archive("# H\n\nbody");
         let ast = tzlint_ast::access(&bytes).unwrap();
         let counter = CountNodes {
-            meta: RuleMeta::new("count", Severity::Info, Vec::<NodeKind>::new()),
+            meta: RuleMeta::new("count", Severity::Info, vec![NodeKind::ROOT]),
         };
         let diags = Engine::lint(ast, &[&counter]);
-        // `finish` walks the whole tree: Root + Heading + Text + Paragraph + Text = 5.
+        // check() is a no-op called once at the root; finish() walks the whole tree:
+        // Root + Heading + Text + Paragraph + Text = 5.
         assert_eq!(diags.len(), 1);
         assert_eq!(diags[0].message, "5 nodes");
     }
@@ -172,5 +174,19 @@ mod tests {
         let bytes = archive("text");
         let ast = tzlint_ast::access(&bytes).unwrap();
         assert!(Engine::lint(ast, &[]).is_empty());
+    }
+
+    #[test]
+    fn lint_on_a_rootless_archive_is_safe() {
+        // A degenerate archive whose root index has no node: the walk is skipped, no panic.
+        let bytes = tzlint_ast::to_archive(&Ast {
+            nodes: vec![],
+            text: String::new(),
+            root: NodeId(0),
+        })
+        .unwrap();
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        let rule = FlagKind::new("flag-text", NodeKind::TEXT, "text");
+        assert!(Engine::lint(ast, &[&rule]).is_empty());
     }
 }

--- a/crates/tzlint_core/src/engine.rs
+++ b/crates/tzlint_core/src/engine.rs
@@ -18,36 +18,43 @@ impl Engine {
     /// cannot overflow the stack here.
     #[must_use]
     pub fn lint(ast: &ArchivedAst, rules: &[&dyn Rule]) -> Vec<Diagnostic> {
-        // One context per rule (rule-scoped accumulation).
-        let mut contexts: Vec<Context> = rules
+        // Hoist metadata once (not per node × rule); one context per rule.
+        let metas: Vec<&tzlint_pdk::RuleMeta> = rules.iter().map(|rule| rule.meta()).collect();
+        let mut contexts: Vec<Context> = metas
             .iter()
-            .map(|rule| {
-                let meta = rule.meta();
-                Context::new(ast, meta.id.clone(), meta.default_severity)
-            })
+            .map(|meta| Context::new(ast, meta.id.clone(), meta.default_severity))
             .collect();
 
-        // Single pre-order walk; dispatch each node to the rules that registered its kind.
+        // Single pre-order walk. A `visited` bitmap makes it cycle-safe and bounds total
+        // work to the node count, so a malformed archive — whose links `access` validates as
+        // bytes but not as a graph — can neither loop nor OOM here.
         if let Some(root) = NodeRef::root(ast) {
+            let mut visited = vec![false; ast.len()];
+            if let Some(slot) = visited.get_mut(root.id().0 as usize) {
+                *slot = true;
+            }
             let mut stack = vec![root];
             while let Some(node) = stack.pop() {
                 let kind = node.kind();
-                for (rule, cx) in rules.iter().zip(contexts.iter_mut()) {
-                    if rule.meta().visits(kind) {
-                        rule.check(node, cx);
+                for (index, cx) in contexts.iter_mut().enumerate() {
+                    if metas[index].visits(kind) {
+                        rules[index].check(node, cx);
                     }
                 }
-                // Push children reversed so they pop in document order.
-                let children: Vec<NodeRef> = node.children().collect();
-                for child in children.into_iter().rev() {
-                    stack.push(child);
+                for child in node.children() {
+                    if let Some(slot) = visited.get_mut(child.id().0 as usize)
+                        && !*slot
+                    {
+                        *slot = true;
+                        stack.push(child);
+                    }
                 }
             }
         }
 
         // Cross-node finalize, then aggregate and sort into the stable total order.
-        for (rule, cx) in rules.iter().zip(contexts.iter_mut()) {
-            rule.finish(cx);
+        for (index, cx) in contexts.iter_mut().enumerate() {
+            rules[index].finish(cx);
         }
         let mut diagnostics: Vec<Diagnostic> = Vec::new();
         for cx in contexts {

--- a/crates/tzlint_core/src/fix.rs
+++ b/crates/tzlint_core/src/fix.rs
@@ -24,15 +24,19 @@ pub struct FixPass {
 /// starting at the same offset the **longest wins**. Non-overlapping fixes apply; a fix
 /// overlapping an already-applied one is **deferred** for a later pass, as is any fix whose
 /// span is inverted, out of range, or not on UTF-8 char boundaries. Spans are absolute byte
-/// offsets into `source`.
+/// offsets into `source`. Zero-width insertions (`start == end`) at the same offset do not
+/// overlap, so they all apply, concatenated in the deterministic sort order.
 #[must_use]
 pub fn apply_fixes(source: &str, diagnostics: &[Diagnostic]) -> FixPass {
     let mut fixes: Vec<&Fix> = diagnostics.iter().flat_map(|d| d.fixes.iter()).collect();
+    // Order: start asc, then end desc (longest-at-a-start wins), then replacement — the last
+    // key makes the order a deterministic *total* order, independent of input/rule order.
     fixes.sort_by(|a, b| {
         a.span
             .start
             .cmp(&b.span.start)
             .then(b.span.end.cmp(&a.span.end))
+            .then_with(|| a.replacement.cmp(&b.replacement))
     });
 
     let mut output = String::with_capacity(source.len());
@@ -135,6 +139,19 @@ mod tests {
         let pass = apply_fixes("hello", &diags);
         assert_eq!(pass.output, "hello"); // unchanged
         assert_eq!((pass.applied, pass.deferred), (0, 2));
+    }
+
+    #[test]
+    fn zero_width_insertions_at_same_offset_all_apply_in_sort_order() {
+        // Two pure insertions at offset 1 (empty spans). Neither overlaps, so both apply;
+        // the order is deterministic by replacement ("A" before "B").
+        let diags = [
+            diag_with_fix(Span::new(1, 1), "B"),
+            diag_with_fix(Span::new(1, 1), "A"),
+        ];
+        let pass = apply_fixes("xy", &diags);
+        assert_eq!(pass.output, "xABy");
+        assert_eq!((pass.applied, pass.deferred), (2, 0));
     }
 
     /// Replaces each Text node's content with `find`→`replace` (a whole-span swap).

--- a/crates/tzlint_core/src/fix.rs
+++ b/crates/tzlint_core/src/fix.rs
@@ -154,6 +154,16 @@ mod tests {
         assert_eq!((pass.applied, pass.deferred), (2, 0));
     }
 
+    #[test]
+    fn fix_splitting_a_multibyte_char_is_deferred() {
+        // "あ" is 3 bytes; the span [0,1) ends inside the char (not a UTF-8 boundary), so the
+        // fix can't be sliced and is deferred rather than corrupting the output.
+        let diags = [diag_with_fix(Span::new(0, 1), "x")];
+        let pass = apply_fixes("あ", &diags);
+        assert_eq!(pass.output, "あ");
+        assert_eq!((pass.applied, pass.deferred), (0, 1));
+    }
+
     /// Replaces each Text node's content with `find`→`replace` (a whole-span swap).
     struct Rewrite {
         meta: RuleMeta,

--- a/crates/tzlint_core/src/fix.rs
+++ b/crates/tzlint_core/src/fix.rs
@@ -1,0 +1,199 @@
+//! Applying autofixes with deterministic conflict resolution.
+
+use tzlint_pdk::{Diagnostic, Fix, Rule};
+
+use crate::Engine;
+
+/// Maximum number of lint→fix passes (ESLint semantics), guaranteeing termination.
+pub const MAX_FIX_PASSES: usize = 10;
+
+/// The outcome of one [`apply_fixes`] pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FixPass {
+    /// The text after applying the non-conflicting fixes.
+    pub output: String,
+    /// How many fixes were applied.
+    pub applied: usize,
+    /// How many fixes were deferred this pass (overlapping or invalid).
+    pub deferred: usize,
+}
+
+/// Apply the fixes carried by `diagnostics` to `source` in one left-to-right pass.
+///
+/// Fixes are ordered by `(span.start` ascending`, span.end` descending`)`, so among fixes
+/// starting at the same offset the **longest wins**. Non-overlapping fixes apply; a fix
+/// overlapping an already-applied one is **deferred** for a later pass, as is any fix whose
+/// span is inverted, out of range, or not on UTF-8 char boundaries. Spans are absolute byte
+/// offsets into `source`.
+#[must_use]
+pub fn apply_fixes(source: &str, diagnostics: &[Diagnostic]) -> FixPass {
+    let mut fixes: Vec<&Fix> = diagnostics.iter().flat_map(|d| d.fixes.iter()).collect();
+    fixes.sort_by(|a, b| {
+        a.span
+            .start
+            .cmp(&b.span.start)
+            .then(b.span.end.cmp(&a.span.end))
+    });
+
+    let mut output = String::with_capacity(source.len());
+    let mut cursor: usize = 0; // bytes of `source` already copied into `output`
+    let mut applied = 0;
+    let mut deferred = 0;
+
+    for fix in fixes {
+        let start = fix.span.start as usize;
+        let end = fix.span.end as usize;
+        // Defer inverted/out-of-range spans and any that overlap an applied fix.
+        if end < start || end > source.len() || start < cursor {
+            deferred += 1;
+            continue;
+        }
+        // Both the gap and the replaced region must slice on char boundaries.
+        let (Some(gap), Some(_)) = (source.get(cursor..start), source.get(start..end)) else {
+            deferred += 1;
+            continue;
+        };
+        output.push_str(gap);
+        output.push_str(&fix.replacement);
+        cursor = end;
+        applied += 1;
+    }
+    if let Some(tail) = source.get(cursor..) {
+        output.push_str(tail);
+    }
+    FixPass {
+        output,
+        applied,
+        deferred,
+    }
+}
+
+/// Lint-and-fix `source` to a fixpoint: parse → lint → apply, repeating until the text
+/// stops changing or [`MAX_FIX_PASSES`] is reached (which guarantees termination). Returns
+/// the fixed text; a parse failure leaves the current text unchanged.
+#[must_use]
+pub fn fix(source: &str, rules: &[&dyn Rule]) -> String {
+    let mut text = source.to_string();
+    for _ in 0..MAX_FIX_PASSES {
+        let Ok(ast) = crate::parse(&text) else { break };
+        let Ok(bytes) = tzlint_ast::to_archive(&ast) else {
+            break;
+        };
+        let Ok(archived) = tzlint_ast::access(&bytes) else {
+            break;
+        };
+        let diagnostics = Engine::lint(archived, rules);
+        let pass = apply_fixes(&text, &diagnostics);
+        if pass.output == text {
+            break; // fixpoint: nothing changed
+        }
+        text = pass.output;
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tzlint_ast::{NodeKind, Span};
+    use tzlint_pdk::{Context, NodeRef, RuleMeta, Severity};
+
+    fn diag_with_fix(span: Span, replacement: &str) -> Diagnostic {
+        Diagnostic::new("t", Severity::Warning, span, "m").with_fix(Fix::replace(span, replacement))
+    }
+
+    #[test]
+    fn applies_non_overlapping_fixes_left_to_right() {
+        // "0123456789": replace [1,3) with "A" and [5,7) with "B".
+        let diags = [
+            diag_with_fix(Span::new(1, 3), "A"),
+            diag_with_fix(Span::new(5, 7), "B"),
+        ];
+        let pass = apply_fixes("0123456789", &diags);
+        assert_eq!(pass.output, "0A34B789");
+        assert_eq!((pass.applied, pass.deferred), (2, 0));
+    }
+
+    #[test]
+    fn overlapping_fixes_longest_wins_other_deferred() {
+        // Same start: [1,5) "X" (longer) beats [1,3) "Y"; the loser is deferred.
+        let diags = [
+            diag_with_fix(Span::new(1, 3), "Y"),
+            diag_with_fix(Span::new(1, 5), "X"),
+        ];
+        let pass = apply_fixes("012345", &diags);
+        assert_eq!(pass.output, "0X5");
+        assert_eq!((pass.applied, pass.deferred), (1, 1));
+    }
+
+    #[test]
+    fn invalid_spans_are_deferred_not_applied() {
+        let diags = [
+            diag_with_fix(Span::new(3, 2), "inverted"),
+            diag_with_fix(Span::new(0, 999), "out of range"),
+        ];
+        let pass = apply_fixes("hello", &diags);
+        assert_eq!(pass.output, "hello"); // unchanged
+        assert_eq!((pass.applied, pass.deferred), (0, 2));
+    }
+
+    /// Replaces each Text node's content with `find`→`replace` (a whole-span swap).
+    struct Rewrite {
+        meta: RuleMeta,
+        find: &'static str,
+        replace: &'static str,
+    }
+    impl Rewrite {
+        fn new(find: &'static str, replace: &'static str) -> Self {
+            Rewrite {
+                meta: RuleMeta::new("rewrite", Severity::Warning, vec![NodeKind::TEXT]),
+                find,
+                replace,
+            }
+        }
+    }
+    impl Rule for Rewrite {
+        fn meta(&self) -> &RuleMeta {
+            &self.meta
+        }
+        fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+            if node.text() == self.find {
+                cx.report_with_fixes(
+                    node.span(),
+                    "rewrite",
+                    [Fix::replace(node.span(), self.replace)],
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fix_converges_when_no_more_apply() {
+        // Once "BAD" → "ok", re-linting finds nothing, so it stops.
+        let rule = Rewrite::new("BAD", "ok");
+        assert_eq!(fix("BAD\n", &[&rule]), "ok\n");
+    }
+
+    #[test]
+    fn fix_terminates_at_the_pass_cap() {
+        // A rule that always grows the text never reaches a fixpoint; the cap stops it.
+        struct Grow {
+            meta: RuleMeta,
+        }
+        impl Rule for Grow {
+            fn meta(&self) -> &RuleMeta {
+                &self.meta
+            }
+            fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+                let grown = format!("{}!", node.text());
+                cx.report_with_fixes(node.span(), "grow", [Fix::replace(node.span(), grown)]);
+            }
+        }
+        let rule = Grow {
+            meta: RuleMeta::new("grow", Severity::Warning, vec![NodeKind::TEXT]),
+        };
+        // Starts as "a"; each of the 10 passes appends one '!'.
+        let out = fix("a", &[&rule]);
+        assert_eq!(out, format!("a{}", "!".repeat(MAX_FIX_PASSES)));
+    }
+}

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -8,11 +8,16 @@
 //!   atomic writes), behind a `Host` provider abstraction so embedders inject their
 //!   environment (native fs / Node / browser).
 //!
-//! Landed so far (M1b): the [`parse`] function (markdown-rs + mdast → index-AST transform)
-//! and the [`LineIndex`] position mapper. TODO(M1): the engine, config, cache, and io.
+//! Landed so far: the [`parse`] function + [`LineIndex`] position mapper (M1b), and the
+//! single-traversal [`Engine`] + autofix [`fix`]/[`apply_fixes`] (M1c-2). TODO(M1): config,
+//! cache, and io.
 
+pub mod engine;
+pub mod fix;
 pub mod parse;
 pub mod position;
 
+pub use engine::Engine;
+pub use fix::{FixPass, MAX_FIX_PASSES, apply_fixes, fix};
 pub use parse::{ParseError, parse};
 pub use position::LineIndex;

--- a/crates/tzlint_pdk/src/lib.rs
+++ b/crates/tzlint_pdk/src/lib.rs
@@ -5,9 +5,9 @@
 //! [`RuleMeta`]. v1 ships a single Rust PDK; the surface is `no_std` (alloc) so it can sit
 //! on the `wasm32` guest side of the plugin ABI.
 //!
-//! Landed in M1c-1: the diagnostic model + `NodeRef` facade + `RuleMeta`. The `Rule` trait
-//! and `Context` land with the engine (M1c-2); the frozen plugin ABI calling convention is
-//! M3 (see `abi-spec.md`).
+//! Landed: the diagnostic model + `NodeRef` facade + `RuleMeta` (M1c-1) and the [`Rule`]
+//! trait + [`Context`] (M1c-2). The frozen plugin ABI calling convention is M3 (see
+//! `abi-spec.md`).
 
 #![cfg_attr(not(test), no_std)]
 
@@ -16,7 +16,9 @@ extern crate alloc;
 mod diagnostic;
 mod meta;
 mod node;
+mod rule;
 
 pub use diagnostic::{Diagnostic, Fix, RuleId, Severity};
 pub use meta::RuleMeta;
 pub use node::{Children, NodeRef};
+pub use rule::{Context, Rule};

--- a/crates/tzlint_pdk/src/meta.rs
+++ b/crates/tzlint_pdk/src/meta.rs
@@ -11,7 +11,10 @@ use crate::{RuleId, Severity};
 ///
 /// The engine applies the `node_kinds` filter itself (a rule is invoked only at matching
 /// nodes), so a rule cannot silently observe nothing because it forgot to filter. A
-/// cross-node rule registers for [`NodeKind::ROOT`] and walks its subtree via `NodeRef`.
+/// cross-node (document-level) rule self-traverses via `NodeRef`: it either registers for
+/// [`NodeKind::ROOT`] and walks the subtree from its [`check`](crate::Rule::check), or
+/// registers for no kind and walks from [`finish`](crate::Rule::finish) via
+/// [`Context::ast`](crate::Context::ast).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuleMeta {
     pub id: RuleId,

--- a/crates/tzlint_pdk/src/node.rs
+++ b/crates/tzlint_pdk/src/node.rs
@@ -68,6 +68,11 @@ impl<'ast> NodeRef<'ast> {
     pub fn children(&self) -> Children<'ast> {
         Children {
             next: self.first_child(),
+            // A valid sibling chain can never exceed the node count. This bounds the
+            // iterator so a malformed (e.g. cyclic) `next_sibling` link — possible in an
+            // arbitrary archive, since `access` validates byte types but not the link graph
+            // — cannot loop forever.
+            remaining: self.ast.len(),
         }
     }
 }
@@ -90,15 +95,23 @@ impl core::fmt::Debug for NodeRef<'_> {
 }
 
 /// Iterator over a node's direct children (see [`NodeRef::children`]).
+///
+/// Bounded: it yields at most `ast.len()` items, so a cyclic `next_sibling` link in a
+/// malformed archive terminates the iterator instead of looping forever.
 #[derive(Clone)]
 pub struct Children<'ast> {
     next: Option<NodeRef<'ast>>,
+    remaining: usize,
 }
 
 impl<'ast> Iterator for Children<'ast> {
     type Item = NodeRef<'ast>;
     fn next(&mut self) -> Option<Self::Item> {
         let current = self.next?;
+        if self.remaining == 0 {
+            return None; // hit the node-count bound → the chain must be cyclic
+        }
+        self.remaining -= 1;
         self.next = current.next_sibling();
         Some(current)
     }
@@ -206,5 +219,36 @@ mod tests {
         let shown = alloc::format!("{heading:?}");
         assert!(shown.contains("NodeRef"), "{shown}");
         assert!(shown.contains("NodeId(1)"), "{shown}"); // the heading's id
+    }
+
+    #[test]
+    fn children_is_bounded_on_a_cyclic_archive() {
+        // A malformed (but byte-valid) archive whose sibling chain is cyclic must not loop
+        // forever: node 1's `next_sibling` points back to itself.
+        let ast = Ast {
+            nodes: vec![
+                Node {
+                    kind: NodeKind::ROOT,
+                    span: Span::new(0, 1),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::some(NodeId(1)),
+                    next_sibling: OptionNodeId::NONE,
+                },
+                Node {
+                    kind: NodeKind::TEXT,
+                    span: Span::new(0, 1),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::NONE,
+                    next_sibling: OptionNodeId::some(NodeId(1)), // self-cycle
+                },
+            ],
+            text: alloc::string::String::from("x"),
+            root: NodeId(0),
+        };
+        let bytes = tzlint_ast::to_archive(&ast).unwrap();
+        let archived = tzlint_ast::access(&bytes).unwrap();
+        let root = NodeRef::root(archived).unwrap();
+        // Terminates (no hang) and is capped at the node count.
+        assert!(root.children().count() <= archived.len());
     }
 }

--- a/crates/tzlint_pdk/src/rule.rs
+++ b/crates/tzlint_pdk/src/rule.rs
@@ -72,7 +72,10 @@ impl<'ast> Context<'ast> {
 /// node whose kind is in [`RuleMeta::node_kinds`]. [`finish`](Rule::finish) runs once after
 /// the walk, for cross-node rules that accumulate in the [`Context`]. `&self` is immutable
 /// (rule instances are shared across workers); all per-file state lives in the `Context`.
-pub trait Rule {
+///
+/// The `Send + Sync` bound expresses that sharing: rule instances are `Arc`-shared across
+/// the (future) rayon workers that lint files in parallel.
+pub trait Rule: Send + Sync {
     /// Static metadata: id, the node kinds to visit, and default severity.
     fn meta(&self) -> &RuleMeta;
 

--- a/crates/tzlint_pdk/src/rule.rs
+++ b/crates/tzlint_pdk/src/rule.rs
@@ -1,0 +1,85 @@
+//! The [`Rule`] trait and the per-rule [`Context`] the engine drives.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use tzlint_ast::{ArchivedAst, Span};
+
+use crate::{Diagnostic, Fix, NodeRef, RuleId, RuleMeta, Severity};
+
+/// Per-rule, per-file scratch the engine hands to a rule during the single walk.
+///
+/// It is **rule-scoped** and persists across that rule's [`Rule::check`] calls, so a
+/// cross-node rule can accumulate state and emit from [`Rule::finish`]. Reported
+/// diagnostics are tagged with the rule's id and effective severity automatically.
+/// Accumulation lives here (not in `&self`) because rule instances are shared across
+/// worker threads.
+pub struct Context<'ast> {
+    ast: &'ast ArchivedAst,
+    rule_id: RuleId,
+    severity: Severity,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl<'ast> Context<'ast> {
+    /// Create a context for `rule_id` reporting at `severity` over `ast`. The engine builds
+    /// one of these per rule.
+    pub fn new(ast: &'ast ArchivedAst, rule_id: RuleId, severity: Severity) -> Self {
+        Context {
+            ast,
+            rule_id,
+            severity,
+            diagnostics: Vec::new(),
+        }
+    }
+
+    /// The archive, for a cross-node rule that self-traverses via [`NodeRef`].
+    pub fn ast(&self) -> &'ast ArchivedAst {
+        self.ast
+    }
+
+    /// Report a problem at `span`. The rule id and severity are filled in automatically.
+    pub fn report(&mut self, span: Span, message: impl Into<String>) {
+        self.diagnostics.push(Diagnostic::new(
+            self.rule_id.clone(),
+            self.severity,
+            span,
+            message,
+        ));
+    }
+
+    /// Report a problem at `span` carrying suggested [`Fix`]es.
+    pub fn report_with_fixes(
+        &mut self,
+        span: Span,
+        message: impl Into<String>,
+        fixes: impl IntoIterator<Item = Fix>,
+    ) {
+        let mut diagnostic = Diagnostic::new(self.rule_id.clone(), self.severity, span, message);
+        diagnostic.fixes.extend(fixes);
+        self.diagnostics.push(diagnostic);
+    }
+
+    /// Consume the accumulated diagnostics (the engine calls this after the walk).
+    pub fn into_diagnostics(self) -> Vec<Diagnostic> {
+        self.diagnostics
+    }
+}
+
+/// A lint rule. Native rules — and, later, plugin shims — implement this.
+///
+/// During the engine's **single traversal**, [`check`](Rule::check) is invoked once per
+/// node whose kind is in [`RuleMeta::node_kinds`]. [`finish`](Rule::finish) runs once after
+/// the walk, for cross-node rules that accumulate in the [`Context`]. `&self` is immutable
+/// (rule instances are shared across workers); all per-file state lives in the `Context`.
+pub trait Rule {
+    /// Static metadata: id, the node kinds to visit, and default severity.
+    fn meta(&self) -> &RuleMeta;
+
+    /// Inspect one matching node, reporting problems via `cx`.
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>);
+
+    /// Optional finalize after the walk (for cross-node / document-level rules). Default:
+    /// no-op.
+    fn finish<'ast>(&self, _cx: &mut Context<'ast>) {}
+}


### PR DESCRIPTION
## M1c-2 — single-traversal engine + autofix (completes M1c)

Builds on M1c-1 (#8: `NodeRef` + diagnostic model). Adds the rule API and the engine that runs it.

### `tzlint_pdk` — rule API
- **`Rule` trait** (`Send + Sync`): `meta()` / `check()` / `finish()`.
- **`Context<'ast>`**: per-rule, per-file scratch — `report` / `report_with_fixes` (auto-tags the rule id + severity) and `ast()` for subtree self-traversal. Accumulation lives here, not in `&self` (rules are shared across workers).

### `tzlint_core`
- **`Engine::lint(ast, rules)`**: one iterative pre-order traversal; at each node, dispatch only to the rules whose `node_kinds` match; each rule keeps its `Context` across the walk; `finish` runs once. Output is in the stable total order `(span.start, span.end, rule_id, message)`. **Cycle-safe** (visited bitmap) and stack-overflow-free (iterative) even on a malformed archive.
- **`apply_fixes` / `fix`**: single-pass fix application with deterministic conflict resolution (sort start asc / end desc → longest wins; overlapping & invalid deferred; `replacement` tie-break for a total order), plus a fixpoint loop capped at `MAX_FIX_PASSES = 10`.
- **`tzlint_ast`**: re-export `AlignedVec` so consumers can name an archive.

### Adversarial review (pre-PR)
A 3-lens review (engine / autofix / API-panic) ran before this PR; **10/12 findings confirmed and fixed** in the second commit. Notable: `access` validates bytes but not the link graph, so a cyclic archive could loop `NodeRef::children` / `Engine::lint` forever — now bounded (children cap + engine visited bitmap). Also autofix tie-break determinism, `Rule: Send + Sync`, zero-width-insertion semantics, and a docs reconcile.

### Verification
`cargo fmt --check`, `clippy -D warnings`, nextest (54 workspace), doctests, `wasm32` build — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 単一走査の AST リントエンジンを追加（安定した診断順で返却）
  * 自動修正（autofix）を追加。決定的な適用順・反復で固定点到達を試行
  * SDK にルール実装用の Context/Rule API を追加、コア経由でエンジン/自動修正APIを利用可能に

* **バグ修正**
  * 不正なアーカイブで子イテレータが無限ループする問題を修正

* **ドキュメント**
  * ルールの横断走査挙動を明確に記載
<!-- end of auto-generated comment: release notes by coderabbit.ai -->