### PR TITLE
M1d-2: multi-format config loader + presets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,10 +26,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "markdown"
@@ -39,6 +67,12 @@ checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
 dependencies = [
  "unicode-id",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "munge"
@@ -144,6 +178,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,8 +285,11 @@ name = "tzlint_core"
 version = "0.0.0"
 dependencies = [
  "markdown",
+ "serde",
+ "serde_json",
  "tzlint_ast",
  "tzlint_pdk",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -239,3 +325,22 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,16 @@ rkyv = { version = "0.8.16", default-features = false, features = [
 # frozen index-AST. Stable since 1.0 (2025-04).
 markdown = "1.0"
 
+# Config (de)serialization. `serde` derives the config model; `serde_json` handles `.json`
+# and (after a small comment/trailing-comma strip) `.jsonc`/`.tzlintrc`, and is the canonical
+# representation for rule-specific `options`. `yaml_serde` is the YAML Organization's maintained,
+# permissively licensed (MIT/Apache-2.0) fork of the now-archived `serde_yaml` for `.yaml`/`.yml`;
+# its `libyaml-rs` backend is libyaml transpiled to pure Rust (no C/FFI), so it builds for
+# `wasm32` too. All are config-only — they never touch the frozen AST (guarded by `io-guard`).
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+yaml_serde = "0.10"
+
 # Lints applied workspace-wide. `unwrap`/`expect`/`panic` are denied in library code
 # (per the design's error-handling rules); the io-guard CI job adds the disallowed-methods
 # checks via clippy.toml.

--- a/crates/tzlint_core/Cargo.toml
+++ b/crates/tzlint_core/Cargo.toml
@@ -15,3 +15,6 @@ workspace = true
 tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
 tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 markdown = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+yaml_serde = { workspace = true }

--- a/crates/tzlint_core/src/config/discover.rs
+++ b/crates/tzlint_core/src/config/discover.rs
@@ -1,0 +1,219 @@
+//! Upward config discovery over the [`Host`](crate::io::Host) boundary.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use super::format::{self, ConfigFormat};
+use super::{Config, ConfigError};
+use crate::io::{Host, MAX_CONFIG};
+
+/// Candidate config file names, highest priority first, paired with their format.
+const CANDIDATES: &[(&str, ConfigFormat)] = &[
+    (".tzlintrc.jsonc", ConfigFormat::Jsonc),
+    (".tzlintrc.json", ConfigFormat::Json),
+    (".tzlintrc.yaml", ConfigFormat::Yaml),
+    (".tzlintrc.yml", ConfigFormat::Yaml),
+    (".tzlintrc", ConfigFormat::Jsonc),
+];
+
+/// A lower-priority config candidate that was shadowed (and therefore ignored) because a
+/// higher-priority candidate existed in the same directory.
+///
+/// Returned as structured data (rather than a pre-rendered sentence) so embedders can attach
+/// the paths to their own diagnostics and localize the wording; [`Display`](fmt::Display)
+/// provides a default English rendering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowedCandidate {
+    /// The candidate that was ignored.
+    pub ignored: PathBuf,
+    /// The higher-priority candidate that was loaded instead.
+    pub winner: PathBuf,
+}
+
+impl fmt::Display for ShadowedCandidate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ignoring `{}`: shadowed by higher-priority `{}`",
+            self.ignored.display(),
+            self.winner.display()
+        )
+    }
+}
+
+/// A config found by [`discover`], plus any warnings about ignored co-located candidates.
+#[derive(Debug, Clone)]
+pub struct DiscoveredConfig {
+    /// The file the config was loaded from.
+    pub path: PathBuf,
+    /// The format it was parsed as.
+    pub format: ConfigFormat,
+    /// The parsed config.
+    pub config: Config,
+    /// Lower-priority candidates in the same directory that were shadowed (and ignored). Empty
+    /// in the common case.
+    pub warnings: Vec<ShadowedCandidate>,
+}
+
+/// Walk upward from `start_dir`, returning the first config found.
+///
+/// At each directory (starting with `start_dir` itself), candidate files are probed in
+/// priority order via [`Host::exists`]. The first directory holding any candidate wins; its
+/// highest-priority candidate is read (capped at [`MAX_CONFIG`]) and parsed, and lower-priority
+/// candidates in that same directory become [`warnings`](DiscoveredConfig::warnings). Returns
+/// `Ok(None)` if no candidate exists in any ancestor directory.
+///
+/// Discovery is best-effort across a small TOCTOU window: a candidate can vanish between the
+/// `exists` probe and the read (surfacing as [`ConfigError::Io`]) or be swapped for a symlink
+/// — the read follows symlinks but stays bounded by [`MAX_CONFIG`], so there is no unbounded
+/// read.
+pub fn discover(
+    host: &dyn Host,
+    start_dir: &Path,
+) -> Result<Option<DiscoveredConfig>, ConfigError> {
+    for dir in start_dir.ancestors() {
+        let mut present = CANDIDATES
+            .iter()
+            .filter(|(name, _)| host.exists(&dir.join(name)));
+
+        let Some(&(winner_name, format)) = present.next() else {
+            continue; // nothing here; try the parent directory
+        };
+        let path = dir.join(winner_name);
+
+        // Remaining candidates in this directory are shadowed by the winner.
+        let warnings: Vec<ShadowedCandidate> = present
+            .map(|&(name, _)| ShadowedCandidate {
+                ignored: dir.join(name),
+                winner: path.clone(),
+            })
+            .collect();
+
+        let text = host.read_to_string(&path, MAX_CONFIG)?;
+        let config = format::parse(&text, format)?;
+        return Ok(Some(DiscoveredConfig {
+            path,
+            format,
+            config,
+            warnings,
+        }));
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::IoError;
+    use std::collections::HashMap;
+
+    /// A read-only, in-memory [`Host`] for hermetic discovery tests: only registered paths
+    /// exist, so the upward walk terminates deterministically (no real filesystem).
+    struct MockHost {
+        files: HashMap<PathBuf, String>,
+    }
+
+    impl MockHost {
+        fn new(files: &[(&str, &str)]) -> Self {
+            MockHost {
+                files: files
+                    .iter()
+                    .map(|(p, c)| (PathBuf::from(p), (*c).to_string()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Host for MockHost {
+        fn read_to_string(&self, path: &Path, limit: usize) -> Result<String, IoError> {
+            match self.files.get(path) {
+                Some(s) if s.len() > limit => Err(IoError::TooLarge { limit }),
+                Some(s) => Ok(s.clone()),
+                None => Err(IoError::NotFound),
+            }
+        }
+        fn write_atomic(&self, _: &Path, _: &[u8]) -> Result<(), IoError> {
+            Err(IoError::Other("read-only mock host".into()))
+        }
+        fn exists(&self, path: &Path) -> bool {
+            self.files.contains_key(path)
+        }
+    }
+
+    #[test]
+    fn finds_config_in_start_dir() {
+        let host = MockHost::new(&[("/proj/.tzlintrc.json", r#"{ "language": "ja" }"#)]);
+        let found = discover(&host, Path::new("/proj")).unwrap().unwrap();
+        assert_eq!(found.path, PathBuf::from("/proj/.tzlintrc.json"));
+        assert_eq!(found.format, ConfigFormat::Json);
+        assert_eq!(found.config.language.as_deref(), Some("ja"));
+        assert!(found.warnings.is_empty());
+    }
+
+    #[test]
+    fn walks_upward_to_an_ancestor() {
+        let host = MockHost::new(&[("/proj/.tzlintrc.yaml", "language: ja\n")]);
+        // Start two directories deep; the config lives at /proj.
+        let found = discover(&host, Path::new("/proj/src/docs"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(found.path, PathBuf::from("/proj/.tzlintrc.yaml"));
+        assert_eq!(found.format, ConfigFormat::Yaml);
+    }
+
+    #[test]
+    fn highest_priority_wins_and_others_warn() {
+        let host = MockHost::new(&[
+            (".tzlintrc.jsonc", "{}"), // relative names → ancestors() yields "" then nothing
+            (".tzlintrc.json", "{}"),
+            (".tzlintrc", "{}"),
+        ]);
+        // Use a relative start dir whose only ancestor is "" (current dir); join("name")
+        // yields the bare candidate names registered above.
+        let found = discover(&host, Path::new("")).unwrap().unwrap();
+        assert_eq!(found.path, PathBuf::from(".tzlintrc.jsonc"));
+        assert_eq!(found.format, ConfigFormat::Jsonc);
+        // The two shadowed candidates are reported as structured data, each pointing at the
+        // winner.
+        assert_eq!(found.warnings.len(), 2);
+        assert!(found.warnings.iter().all(|w| w.winner == found.path));
+        let ignored: Vec<&PathBuf> = found.warnings.iter().map(|w| &w.ignored).collect();
+        assert!(ignored.contains(&&PathBuf::from(".tzlintrc.json")));
+        assert!(ignored.contains(&&PathBuf::from(".tzlintrc")));
+        // Display renders both paths.
+        assert!(found.warnings[0].to_string().contains("shadowed by"));
+    }
+
+    #[test]
+    fn nearer_directory_shadows_farther_one() {
+        let host = MockHost::new(&[
+            ("/proj/.tzlintrc.json", r#"{ "language": "outer" }"#),
+            ("/proj/src/.tzlintrc.json", r#"{ "language": "inner" }"#),
+        ]);
+        let found = discover(&host, Path::new("/proj/src")).unwrap().unwrap();
+        assert_eq!(found.path, PathBuf::from("/proj/src/.tzlintrc.json"));
+        assert_eq!(found.config.language.as_deref(), Some("inner"));
+    }
+
+    #[test]
+    fn returns_none_when_nothing_found() {
+        let host = MockHost::new(&[]);
+        assert!(discover(&host, Path::new("/proj/src")).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_error_propagates() {
+        let host = MockHost::new(&[("/proj/.tzlintrc.json", "{ not valid json ")]);
+        let err = discover(&host, Path::new("/proj")).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn read_error_propagates() {
+        // Candidate exists but exceeds the config size cap → the IoError surfaces.
+        let big = "x".repeat(MAX_CONFIG + 1);
+        let host = MockHost::new(&[("/proj/.tzlintrc.json", &big)]);
+        let err = discover(&host, Path::new("/proj")).unwrap_err();
+        assert!(matches!(err, ConfigError::Io(IoError::TooLarge { .. })));
+    }
+}

--- a/crates/tzlint_core/src/config/format.rs
+++ b/crates/tzlint_core/src/config/format.rs
@@ -1,0 +1,432 @@
+//! Config file formats: detection by name, the JSONC pre-processor, and parse dispatch.
+
+use std::fmt;
+use std::path::Path;
+
+use super::model::RawConfig;
+use super::{Config, ConfigError};
+
+/// A supported config file format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigFormat {
+    /// Strict JSON (`.json`).
+    Json,
+    /// JSON with `//`/`/* */` comments and trailing commas (`.jsonc`, and the extensionless
+    /// `.tzlintrc`).
+    Jsonc,
+    /// YAML (`.yaml`, `.yml`).
+    Yaml,
+}
+
+impl fmt::Display for ConfigFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ConfigFormat::Json => "JSON",
+            ConfigFormat::Jsonc => "JSONC",
+            ConfigFormat::Yaml => "YAML",
+        })
+    }
+}
+
+impl ConfigFormat {
+    /// Infer the format from a path's file name, or `None` if it is not a recognized config
+    /// file. The extension match is ASCII-case-insensitive (so `.JSON` works on
+    /// case-insensitive filesystems), and the bare extension dotfiles (`.json`, `.yaml`, …)
+    /// are *not* recognized — only the extensionless `.tzlintrc` may have an empty stem, and
+    /// it is treated as JSONC.
+    pub fn from_path(path: &Path) -> Option<ConfigFormat> {
+        let name = path.file_name()?.to_str()?;
+        let (stem, ext) = name.rsplit_once('.')?;
+        match (stem, ext.to_ascii_lowercase().as_str()) {
+            (stem, "json") if !stem.is_empty() => Some(ConfigFormat::Json),
+            (stem, "jsonc") if !stem.is_empty() => Some(ConfigFormat::Jsonc),
+            (stem, "yaml" | "yml") if !stem.is_empty() => Some(ConfigFormat::Yaml),
+            // `.tzlintrc` has no second dot: `rsplit_once('.')` yields `("", "tzlintrc")`.
+            ("", "tzlintrc") => Some(ConfigFormat::Jsonc),
+            _ => None,
+        }
+    }
+}
+
+/// Parse `text` in `format` into a resolved [`Config`].
+pub(super) fn parse(text: &str, format: ConfigFormat) -> Result<Config, ConfigError> {
+    let parse_err = |message: String| ConfigError::Parse { format, message };
+    // A leading UTF-8 BOM (common from Windows/editor saves) is not valid JSON, while YAML
+    // tolerates it; strip one so every format behaves the same.
+    let text = text.strip_prefix('\u{feff}').unwrap_or(text);
+    // An empty or whitespace-only document is the default config, uniformly across formats
+    // (serde_json rejects an empty document outright, and some whitespace is not a valid YAML
+    // token either). A comments-only JSONC file is handled after stripping, below.
+    if text.trim().is_empty() {
+        return Ok(Config::default());
+    }
+    let raw: RawConfig = match format {
+        ConfigFormat::Json => serde_json::from_str(text).map_err(|e| parse_err(e.to_string()))?,
+        ConfigFormat::Jsonc => {
+            let stripped = strip_jsonc(text);
+            if stripped.trim().is_empty() {
+                return Ok(Config::default()); // e.g. a comments-only file
+            }
+            serde_json::from_str(&stripped).map_err(|e| parse_err(e.to_string()))?
+        }
+        ConfigFormat::Yaml => {
+            // YAML anchors/aliases enable alias-expansion ("billion laughs") memory-exhaustion
+            // that the MAX_CONFIG byte cap does not bound; reject them up front.
+            reject_yaml_anchors(text).map_err(parse_err)?;
+            yaml_serde::from_str(text).map_err(|e| parse_err(e.to_string()))?
+        }
+    };
+    raw.into_config()
+}
+
+/// Strip JSONC extensions (line/block comments and trailing commas) to plain JSON.
+///
+/// String-aware: `//`, `/* */`, and trailing commas are only treated as such *outside* string
+/// literals (escaped quotes inside strings are honored). Trailing commas are removed by, at
+/// each `}`/`]`, dropping any immediately preceding whitespace and a single comma — comments
+/// were already elided, so only whitespace can sit between the comma and the bracket.
+fn strip_jsonc(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if in_string {
+            out.push(c);
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        match c {
+            '"' => {
+                in_string = true;
+                out.push(c);
+                i += 1;
+            }
+            '/' if chars.get(i + 1) == Some(&'/') => {
+                i += 2;
+                while i < chars.len() && chars[i] != '\n' {
+                    i += 1;
+                }
+            }
+            '/' if chars.get(i + 1) == Some(&'*') => {
+                i += 2;
+                while i + 1 < chars.len() && !(chars[i] == '*' && chars[i + 1] == '/') {
+                    i += 1;
+                }
+                // Skip the closing `*/`, clamped so an unterminated comment lands at EOF and
+                // keeps the `i <= chars.len()` invariant.
+                i = (i + 2).min(chars.len());
+            }
+            '}' | ']' => {
+                while out.ends_with(|w: char| w.is_ascii_whitespace()) {
+                    out.pop();
+                }
+                if out.ends_with(',') {
+                    out.pop();
+                }
+                out.push(c);
+                i += 1;
+            }
+            _ => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+
+    out
+}
+
+/// Reject YAML anchors (`&name`) and aliases (`*name`) in config files.
+///
+/// They are unnecessary for configuration and enable alias-expansion ("billion laughs")
+/// memory-exhaustion: a sub-1-MiB document can expand to multiple gigabytes during
+/// deserialization, so the [`MAX_CONFIG`](crate::io::MAX_CONFIG) byte cap does not bound it.
+/// The scan is string- and comment-aware: a `&`/`*` inside a quoted scalar (`"…"`/`'…'`) or a
+/// `#` comment is ignored, and a `&`/`*` is only flagged when it begins a token (preceded by
+/// start-of-input, whitespace, or a flow indicator) and is followed by a name character — so
+/// arithmetic-like plain scalars such as `a & b` or `2 * 3` are not flagged.
+fn reject_yaml_anchors(text: &str) -> Result<(), String> {
+    #[derive(PartialEq)]
+    enum State {
+        Plain,
+        Single,
+        Double,
+        Comment,
+    }
+
+    let chars: Vec<char> = text.chars().collect();
+    let mut state = State::Plain;
+    let mut escaped = false;
+    let mut prev: Option<char> = None;
+    let mut i = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+        match state {
+            State::Double => {
+                if escaped {
+                    escaped = false;
+                } else if c == '\\' {
+                    escaped = true;
+                } else if c == '"' {
+                    state = State::Plain;
+                }
+            }
+            State::Single => {
+                if c == '\'' {
+                    if chars.get(i + 1) == Some(&'\'') {
+                        i += 1; // `''` is an escaped single quote: stay in the string
+                    } else {
+                        state = State::Plain;
+                    }
+                }
+            }
+            State::Comment => {
+                if c == '\n' {
+                    state = State::Plain;
+                }
+            }
+            State::Plain => match c {
+                '"' => state = State::Double,
+                '\'' => state = State::Single,
+                '#' if matches!(prev, None | Some(' ' | '\t' | '\n' | '\r')) => {
+                    state = State::Comment;
+                }
+                '&' | '*' if is_node_start(prev) && chars.get(i + 1).is_some_and(is_name_char) => {
+                    let kind = if c == '&' {
+                        "anchors (&)"
+                    } else {
+                        "aliases (*)"
+                    };
+                    return Err(format!(
+                        "YAML {kind} are not supported in config files \
+                         (they enable alias-expansion denial-of-service); \
+                         remove it or quote the value"
+                    ));
+                }
+                _ => {}
+            },
+        }
+        prev = Some(c);
+        i += 1;
+    }
+    Ok(())
+}
+
+/// Whether a `&`/`*` at this position could begin a YAML node (so an anchor/alias indicator),
+/// based on the preceding character: start-of-input, whitespace, or a flow indicator.
+fn is_node_start(prev: Option<char>) -> bool {
+    matches!(
+        prev,
+        None | Some(' ' | '\t' | '\n' | '\r' | '[' | '{' | ',')
+    )
+}
+
+/// Whether `c` can start a YAML anchor name (conservatively: any non-space char that is not a
+/// flow terminator or comment marker).
+fn is_name_char(c: &char) -> bool {
+    !c.is_whitespace() && !matches!(c, ',' | ']' | '}' | '#')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_path_detects_each_format() {
+        let f = |p: &str| ConfigFormat::from_path(Path::new(p));
+        assert_eq!(f("/x/.tzlintrc.jsonc"), Some(ConfigFormat::Jsonc));
+        assert_eq!(f("/x/.tzlintrc.json"), Some(ConfigFormat::Json));
+        assert_eq!(f("/x/.tzlintrc.yaml"), Some(ConfigFormat::Yaml));
+        assert_eq!(f("/x/.tzlintrc.yml"), Some(ConfigFormat::Yaml));
+        assert_eq!(f("/x/.tzlintrc"), Some(ConfigFormat::Jsonc));
+        assert_eq!(f("/x/config.toml"), None);
+        assert_eq!(f("/x/README"), None);
+    }
+
+    #[test]
+    fn from_path_is_case_insensitive() {
+        let f = |p: &str| ConfigFormat::from_path(Path::new(p));
+        assert_eq!(f("/x/.tzlintrc.JSON"), Some(ConfigFormat::Json));
+        assert_eq!(f("/x/config.YAML"), Some(ConfigFormat::Yaml));
+        assert_eq!(f("/x/.tzlintrc.YML"), Some(ConfigFormat::Yaml));
+    }
+
+    #[test]
+    fn from_path_rejects_bare_extension_dotfiles() {
+        let f = |p: &str| ConfigFormat::from_path(Path::new(p));
+        assert_eq!(f("/x/.json"), None);
+        assert_eq!(f("/x/.yaml"), None);
+        assert_eq!(f("/x/.jsonc"), None);
+    }
+
+    #[test]
+    fn display_names() {
+        assert_eq!(ConfigFormat::Json.to_string(), "JSON");
+        assert_eq!(ConfigFormat::Jsonc.to_string(), "JSONC");
+        assert_eq!(ConfigFormat::Yaml.to_string(), "YAML");
+    }
+
+    #[test]
+    fn jsonc_strips_line_and_block_comments() {
+        let src = r#"{
+            // a line comment
+            "language": "ja", /* inline block */
+            "rules": {} /* trailing */
+        }"#;
+        let v: serde_json::Value = serde_json::from_str(&strip_jsonc(src)).unwrap();
+        assert_eq!(v["language"], serde_json::json!("ja"));
+    }
+
+    #[test]
+    fn jsonc_strips_trailing_commas() {
+        let src = r#"{ "a": [1, 2, 3,], "b": { "c": 1, }, }"#;
+        let v: serde_json::Value = serde_json::from_str(&strip_jsonc(src)).unwrap();
+        assert_eq!(v["a"], serde_json::json!([1, 2, 3]));
+        assert_eq!(v["b"]["c"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn jsonc_preserves_comment_markers_inside_strings() {
+        // `//`, `/*`, and a `}` inside a string must NOT be treated as comments/structure.
+        let src = r#"{ "url": "http://example.com/*not a comment*/", "brace": "a}b" }"#;
+        let v: serde_json::Value = serde_json::from_str(&strip_jsonc(src)).unwrap();
+        assert_eq!(
+            v["url"],
+            serde_json::json!("http://example.com/*not a comment*/")
+        );
+        assert_eq!(v["brace"], serde_json::json!("a}b"));
+    }
+
+    #[test]
+    fn jsonc_honors_escaped_quotes_in_strings() {
+        let src = r#"{ "q": "a \" // still string", "n": 1, }"#;
+        let v: serde_json::Value = serde_json::from_str(&strip_jsonc(src)).unwrap();
+        assert_eq!(v["q"], serde_json::json!("a \" // still string"));
+        assert_eq!(v["n"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn jsonc_does_not_strip_comma_inside_string() {
+        // A comma inside a string just before a `}` must survive.
+        let src = r#"{ "a": "x," }"#;
+        let v: serde_json::Value = serde_json::from_str(&strip_jsonc(src)).unwrap();
+        assert_eq!(v["a"], serde_json::json!("x,"));
+    }
+
+    #[test]
+    fn jsonc_unterminated_block_comment_does_not_panic() {
+        // The clamped `i` keeps stripping safe even when `*/` is missing; the result is still
+        // valid JSON (whitespace before `}` is collapsed, which is fine).
+        assert_eq!(strip_jsonc("{}/*").trim(), "{}");
+        let v: serde_json::Value =
+            serde_json::from_str(&strip_jsonc("{ \"a\": 1 } /* never closed")).unwrap();
+        assert_eq!(v["a"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn parse_json_strict_rejects_comments() {
+        // The strict `.json` path must NOT accept comments.
+        let err = parse("{ // nope\n}", ConfigFormat::Json).unwrap_err();
+        assert!(matches!(err, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn parse_jsonc_accepts_comments() {
+        let c = parse(
+            "{ \"language\": \"ja\", // comment\n }",
+            ConfigFormat::Jsonc,
+        )
+        .unwrap();
+        assert_eq!(c.language.as_deref(), Some("ja"));
+    }
+
+    #[test]
+    fn parse_yaml_roundtrips() {
+        let c = parse(
+            "language: ja\nrules:\n  sentence-length: false\n",
+            ConfigFormat::Yaml,
+        )
+        .unwrap();
+        assert_eq!(c.language.as_deref(), Some("ja"));
+        assert!(!c.rules.is_empty());
+    }
+
+    #[test]
+    fn parse_strips_leading_bom() {
+        // A leading BOM must not break any format.
+        for (text, fmt) in [
+            ("\u{feff}{ \"language\": \"ja\" }", ConfigFormat::Json),
+            ("\u{feff}{ \"language\": \"ja\" }", ConfigFormat::Jsonc),
+            ("\u{feff}language: ja\n", ConfigFormat::Yaml),
+        ] {
+            let c = parse(text, fmt).unwrap();
+            assert_eq!(c.language.as_deref(), Some("ja"), "format {fmt}");
+        }
+    }
+
+    #[test]
+    fn parse_empty_file_is_default_config_for_all_formats() {
+        for fmt in [ConfigFormat::Json, ConfigFormat::Jsonc, ConfigFormat::Yaml] {
+            let c = parse("", fmt).unwrap();
+            assert_eq!(c, Config::default(), "empty {fmt}");
+            let ws = parse("   \n\t", fmt).unwrap();
+            assert_eq!(ws, Config::default(), "whitespace {fmt}");
+        }
+        // A comments-only JSONC document is also the default config.
+        assert_eq!(
+            parse("// just a comment\n", ConfigFormat::Jsonc).unwrap(),
+            Config::default()
+        );
+    }
+
+    #[test]
+    fn yaml_rejects_anchor_alias_bomb() {
+        let bomb = "rules:\n  r:\n    options:\n      a: &a [1, 1, 1]\n      b: [*a, *a, *a]\n";
+        let err = parse(bomb, ConfigFormat::Yaml).unwrap_err();
+        match err {
+            ConfigError::Parse { message, .. } => {
+                assert!(
+                    message.contains("anchors") || message.contains("aliases"),
+                    "{message}"
+                );
+            }
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+        // An alias on its own is rejected too.
+        assert!(parse("a: *x\n", ConfigFormat::Yaml).is_err());
+    }
+
+    #[test]
+    fn yaml_anchor_scan_ignores_non_anchor_ampersand_and_star() {
+        // The scanner must NOT flag `&`/`*` inside quotes, comments, or spaced/mid plain
+        // scalars (tested directly, since these sample keys would otherwise trip
+        // deny_unknown_fields). Includes a double-quote escape (`\"`), a single-quote escape
+        // (`''`), and a mid-scalar `&` (preceded by a non-indicator char).
+        let ok = "language: ja\n\
+                  quoted: \"A & B with an escaped \\\" quote and *star\"\n\
+                  single: 'it''s a *.md glob & more'\n\
+                  arith: 2 * 3 = 6\n\
+                  spaced: a & b\n\
+                  midscalar: a&b\n\
+                  # & * in a comment\n";
+        assert!(reject_yaml_anchors(ok).is_ok());
+        // But a real anchor or alias IS flagged.
+        assert!(reject_yaml_anchors("x: &anchor 1\n").is_err());
+        assert!(reject_yaml_anchors("y: *alias\n").is_err());
+        assert!(reject_yaml_anchors("z: [&a 1, *a]\n").is_err());
+    }
+}

--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -1,0 +1,155 @@
+//! Multi-format configuration: discovery, parsing, strict validation, and preset resolution.
+//!
+//! A TsuzuLint config selects a document [`language`](Config::language), a
+//! [`message_language`](Config::message_language) (the diagnostic locale, independent of the
+//! document language), and a per-rule [`rules`](Config::rules) map. Three concerns live here:
+//!
+//! - **Discovery** ([`discover`]) walks upward from a start directory. The first directory
+//!   that holds any candidate file wins; within it the highest-priority candidate is loaded
+//!   and any co-located lower-priority candidates are reported as [`warnings`](DiscoveredConfig::warnings)
+//!   (they are ignored, not merged). Presence is probed through the [`Host`](crate::io::Host)
+//!   boundary, so discovery works on native and `wasm32` alike.
+//! - **Parsing** ([`Config::parse`]) is strict: unknown keys are an error
+//!   (`deny_unknown_fields`). Formats, highest priority first:
+//!   `.tzlintrc.jsonc` → `.tzlintrc.json` → `.tzlintrc.yaml` → `.tzlintrc.yml` → `.tzlintrc`
+//!   (the extensionless file is parsed as JSONC).
+//! - **Presets** ([`Preset`], [`resolve`]) provide a base rule set that the user config
+//!   overrides by id. The `extends` key is reserved for a later milestone and is currently
+//!   rejected with a clear error rather than silently ignored.
+
+mod discover;
+mod format;
+mod model;
+mod preset;
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use tzlint_pdk::RuleId;
+
+pub use discover::{DiscoveredConfig, ShadowedCandidate, discover};
+pub use format::ConfigFormat;
+pub use model::RuleSetting;
+pub use preset::{Preset, resolve};
+
+use crate::io::IoError;
+
+/// A resolved configuration: the document/message languages and the per-rule settings map.
+///
+/// Build one with [`Config::parse`] (from a single file's text), [`discover`] (walk-up
+/// discovery), or [`resolve`] (layer a user config over a preset). [`Config::default`] is the
+/// empty config (no language pins, no rule overrides).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Config {
+    /// The document language (e.g. `"ja"`), or `None` to let the embedder decide.
+    pub language: Option<String>,
+    /// The diagnostic-message locale, independent of [`language`](Config::language).
+    pub message_language: Option<String>,
+    /// Per-rule settings, keyed by [`RuleId`]. Absent ids fall back to a rule's own defaults.
+    pub rules: BTreeMap<RuleId, RuleSetting>,
+}
+
+impl Config {
+    /// Parse a config from `text` in the given [`ConfigFormat`].
+    ///
+    /// Strict: unknown top-level keys, malformed values, or a (reserved) `extends` key are
+    /// errors. Rule-specific `options` are preserved verbatim as JSON values.
+    pub fn parse(text: &str, format: ConfigFormat) -> Result<Self, ConfigError> {
+        format::parse(text, format)
+    }
+}
+
+/// A configuration failure: an I/O error, a parse/validation error, or use of a reserved key.
+#[derive(Debug)]
+pub enum ConfigError {
+    /// Reading a discovered config file failed.
+    Io(IoError),
+    /// The file did not parse or violated the schema (unknown key, bad value, …).
+    Parse {
+        /// The format the text was parsed as.
+        format: ConfigFormat,
+        /// A human-readable reason from the underlying deserializer.
+        message: String,
+    },
+    /// A key that is recognized but reserved for a future milestone (e.g. `extends`).
+    Reserved(&'static str),
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigError::Io(e) => write!(f, "config I/O error: {e}"),
+            ConfigError::Parse { format, message } => {
+                write!(f, "failed to parse {format} config: {message}")
+            }
+            ConfigError::Reserved(key) => {
+                write!(f, "`{key}` is reserved and not supported yet")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ConfigError::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<IoError> for ConfigError {
+    fn from(error: IoError) -> Self {
+        ConfigError::Io(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_messages() {
+        assert_eq!(
+            ConfigError::Io(IoError::NotFound).to_string(),
+            "config I/O error: file not found"
+        );
+        assert_eq!(
+            ConfigError::Parse {
+                format: ConfigFormat::Json,
+                message: "boom".into(),
+            }
+            .to_string(),
+            "failed to parse JSON config: boom"
+        );
+        assert_eq!(
+            ConfigError::Reserved("extends").to_string(),
+            "`extends` is reserved and not supported yet"
+        );
+    }
+
+    #[test]
+    fn error_source_chains_io_only() {
+        use std::error::Error;
+        assert!(ConfigError::Io(IoError::NotFound).source().is_some());
+        assert!(ConfigError::Reserved("extends").source().is_none());
+    }
+
+    #[test]
+    fn default_config_is_empty() {
+        let c = Config::default();
+        assert!(c.language.is_none());
+        assert!(c.message_language.is_none());
+        assert!(c.rules.is_empty());
+    }
+
+    #[test]
+    fn config_parse_delegates_to_format() {
+        let c = Config::parse(r#"{ "language": "ja" }"#, ConfigFormat::Json).unwrap();
+        assert_eq!(c.language.as_deref(), Some("ja"));
+        assert!(matches!(
+            Config::parse("{ not json", ConfigFormat::Json),
+            Err(ConfigError::Parse { .. })
+        ));
+    }
+}

--- a/crates/tzlint_core/src/config/model.rs
+++ b/crates/tzlint_core/src/config/model.rs
@@ -1,0 +1,347 @@
+//! The serde model behind a config file and its conversion to a resolved [`Config`].
+//!
+//! [`RawConfig`] mirrors the on-disk shape (strict: `deny_unknown_fields`, kebab-case keys);
+//! [`RawConfig::into_config`] validates the reserved `extends` key and lifts string rule keys
+//! into [`RuleId`]s. [`RuleSetting`] has a hand-written `Deserialize` so a rule value may be
+//! `false`, `true`, or `{ severity?, options? }` while still rejecting unknown keys in the
+//! object form — something `#[serde(untagged)]` cannot enforce.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::Deserialize;
+use serde::de::{self, Deserializer, MapAccess, Visitor};
+use serde_json::Value;
+use tzlint_pdk::{RuleId, Severity};
+
+use super::{Config, ConfigError};
+
+/// The on-disk config shape. Kebab-case keys, no unknown keys.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub(super) struct RawConfig {
+    #[serde(default)]
+    language: Option<String>,
+    #[serde(default)]
+    message_language: Option<String>,
+    #[serde(default)]
+    rules: BTreeMap<String, RuleSetting>,
+    /// Reserved: composing/extending configs is a later milestone. Accepted into the model (so
+    /// a lone `extends` produces a precise "reserved" error rather than an "unknown field" one)
+    /// and rejected in [`into_config`](RawConfig::into_config). `extends: null` is treated as
+    /// absent (a no-op), matching serde's null→`None` mapping. Note: if the file *also* has an
+    /// unknown key or a type error, serde's `deny_unknown_fields`/type error fires first and
+    /// that message wins over the reserved-key one.
+    #[serde(default)]
+    extends: Option<Value>,
+}
+
+impl RawConfig {
+    /// Validate reserved keys and lift `rules` keys into [`RuleId`]s.
+    ///
+    /// Rule ids are not checked against a known-rule set here — that registry does not exist
+    /// until the rules crate lands (M1f), so an unknown id is kept verbatim and simply matches
+    /// no rule. (`deny_unknown_fields` guards the fixed top-level keys, not the dynamic `rules`
+    /// map keys.)
+    pub(super) fn into_config(self) -> Result<Config, ConfigError> {
+        if self.extends.is_some() {
+            return Err(ConfigError::Reserved("extends"));
+        }
+        let rules = self
+            .rules
+            .into_iter()
+            .map(|(id, setting)| (RuleId::from(id), setting))
+            .collect();
+        Ok(Config {
+            language: self.language,
+            message_language: self.message_language,
+            rules,
+        })
+    }
+}
+
+/// One rule's setting: disabled, or enabled with an optional severity override and
+/// rule-specific options.
+///
+/// Deserializes from `false` (→ [`Off`](RuleSetting::Off)), `true`
+/// (→ [`On`](RuleSetting::On) with no severity override and null options), or an object
+/// `{ severity?, options? }`. Unknown keys in the object form are rejected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuleSetting {
+    /// The rule is turned off.
+    Off,
+    /// The rule is on, optionally overriding its default severity, with `options` passed
+    /// through to the rule (a JSON value; `Null` when omitted).
+    On {
+        /// Overrides the rule's default severity when `Some`.
+        severity: Option<Severity>,
+        /// Rule-specific options, preserved verbatim as a JSON value. Values must be
+        /// JSON-representable: from YAML, non-string mapping keys are coerced to strings and an
+        /// integer outside the i64/u64 range is rejected.
+        options: Value,
+    },
+}
+
+impl RuleSetting {
+    /// Whether the rule is enabled.
+    pub fn is_enabled(&self) -> bool {
+        matches!(self, RuleSetting::On { .. })
+    }
+}
+
+impl<'de> Deserialize<'de> for RuleSetting {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RuleSettingVisitor;
+
+        impl<'de> Visitor<'de> for RuleSettingVisitor {
+            type Value = RuleSetting;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("`false`, `true`, or a `{ severity?, options? }` object")
+            }
+
+            fn visit_bool<E>(self, enabled: bool) -> Result<RuleSetting, E> {
+                Ok(if enabled {
+                    RuleSetting::On {
+                        severity: None,
+                        options: Value::Null,
+                    }
+                } else {
+                    RuleSetting::Off
+                })
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<RuleSetting, E>
+            where
+                E: de::Error,
+            {
+                // Accept the common boolean spellings as on/off. YAML 1.2 (yaml_serde) parses
+                // `yes`/`no`/`on`/`off` as plain strings, not booleans, so without this a natural
+                // `rule: no` would be a confusing "invalid type: string" error.
+                match value.to_ascii_lowercase().as_str() {
+                    "true" | "yes" | "on" => Ok(RuleSetting::On {
+                        severity: None,
+                        options: Value::Null,
+                    }),
+                    "false" | "no" | "off" => Ok(RuleSetting::Off),
+                    _ => Err(de::Error::invalid_value(de::Unexpected::Str(value), &self)),
+                }
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<RuleSetting, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                const FIELDS: &[&str] = &["severity", "options"];
+                let mut severity: Option<Severity> = None;
+                let mut options: Option<Value> = None;
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "severity" => {
+                            if severity.is_some() {
+                                return Err(de::Error::duplicate_field("severity"));
+                            }
+                            severity = Some(map.next_value::<SeverityRepr>()?.into());
+                        }
+                        "options" => {
+                            if options.is_some() {
+                                return Err(de::Error::duplicate_field("options"));
+                            }
+                            options = Some(map.next_value::<Value>()?);
+                        }
+                        other => return Err(de::Error::unknown_field(other, FIELDS)),
+                    }
+                }
+                Ok(RuleSetting::On {
+                    severity,
+                    options: options.unwrap_or(Value::Null),
+                })
+            }
+        }
+
+        // `deserialize_any`: dispatch on the actual JSON/YAML node (bool vs map). Both formats
+        // are self-describing, so this is well-defined.
+        deserializer.deserialize_any(RuleSettingVisitor)
+    }
+}
+
+/// Severity as written in config (`"error"`, `"warning"`, `"info"`, `"hint"`), mapped to the
+/// PDK [`Severity`]. Kept separate so the PDK stays serde-free (it is `no_std` and ABI-frozen).
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum SeverityRepr {
+    Error,
+    Warning,
+    Info,
+    Hint,
+}
+
+impl From<SeverityRepr> for Severity {
+    fn from(repr: SeverityRepr) -> Self {
+        match repr {
+            SeverityRepr::Error => Severity::Error,
+            SeverityRepr::Warning => Severity::Warning,
+            SeverityRepr::Info => Severity::Info,
+            SeverityRepr::Hint => Severity::Hint,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rule_setting_false_is_off() {
+        let s: RuleSetting = serde_json::from_str("false").unwrap();
+        assert_eq!(s, RuleSetting::Off);
+        assert!(!s.is_enabled());
+    }
+
+    #[test]
+    fn rule_setting_true_is_on_with_defaults() {
+        let s: RuleSetting = serde_json::from_str("true").unwrap();
+        assert_eq!(
+            s,
+            RuleSetting::On {
+                severity: None,
+                options: Value::Null,
+            }
+        );
+        assert!(s.is_enabled());
+    }
+
+    #[test]
+    fn rule_setting_object_severity_and_options() {
+        let s: RuleSetting =
+            serde_json::from_str(r#"{ "severity": "error", "options": { "max": 3 } }"#).unwrap();
+        match s {
+            RuleSetting::On { severity, options } => {
+                assert_eq!(severity, Some(Severity::Error));
+                assert_eq!(options["max"], serde_json::json!(3));
+            }
+            RuleSetting::Off => panic!("expected On"),
+        }
+    }
+
+    #[test]
+    fn rule_setting_object_partial_fields_default() {
+        // Only `options` → severity defaults to None.
+        let s: RuleSetting = serde_json::from_str(r#"{ "options": [1, 2] }"#).unwrap();
+        assert_eq!(
+            s,
+            RuleSetting::On {
+                severity: None,
+                options: serde_json::json!([1, 2]),
+            }
+        );
+        // Empty object → On with all defaults.
+        let empty: RuleSetting = serde_json::from_str("{}").unwrap();
+        assert_eq!(
+            empty,
+            RuleSetting::On {
+                severity: None,
+                options: Value::Null,
+            }
+        );
+    }
+
+    #[test]
+    fn rule_setting_accepts_yaml_boolean_spellings() {
+        // From YAML, `yes`/`on` and `no`/`off` arrive as strings; map them to On/Off.
+        for on in ["yes", "on", "true", "On", "YES"] {
+            let s: RuleSetting = yaml_serde::from_str(on).unwrap();
+            assert!(s.is_enabled(), "{on} should enable");
+        }
+        for off in ["no", "off", "false", "Off", "NO"] {
+            let s: RuleSetting = yaml_serde::from_str(off).unwrap();
+            assert_eq!(s, RuleSetting::Off, "{off} should disable");
+        }
+        // A non-boolean string is still rejected.
+        assert!(yaml_serde::from_str::<RuleSetting>("maybe").is_err());
+    }
+
+    #[test]
+    fn rule_setting_rejects_unknown_key() {
+        let err = serde_json::from_str::<RuleSetting>(r#"{ "severty": "error" }"#).unwrap_err();
+        assert!(err.to_string().contains("severty"), "got {err}");
+    }
+
+    #[test]
+    fn rule_setting_rejects_duplicate_severity() {
+        let err =
+            serde_json::from_str::<RuleSetting>(r#"{ "severity": "error", "severity": "info" }"#)
+                .unwrap_err();
+        assert!(err.to_string().contains("severity"), "got {err}");
+    }
+
+    #[test]
+    fn rule_setting_rejects_duplicate_options() {
+        let err =
+            serde_json::from_str::<RuleSetting>(r#"{ "options": 1, "options": 2 }"#).unwrap_err();
+        assert!(err.to_string().contains("options"), "got {err}");
+    }
+
+    #[test]
+    fn severity_repr_maps_all_levels() {
+        for (text, expected) in [
+            ("error", Severity::Error),
+            ("warning", Severity::Warning),
+            ("info", Severity::Info),
+            ("hint", Severity::Hint),
+        ] {
+            let setting: RuleSetting =
+                serde_json::from_str(&format!(r#"{{ "severity": "{text}" }}"#)).unwrap();
+            assert_eq!(
+                setting,
+                RuleSetting::On {
+                    severity: Some(expected),
+                    options: Value::Null,
+                },
+                "severity {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn rule_setting_rejects_bad_severity_value() {
+        let err = serde_json::from_str::<RuleSetting>(r#"{ "severity": "fatal" }"#).unwrap_err();
+        assert!(err.to_string().contains("fatal") || err.to_string().contains("variant"));
+    }
+
+    #[test]
+    fn raw_config_rejects_unknown_top_level_key() {
+        let err = serde_json::from_str::<RawConfig>(r#"{ "langauge": "ja" }"#).unwrap_err();
+        assert!(err.to_string().contains("langauge"), "got {err}");
+    }
+
+    #[test]
+    fn into_config_lifts_rule_ids_and_languages() {
+        let raw: RawConfig = serde_json::from_str(
+            r#"{ "language": "ja", "message-language": "en", "rules": { "sentence-length": false } }"#,
+        )
+        .unwrap();
+        let config = raw.into_config().unwrap();
+        assert_eq!(config.language.as_deref(), Some("ja"));
+        assert_eq!(config.message_language.as_deref(), Some("en"));
+        assert_eq!(
+            config.rules.get(&RuleId::from("sentence-length")),
+            Some(&RuleSetting::Off)
+        );
+    }
+
+    #[test]
+    fn into_config_rejects_reserved_extends() {
+        let raw: RawConfig = serde_json::from_str(r#"{ "extends": ["ja-basic"] }"#).unwrap();
+        assert!(matches!(
+            raw.into_config(),
+            Err(ConfigError::Reserved("extends"))
+        ));
+        // `extends: null` is treated as absent (a no-op), not reserved.
+        let null_extends: RawConfig = serde_json::from_str(r#"{ "extends": null }"#).unwrap();
+        assert!(null_extends.into_config().is_ok());
+    }
+}

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -1,0 +1,125 @@
+//! Presets: named base rule sets a user config layers over.
+
+use std::collections::BTreeMap;
+
+use tzlint_pdk::RuleId;
+
+use super::{Config, RuleSetting};
+
+/// A built-in preset: a base set of rule settings the user config overrides by id.
+///
+/// The concrete rule sets are populated when `tzlint_rules` lands (M1f); the resolution
+/// machinery ([`resolve`]) is already complete and tested, so filling them in is additive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Preset {
+    /// A small, broadly-applicable base for Japanese prose.
+    JaBasic,
+    /// The stricter Japanese technical-writing rule set.
+    JaTechnicalWriting,
+}
+
+impl Preset {
+    /// The preset's stable string id (as used in config/CLI).
+    pub fn id(self) -> &'static str {
+        match self {
+            Preset::JaBasic => "ja-basic",
+            Preset::JaTechnicalWriting => "ja-technical-writing",
+        }
+    }
+
+    /// Parse a preset id, or `None` if unrecognized.
+    pub fn from_id(id: &str) -> Option<Preset> {
+        match id {
+            "ja-basic" => Some(Preset::JaBasic),
+            "ja-technical-writing" => Some(Preset::JaTechnicalWriting),
+            _ => None,
+        }
+    }
+
+    /// The rule settings this preset contributes as a base layer.
+    // TODO(M1f): populate once `tzlint_rules` defines the rule ids these presets enable.
+    fn rules(self) -> BTreeMap<RuleId, RuleSetting> {
+        BTreeMap::new()
+    }
+}
+
+/// Resolve a `user` config over an optional `preset` base.
+///
+/// The preset's rules form the base layer; the user's rules override by id (user wins on a
+/// collision). `language`/`message_language` come from the user config — presets do not set
+/// them in M1.
+pub fn resolve(preset: Option<Preset>, user: Config) -> Config {
+    let base = preset.map(Preset::rules).unwrap_or_default();
+    Config {
+        language: user.language,
+        message_language: user.message_language,
+        rules: merge(base, user.rules),
+    }
+}
+
+/// Overlay `user` rules onto `base` rules; on a shared id, `user` wins.
+fn merge(
+    mut base: BTreeMap<RuleId, RuleSetting>,
+    user: BTreeMap<RuleId, RuleSetting>,
+) -> BTreeMap<RuleId, RuleSetting> {
+    base.extend(user);
+    base
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    fn on() -> RuleSetting {
+        RuleSetting::On {
+            severity: None,
+            options: Value::Null,
+        }
+    }
+
+    #[test]
+    fn preset_id_roundtrips() {
+        for p in [Preset::JaBasic, Preset::JaTechnicalWriting] {
+            assert_eq!(Preset::from_id(p.id()), Some(p));
+        }
+        assert_eq!(Preset::from_id("nope"), None);
+    }
+
+    #[test]
+    fn merge_user_overrides_base_by_id() {
+        let mut base = BTreeMap::new();
+        base.insert(RuleId::from("shared"), RuleSetting::Off);
+        base.insert(RuleId::from("base-only"), on());
+        let mut user = BTreeMap::new();
+        user.insert(RuleId::from("shared"), on()); // user re-enables a base-disabled rule
+        user.insert(RuleId::from("user-only"), RuleSetting::Off);
+
+        let merged = merge(base, user);
+        assert_eq!(merged.get(&RuleId::from("shared")), Some(&on()));
+        assert_eq!(merged.get(&RuleId::from("base-only")), Some(&on()));
+        assert_eq!(
+            merged.get(&RuleId::from("user-only")),
+            Some(&RuleSetting::Off)
+        );
+        assert_eq!(merged.len(), 3);
+    }
+
+    #[test]
+    fn resolve_keeps_user_languages_and_rules() {
+        let user = Config {
+            language: Some("ja".into()),
+            message_language: Some("en".into()),
+            rules: {
+                let mut m = BTreeMap::new();
+                m.insert(RuleId::from("sentence-length"), RuleSetting::Off);
+                m
+            },
+        };
+        // Presets are empty in M1, so resolution is currently identity on the rule set.
+        let resolved = resolve(Some(Preset::JaBasic), user.clone());
+        assert_eq!(resolved, user);
+        // No preset behaves the same.
+        assert_eq!(resolve(None, user.clone()), user);
+    }
+}

--- a/crates/tzlint_core/src/io.rs
+++ b/crates/tzlint_core/src/io.rs
@@ -78,6 +78,11 @@ pub trait Host {
     fn read_to_string(&self, path: &Path, limit: usize) -> Result<String, IoError>;
     /// Atomically replace `path` with `contents` (no torn file on crash).
     fn write_atomic(&self, path: &Path, contents: &[u8]) -> Result<(), IoError>;
+    /// Whether `path` exists. Best-effort: returns `false` when existence cannot be
+    /// determined (e.g. a permission error). Config discovery uses this to probe candidate
+    /// files cheaply without reading them — so checking presence still goes through the
+    /// boundary rather than touching `std::fs` directly.
+    fn exists(&self, path: &Path) -> bool;
 }
 
 // The real-filesystem host. Not compiled for `wasm32`, where the embedder injects its own
@@ -121,6 +126,12 @@ mod native {
             tmp.commit(path)?; // rename over the target (atomic on POSIX)
             fsync_parent(path);
             Ok(())
+        }
+
+        fn exists(&self, path: &Path) -> bool {
+            // `try_exists` follows symlinks and distinguishes "absent" from "couldn't tell";
+            // a permission/other error is treated as "not present" (best-effort discovery).
+            path.try_exists().unwrap_or(false)
         }
     }
 
@@ -364,6 +375,18 @@ mod native {
             );
             assert_eq!(host.read_to_string(&link, MAX_FILE).unwrap(), "new");
             assert_eq!(host.read_to_string(&target, MAX_FILE).unwrap(), "original");
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn exists_reports_presence() {
+            let dir = temp_dir();
+            let path = dir.join("present");
+            let host = NativeHost;
+            assert!(!host.exists(&path), "absent before creation");
+            host.write_atomic(&path, b"x").unwrap();
+            assert!(host.exists(&path), "present after creation");
+            assert!(!host.exists(&dir.join("never")), "unrelated path absent");
             std::fs::remove_dir_all(&dir).ok();
         }
 

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -9,15 +9,21 @@
 //!   embedders inject their environment (native fs / Node / browser).
 //!
 //! Landed so far: the [`parse`] function + [`LineIndex`] position mapper (M1b), the
-//! single-traversal [`Engine`] + autofix [`fix`]/[`apply_fixes`] (M1c-2), and the centralized
-//! [`io`] boundary ([`Host`] + size limits + atomic writes, M1d-1). TODO(M1): config, cache.
+//! single-traversal [`Engine`] + autofix [`fix`]/[`apply_fixes`] (M1c-2), the centralized
+//! [`io`] boundary ([`Host`] + size limits + atomic writes, M1d-1), and the multi-format
+//! [`config`] loader (discovery + presets + strict validation, M1d-2). TODO(M1): cache.
 
+pub mod config;
 pub mod engine;
 pub mod fix;
 pub mod io;
 pub mod parse;
 pub mod position;
 
+pub use config::{
+    Config, ConfigError, ConfigFormat, DiscoveredConfig, Preset, RuleSetting, ShadowedCandidate,
+    discover, resolve,
+};
 pub use engine::Engine;
 pub use fix::{FixPass, MAX_FIX_PASSES, apply_fixes, fix};
 pub use io::{Host, IoError};

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,15 +1,35 @@
 # Configuration reference
 
-> Status: template (M0/M1).
+> Status: M1d-2 implemented the loader (`tzlint_core::config`). A published JSON Schema and
+> per-file `overrides` are planned (see *Planned* below).
 
-- **Files:** `.tzlintrc.jsonc` → `.json` → `.yaml` → `.yml` → `.tzlintrc` (JSONC).
-  Discovery walks upward; first found wins; extras warn.
-- **Validation:** serde `deny_unknown_fields` + a published JSON Schema (unknown keys are
-  an error).
-- **Rules:** map of `rule-id` → `false` | `{ severity, options }`. **Presets**
-  (`ja-technical-writing`, `ja-basic`) expand to rule sets; user config overrides by id.
-  `extends` reserved for later.
-- **Language:** `Config.language` (+ per-file overrides); `message_language` selects
-  diagnostic locale (independent of document language).
+- **Files:** `.tzlintrc.jsonc` → `.tzlintrc.json` → `.tzlintrc.yaml` → `.tzlintrc.yml` →
+  `.tzlintrc` (parsed as JSONC). Discovery walks upward from a start directory; the first
+  directory holding any candidate wins, the highest-priority candidate in it is loaded, and
+  co-located lower-priority candidates are returned as structured warnings (ignored, not
+  merged). A leading UTF-8 BOM is stripped, and an empty/whitespace-only (or comments-only)
+  file is the default config — consistently across all formats.
+- **Formats:** strict JSON (`.json`); JSONC (`//` and `/* */` comments + trailing commas);
+  YAML (`.yaml`/`.yml`). YAML **anchors/aliases are rejected** — they are unnecessary for
+  configuration and enable alias-expansion ("billion laughs") memory-exhaustion that the
+  config size cap cannot bound.
+- **Validation:** serde `deny_unknown_fields` — an unknown top-level key is an error. (The
+  dynamic `rules` map keys are not yet checked against a known-rule set; that arrives with the
+  rules crate in M1f, after which an unknown rule id can be warned.)
+- **Rules:** map of `rule-id` → `false` (off) | `true` (on, defaults) | `{ severity?, options? }`.
+  `severity` is one of `error` | `warning` | `info` | `hint` (overrides the rule's default);
+  `options` is arbitrary JSON passed through to the rule (must be JSON-representable). In YAML,
+  the boolean spellings `yes`/`no`/`on`/`off` are accepted in addition to `true`/`false`.
+- **Presets:** `ja-basic`, `ja-technical-writing` provide a base rule set that the user config
+  overrides by id (user wins). The concrete rule sets are populated once rules land (M1f). The
+  `extends` key is **reserved** and currently rejected with a clear error.
+- **Language:** `language` (e.g. `ja`) and `message_language` (the diagnostic locale,
+  independent of the document language). Config file keys are kebab-case (`message-language`).
 - **Cache key:** `blake3(content)` + config + rule versions + parser/engine version +
-  morphology dictionary fingerprint.
+  morphology dictionary fingerprint. *(Cache lands in M1e.)*
+
+## Planned
+
+- A **published JSON Schema** for editor completion/validation (M1d-3).
+- Per-file **`overrides`** (glob-scoped `language`/rule settings).
+- `extends` for composing configs and pulling in presets from config.


### PR DESCRIPTION
## M1d-2 — multi-format config loader + presets

Adds `tzlint_core::config`: discovery, parsing, strict validation, and preset resolution, all
through the `Host` I/O boundary so it works on native and `wasm32`.

### What's in it
- **Formats:** strict JSON, JSONC (string-aware comment/trailing-comma strip), and YAML via
  [`yaml_serde`](https://github.com/yaml/yaml-serde) (the YAML org's maintained, pure-Rust
  serde_yaml fork). A leading BOM is stripped and an empty/whitespace/comments-only file is the
  default config, consistently across all formats.
- **Discovery** walks upward: the first directory holding any candidate wins, its
  highest-priority candidate loads, and co-located lower-priority candidates become structured
  `ShadowedCandidate` warnings (ignored, not merged). Adds `Host::exists` so presence probing
  also goes through the I/O boundary.
- **Validation:** `deny_unknown_fields` (unknown top-level key → error). `RuleSetting` is
  `false` | `true` | `{ severity?, options? }` via a hand-written `Deserialize` that also rejects
  unknown keys in the object form (something `#[serde(untagged)]` can't) and accepts the YAML
  `yes`/`no`/`on`/`off` boolean spellings.
- **Presets** `ja-basic`/`ja-technical-writing` resolve under the user config (user wins by id;
  the concrete rule sets are populated in M1f). `extends` is reserved and rejected with a clear
  error.

### Security
YAML **anchors/aliases are rejected**. An adversarial review confirmed a sub-1-MiB
`.tzlintrc.yaml` alias bomb expands to multiple GiB during deserialization — the `MAX_CONFIG`
byte cap can't bound it. The string/comment-aware pre-scan neutralizes this (and would for any
YAML backend); arithmetic-like plain scalars (`a & b`, `2 * 3`) and quoted/commented `&`/`*`
are not flagged.

### Review & coverage
- Pre-PR adversarial multi-lens review (parser-correctness / security-DoS / API-semantics → per-finding verify): **15 findings confirmed, 0 refuted**, all addressed — fixed (BOM, case/dotfile-aware `from_path`, alias-bomb, empty-file symmetry, block-comment clamp, YAML boolean spellings, structured warnings), documented (unknown rule ids → M1f, `exists` TOCTOU, `options` JSON limits, `extends` ordering/null), or deferred with rationale (`#[non_exhaustive]` until the API stabilizes pre-1.0; JSONC `Vec<char>` perf is bounded by the cap).
- New production code has no coverable-but-untested lines (added tests for `Config::parse`, all severities, duplicate `options`, quote escapes, mid-scalar `&`). Remaining uncovered lines are the in-memory test mock's trait methods and `panic!`-on-unexpected test arms.

### Deferred
A published **JSON Schema** is split into a follow-up (M1d-3); `config-reference.md` marks it and
per-file `overrides` as planned.

### Gates (local)
rustfmt + clippy (`-D warnings`), 96 tests + doctests, `wasm32-unknown-unknown` build, io-guard,
and `cargo deny check` (advisories/bans/licenses/sources ok) all pass. All new deps
(`serde`, `serde_json`, `yaml_serde` → `libyaml-rs`) are MIT/Apache-2.0 with MSRV ≤ 1.94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノーツ

* **新機能**
  * 設定ファイルの自動探索機能を追加。プロジェクトディレクトリから設定を自動的に検出します
  * JSON、JSONC、YAML形式の設定ファイルをサポート。複数形式の設定をご利用いただけます
  * ルール設定のプリセットシステムを導入。組み込みプリセットを活用できます

* **ドキュメント**
  * 設定リファレンスを更新。設定ファイル探索、形式サポート、パース処理の詳細を記載しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->