### PR TITLE
docs: re-anchor relative-time comments to state/condition

### DIFF
--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -14,8 +14,8 @@
 //!   `.tzlintrc.jsonc` → `.tzlintrc.json` → `.tzlintrc.yaml` → `.tzlintrc.yml` → `.tzlintrc`
 //!   (the extensionless file is parsed as JSONC).
 //! - **Presets** ([`Preset`], [`resolve`]) provide a base rule set that the user config
-//!   overrides by id. The `extends` key is reserved for a later milestone and is currently
-//!   rejected with a clear error rather than silently ignored.
+//!   overrides by id. The `extends` key is reserved for a later milestone and is rejected
+//!   with a clear error rather than silently ignored.
 
 mod discover;
 mod format;

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -116,7 +116,7 @@ mod tests {
                 m
             },
         };
-        // Presets are empty in M1, so resolution is currently identity on the rule set.
+        // Presets are empty until rules land (M1f), so resolution is identity on the rule set.
         let resolved = resolve(Some(Preset::JaBasic), user.clone());
         assert_eq!(resolved, user);
         // No preset behaves the same.

--- a/crates/tzlint_core/src/engine.rs
+++ b/crates/tzlint_core/src/engine.rs
@@ -3,7 +3,7 @@
 use tzlint_ast::ArchivedAst;
 use tzlint_pdk::{Context, Diagnostic, NodeRef, Rule};
 
-/// The lint engine. Stateless for now (config/rule-registry land later); the one dispatch
+/// The lint engine. Stateless (config/rule-registry land later); the one dispatch
 /// entry point for CLI, LSP, native, and (future) plugin rules.
 pub struct Engine;
 


### PR DESCRIPTION
## docs: re-anchor relative-time comments

A few committed comments lean on relative-time wording ("for now", "currently", "in M1") that
loses meaning as the project moves on — a future reader can't tell when "now" was. This
re-anchors each to the *condition* that changes the state, keeping the forward milestone
references (which point at where the work lands and stay meaningful):

- `engine.rs`: "Stateless **for now** (config/rule-registry land later)" → "Stateless
  (config/rule-registry land later)".
- `config/preset.rs`: "Presets are empty **in M1** … **currently** identity" → "Presets are
  empty **until rules land (M1f)** … identity".
- `config/mod.rs`: "reserved for a later milestone and is **currently** rejected" → "… and is
  rejected".

Comments only — no behavior change. fmt + clippy (`-D warnings`) pass.

(Split out of #16 review feedback so the cache PR stays scoped to M1e.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
