### PR TITLE
M1f-1: first batch of native rules (tzlint_rules)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,8 +1660,10 @@ dependencies = [
 name = "tzlint_rules"
 version = "0.0.0"
 dependencies = [
+ "serde_json",
  "tzlint_ast",
  "tzlint_core",
+ "tzlint_pdk",
 ]
 
 [[package]]

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -37,10 +37,53 @@ impl Preset {
     }
 
     /// The rule settings this preset contributes as a base layer.
-    // TODO(M1f): populate once `tzlint_rules` defines the rule ids these presets enable.
+    ///
+    /// Rule ids are referenced as strings (no dependency on `tzlint_rules`); they MUST match the
+    /// ids in `tzlint_rules::RULE_IDS` verbatim. Rules whose detection needs morphology (M2),
+    /// such as `no-doubled-joshi`, are intentionally omitted until that lands — additively.
+    /// Options here are config-layer metadata; routing them into rule instances is a later step,
+    /// so a rule currently runs with its own defaults regardless of the value set here.
     fn rules(self) -> BTreeMap<RuleId, RuleSetting> {
-        BTreeMap::new()
+        match self {
+            Preset::JaBasic => ja_basic(),
+            Preset::JaTechnicalWriting => ja_technical_writing(),
+        }
     }
+}
+
+/// Enable a rule with the given options and no severity override.
+fn on(options: serde_json::Value) -> RuleSetting {
+    RuleSetting::On {
+        severity: None,
+        options,
+    }
+}
+
+/// The `ja-basic` preset: a small, broadly-applicable base.
+fn ja_basic() -> BTreeMap<RuleId, RuleSetting> {
+    use serde_json::Value;
+    [
+        ("no-hankaku-kana", on(Value::Null)),
+        ("no-mixed-zenkaku-hankaku-alphabet", on(Value::Null)),
+    ]
+    .into_iter()
+    .map(|(id, setting)| (RuleId::from(id), setting))
+    .collect()
+}
+
+/// The `ja-technical-writing` preset: stricter, with thresholds.
+fn ja_technical_writing() -> BTreeMap<RuleId, RuleSetting> {
+    use serde_json::{Value, json};
+    [
+        ("sentence-length", on(json!({ "max": 100 }))),
+        ("max-ten", on(json!({ "max": 3 }))),
+        ("max-kanji-continuous-len", on(json!({ "max": 6 }))),
+        ("no-hankaku-kana", on(Value::Null)),
+        ("no-mixed-zenkaku-hankaku-alphabet", on(Value::Null)),
+    ]
+    .into_iter()
+    .map(|(id, setting)| (RuleId::from(id), setting))
+    .collect()
 }
 
 /// Resolve a `user` config over an optional `preset` base.
@@ -106,20 +149,62 @@ mod tests {
     }
 
     #[test]
-    fn resolve_keeps_user_languages_and_rules() {
+    fn resolve_layers_preset_under_user() {
         let user = Config {
             language: Some("ja".into()),
             message_language: Some("en".into()),
             rules: {
                 let mut m = BTreeMap::new();
-                m.insert(RuleId::from("sentence-length"), RuleSetting::Off);
+                m.insert(RuleId::from("no-hankaku-kana"), RuleSetting::Off); // override a preset rule
+                m.insert(RuleId::from("custom-rule"), on()); // user-only
                 m
             },
         };
-        // Presets are empty until rules land (M1f), so resolution is identity on the rule set.
         let resolved = resolve(Some(Preset::JaBasic), user.clone());
-        assert_eq!(resolved, user);
-        // No preset behaves the same.
+        // Languages come from the user.
+        assert_eq!(resolved.language.as_deref(), Some("ja"));
+        assert_eq!(resolved.message_language.as_deref(), Some("en"));
+        // The user override wins on a shared id.
+        assert_eq!(
+            resolved.rules.get(&RuleId::from("no-hankaku-kana")),
+            Some(&RuleSetting::Off)
+        );
+        // The preset's other rule is present as the base layer; the user-only rule is kept.
+        assert!(
+            resolved
+                .rules
+                .contains_key(&RuleId::from("no-mixed-zenkaku-hankaku-alphabet"))
+        );
+        assert!(resolved.rules.contains_key(&RuleId::from("custom-rule")));
+        // No preset → identity.
         assert_eq!(resolve(None, user.clone()), user);
+    }
+
+    #[test]
+    fn presets_are_populated_with_kebab_ids() {
+        for preset in [Preset::JaBasic, Preset::JaTechnicalWriting] {
+            let rules = preset.rules();
+            assert!(!rules.is_empty(), "{} should have rules", preset.id());
+            for id in rules.keys() {
+                assert!(
+                    id.as_str()
+                        .chars()
+                        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                    "non-kebab rule id: {}",
+                    id.as_str()
+                );
+            }
+        }
+        // ja-technical-writing carries thresholds (sentence-length); ja-basic does not.
+        assert!(
+            Preset::JaTechnicalWriting
+                .rules()
+                .contains_key(&RuleId::from("sentence-length"))
+        );
+        assert!(
+            !Preset::JaBasic
+                .rules()
+                .contains_key(&RuleId::from("sentence-length"))
+        );
     }
 }

--- a/crates/tzlint_rules/Cargo.toml
+++ b/crates/tzlint_rules/Cargo.toml
@@ -12,5 +12,16 @@ description = "Built-in native rules for TsuzuLint (Rule impls + scheduler regis
 workspace = true
 
 [dependencies]
+# Rules implement the `Rule` trait + emit the diagnostic model, both owned by the PDK. They
+# need `tzlint_ast` only for `NodeKind`/`Span`. They deliberately do NOT depend on `tzlint_core`
+# (the engine): rules are pure visitors, and keeping the dep out avoids a cycle once `tzlint_core`
+# wires the registry. `serde_json` parses rule options leniently.
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+# Test-only: the parser + engine, used to run a rule end-to-end over markdown (see
+# `src/test_support.rs`). A dev-dependency — never part of the normal graph — so it does not
+# create a cycle even once `tzlint_core` references the rule registry.
 tzlint_core = { path = "../tzlint_core", version = "0.0.0" }

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -1,8 +1,128 @@
 //! `tzlint_rules` — built-in native rules.
 //!
-//! Each rule implements the `Rule` trait (from `tzlint_core`) and registers the node
-//! kinds it cares about with the single-traversal scheduler. Cross-node rules use the
-//! `Context` accumulator + `finish()` hook.
+//! Each rule implements the [`Rule`](tzlint_pdk::Rule) trait (from `tzlint_pdk`) and declares
+//! the [`NodeKind`](tzlint_ast::NodeKind)s it visits, which the single-traversal scheduler in
+//! `tzlint_core` dispatches. Per-node rules act in `check`; the one document-level rule
+//! ([`NoMixedZenkakuHankakuAlphabet`]) registers `ROOT` and walks the subtree from `check`.
 //!
-//! TODO(M1): migrate/refactor the legacy native rules and presets (ja-technical-writing,
-//! ja-basic) into this crate against the new `Rule` trait and Diagnostic/Fix model.
+//! [`builtin_rules`] returns every shipped rule (the registry the engine is wired through);
+//! [`RULE_IDS`] is the matching id list. Rule options are parsed leniently per rule
+//! (`from_options`), but the engine does not yet route config options into rule instances, so
+//! [`builtin_rules`] constructs each rule with its defaults — see the per-rule `from_options`
+//! and the `TODO` below. Morphology-dependent rules (e.g. `no-doubled-joshi`) are deferred to
+//! M2 and are not in this crate yet.
+
+pub mod rules;
+mod util;
+
+#[cfg(test)]
+mod test_support;
+
+use tzlint_pdk::Rule;
+
+use rules::{
+    max_kanji_continuous_len, max_ten, no_hankaku_kana, no_mixed_zenkaku_hankaku_alphabet,
+    sentence_length,
+};
+pub use rules::{
+    max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
+    no_hankaku_kana::NoHankakuKana,
+    no_mixed_zenkaku_hankaku_alphabet::NoMixedZenkakuHankakuAlphabet,
+    sentence_length::SentenceLength,
+};
+
+/// The ids of every built-in rule, in [`builtin_rules`] order. Single source of truth — preset
+/// keys in `tzlint_core` must match these verbatim.
+pub const RULE_IDS: &[&str] = &[
+    sentence_length::ID,
+    max_ten::ID,
+    max_kanji_continuous_len::ID,
+    no_hankaku_kana::ID,
+    no_mixed_zenkaku_hankaku_alphabet::ID,
+];
+
+/// Every built-in rule, default-constructed.
+///
+/// TODO: once `tzlint_core` routes resolved config options into rule construction, build these
+/// via each rule's `from_options` instead of `new`.
+pub fn builtin_rules() -> Vec<Box<dyn Rule>> {
+    vec![
+        Box::new(SentenceLength::new()),
+        Box::new(MaxTen::new()),
+        Box::new(MaxKanjiContinuousLen::new()),
+        Box::new(NoHankakuKana::new()),
+        Box::new(NoMixedZenkakuHankakuAlphabet::new()),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_and_rule_ids_agree() {
+        let rules = builtin_rules();
+        assert_eq!(rules.len(), RULE_IDS.len());
+        for (rule, id) in rules.iter().zip(RULE_IDS) {
+            assert_eq!(rule.meta().id.as_str(), *id);
+        }
+    }
+
+    #[test]
+    fn rules_construct_via_default() {
+        // `Default` delegates to `new()`; exercise each so the delegation is covered.
+        assert_eq!(
+            SentenceLength::default().meta().id.as_str(),
+            "sentence-length"
+        );
+        assert_eq!(MaxTen::default().meta().id.as_str(), "max-ten");
+        assert_eq!(
+            MaxKanjiContinuousLen::default().meta().id.as_str(),
+            "max-kanji-continuous-len"
+        );
+        assert_eq!(
+            NoHankakuKana::default().meta().id.as_str(),
+            "no-hankaku-kana"
+        );
+        assert_eq!(
+            NoMixedZenkakuHankakuAlphabet::default().meta().id.as_str(),
+            "no-mixed-zenkaku-hankaku-alphabet"
+        );
+    }
+
+    #[test]
+    fn presets_only_reference_built_in_rule_ids() {
+        // tzlint_core's presets reference rule ids as plain strings (no dependency on this
+        // crate). This cross-crate guard (tzlint_core is a dev-dependency here) catches a
+        // preset that points at a renamed/typo'd or not-yet-implemented rule id.
+        use std::collections::BTreeSet;
+
+        use tzlint_core::{Config, Preset, resolve};
+
+        let known: BTreeSet<&str> = RULE_IDS.iter().copied().collect();
+        for preset in [Preset::JaBasic, Preset::JaTechnicalWriting] {
+            let resolved = resolve(Some(preset), Config::default());
+            for id in resolved.rules.keys() {
+                assert!(
+                    known.contains(id.as_str()),
+                    "preset {} references unknown rule id {:?}",
+                    preset.id(),
+                    id.as_str()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rule_ids_are_unique_and_kebab_case() {
+        let mut seen = std::collections::BTreeSet::new();
+        for id in RULE_IDS {
+            assert!(seen.insert(*id), "duplicate rule id {id}");
+            assert!(
+                id.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "rule id {id} is not kebab-case"
+            );
+        }
+    }
+}

--- a/crates/tzlint_rules/src/rules/max_kanji_continuous_len.rs
+++ b/crates/tzlint_rules/src/rules/max_kanji_continuous_len.rs
@@ -1,0 +1,127 @@
+//! `max-kanji-continuous-len` — flag runs of consecutive kanji longer than a limit.
+
+use serde_json::Value;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+use crate::util::is_kanji;
+
+/// The rule id.
+pub const ID: &str = "max-kanji-continuous-len";
+/// Default maximum consecutive-kanji run length, in characters.
+const DEFAULT_MAX: usize = 5;
+
+/// Flags any run of consecutive kanji whose length (in characters) exceeds `max`.
+pub struct MaxKanjiContinuousLen {
+    meta: RuleMeta,
+    max: usize,
+}
+
+impl MaxKanjiContinuousLen {
+    /// Construct with the default options (`max` 5).
+    pub fn new() -> Self {
+        MaxKanjiContinuousLen {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]),
+            max: DEFAULT_MAX,
+        }
+    }
+
+    /// Construct from config `options`, leniently (reads `max`; missing/wrong-typed keeps default).
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        if let Some(max) = options.get("max").and_then(Value::as_u64) {
+            // Fail safe toward "no limit" on a 32-bit target rather than truncating.
+            rule.max = usize::try_from(max).unwrap_or(usize::MAX);
+        }
+        rule
+    }
+
+    fn message(&self, run_len: usize) -> String {
+        format!(
+            "Kanji run of length {run_len} exceeds the maximum of {}.",
+            self.max
+        )
+    }
+}
+
+impl Default for MaxKanjiContinuousLen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for MaxKanjiContinuousLen {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+        let mut run_start: Option<usize> = None; // byte offset within the node
+        let mut run_len = 0usize; // character count of the current run
+        for (i, c) in text.char_indices() {
+            if is_kanji(c) {
+                if run_start.is_none() {
+                    run_start = Some(i);
+                }
+                run_len += 1;
+            } else if let Some(start) = run_start.take() {
+                if run_len > self.max {
+                    // Span covers the kanji bytes only, excluding the terminating char.
+                    cx.report(
+                        Span::new(
+                            base.saturating_add(start as u32),
+                            base.saturating_add(i as u32),
+                        ),
+                        self.message(run_len),
+                    );
+                }
+                run_len = 0;
+            }
+        }
+        // Flush a run that reaches the end of the text.
+        if let Some(start) = run_start
+            && run_len > self.max
+        {
+            cx.report(
+                Span::new(
+                    base.saturating_add(start as u32),
+                    base.saturating_add(text.len() as u32),
+                ),
+                self.message(run_len),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_run_over_limit() {
+        let rule = MaxKanjiContinuousLen::from_options(&serde_json::json!({"max": 6}));
+        // 7 consecutive kanji that run to end-of-text → one diagnostic (the trailing flush).
+        assert_eq!(diagnose(&rule, "一二三四五六七\n").len(), 1);
+        // 7 kanji closed by a non-kanji mid-text → one diagnostic (the in-loop close path).
+        assert_eq!(diagnose(&rule, "一二三四五六七です\n").len(), 1);
+    }
+
+    #[test]
+    fn exactly_max_and_split_runs_pass() {
+        let rule = MaxKanjiContinuousLen::from_options(&serde_json::json!({"max": 6}));
+        // Exactly 6 passes (strict >).
+        assert!(diagnose(&rule, "一二三四五六\n").is_empty());
+        // Two short runs broken by a non-kanji each stay under the default max (5).
+        assert!(diagnose(&MaxKanjiContinuousLen::new(), "一二三の四五六\n").is_empty());
+    }
+
+    #[test]
+    fn iteration_mark_breaks_a_run() {
+        // 々 (U+3005) is intentionally not a kanji here, so it splits the run.
+        let rule = MaxKanjiContinuousLen::from_options(&serde_json::json!({"max": 2}));
+        assert!(diagnose(&rule, "人々人\n").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/max_ten.rs
+++ b/crates/tzlint_rules/src/rules/max_ten.rs
@@ -1,0 +1,158 @@
+//! `max-ten` — flag sentences with too many 読点 (Japanese commas).
+
+use serde_json::Value;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "max-ten";
+/// Default maximum number of 読点 per sentence.
+const DEFAULT_MAX: usize = 3;
+const DEFAULT_TOUTEN: char = '、';
+const DEFAULT_KUTEN: char = '。';
+
+/// Flags any sentence whose count of `touten` (読点) exceeds `max`.
+pub struct MaxTen {
+    meta: RuleMeta,
+    max: usize,
+    touten: char,
+    kuten: char,
+}
+
+impl MaxTen {
+    /// Construct with default options (`max` 3, `touten` 「、」, `kuten` 「。」).
+    pub fn new() -> Self {
+        MaxTen {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            ),
+            max: DEFAULT_MAX,
+            touten: DEFAULT_TOUTEN,
+            kuten: DEFAULT_KUTEN,
+        }
+    }
+
+    /// Construct from config `options`, leniently. Reads `max` (integer), `touten` and `kuten`
+    /// (first character of a string); missing/wrong-typed values keep the defaults.
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        if let Some(max) = options.get("max").and_then(Value::as_u64) {
+            // Fail safe toward "no limit" on a 32-bit target rather than truncating.
+            rule.max = usize::try_from(max).unwrap_or(usize::MAX);
+        }
+        if let Some(c) = options
+            .get("touten")
+            .and_then(Value::as_str)
+            .and_then(|s| s.chars().next())
+        {
+            rule.touten = c;
+        }
+        if let Some(c) = options
+            .get("kuten")
+            .and_then(Value::as_str)
+            .and_then(|s| s.chars().next())
+        {
+            rule.kuten = c;
+        }
+        rule
+    }
+
+    fn message(&self, count: usize) -> String {
+        format!(
+            "一文に「{}」が {count} 個あります。上限は {} 個です。",
+            self.touten, self.max
+        )
+    }
+}
+
+impl Default for MaxTen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for MaxTen {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+        let mut ten_count = 0usize;
+        let mut sentence_start = 0usize; // byte offset within the block
+        for (i, c) in text.char_indices() {
+            if c == self.touten {
+                ten_count += 1;
+            } else if c == self.kuten {
+                if ten_count > self.max {
+                    let end = i + c.len_utf8(); // include the terminating 。
+                    cx.report(
+                        Span::new(
+                            base.saturating_add(sentence_start as u32),
+                            base.saturating_add(end as u32),
+                        ),
+                        self.message(ten_count),
+                    );
+                }
+                ten_count = 0;
+                sentence_start = i + c.len_utf8();
+            }
+        }
+        // A trailing sentence with no terminating 。.
+        if ten_count > self.max && sentence_start < text.len() {
+            cx.report(
+                Span::new(
+                    base.saturating_add(sentence_start as u32),
+                    base.saturating_add(text.len() as u32),
+                ),
+                self.message(ten_count),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_too_many_commas() {
+        let rule = MaxTen::new(); // max 3
+        let diags = diagnose(&rule, "あ、い、う、え、お。\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("上限は 3 個"));
+    }
+
+    #[test]
+    fn within_limit_passes() {
+        assert!(diagnose(&MaxTen::new(), "あ、い、う。\n").is_empty());
+        // Exactly max passes (strict >).
+        assert!(diagnose(&MaxTen::new(), "あ、い、う、え。\n").is_empty());
+    }
+
+    #[test]
+    fn trailing_sentence_without_kuten_is_checked() {
+        let diags = diagnose(&MaxTen::new(), "あ、い、う、え、お\n");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn from_options_overrides() {
+        let rule = MaxTen::from_options(&serde_json::json!({"max": 1}));
+        // max 1: a sentence with 2 読点 exceeds it (1 alone would pass — strict >).
+        assert_eq!(diagnose(&rule, "あ、い、う。\n").len(), 1);
+        assert!(diagnose(&rule, "あ、い。\n").is_empty());
+        assert_eq!(
+            MaxTen::from_options(&serde_json::json!({"touten": ","})).touten,
+            ','
+        );
+        assert_eq!(
+            MaxTen::from_options(&serde_json::json!({"kuten": "."})).kuten,
+            '.'
+        );
+    }
+}

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -1,0 +1,7 @@
+//! The built-in rules, one module each.
+
+pub mod max_kanji_continuous_len;
+pub mod max_ten;
+pub mod no_hankaku_kana;
+pub mod no_mixed_zenkaku_hankaku_alphabet;
+pub mod sentence_length;

--- a/crates/tzlint_rules/src/rules/no_hankaku_kana.rs
+++ b/crates/tzlint_rules/src/rules/no_hankaku_kana.rs
@@ -1,0 +1,85 @@
+//! `no-hankaku-kana` — flag half-width katakana (full-width is preferred).
+
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+use crate::util::is_halfwidth_kana;
+
+/// The rule id.
+pub const ID: &str = "no-hankaku-kana";
+const MESSAGE: &str = "半角カタカナは推奨されません。全角カタカナを使ってください。";
+
+/// Flags any run of half-width katakana characters.
+pub struct NoHankakuKana {
+    meta: RuleMeta,
+}
+
+impl NoHankakuKana {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        NoHankakuKana {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]),
+        }
+    }
+}
+
+impl Default for NoHankakuKana {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoHankakuKana {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+        let mut run_start: Option<usize> = None; // byte offset within the node
+        for (i, c) in text.char_indices() {
+            if is_halfwidth_kana(c) {
+                if run_start.is_none() {
+                    run_start = Some(i);
+                }
+            } else if let Some(start) = run_start.take() {
+                cx.report(
+                    Span::new(
+                        base.saturating_add(start as u32),
+                        base.saturating_add(i as u32),
+                    ),
+                    MESSAGE,
+                );
+            }
+        }
+        if let Some(start) = run_start {
+            cx.report(
+                Span::new(
+                    base.saturating_add(start as u32),
+                    base.saturating_add(text.len() as u32),
+                ),
+                MESSAGE,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_each_run_once() {
+        // A single consecutive run is one diagnostic.
+        assert_eq!(diagnose(&NoHankakuKana::new(), "ｺﾝﾆﾁﾊ\n").len(), 1);
+        // Two runs separated by full-width text → two diagnostics.
+        assert_eq!(diagnose(&NoHankakuKana::new(), "ｱあｲ\n").len(), 2);
+    }
+
+    #[test]
+    fn full_width_kana_is_clean() {
+        assert!(diagnose(&NoHankakuKana::new(), "コンニチハ\n").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/no_mixed_zenkaku_hankaku_alphabet.rs
+++ b/crates/tzlint_rules/src/rules/no_mixed_zenkaku_hankaku_alphabet.rs
@@ -1,0 +1,189 @@
+//! `no-mixed-zenkaku-hankaku-alphabet` — flag mixing half- and full-width Latin letters.
+//!
+//! This is a document-level rule: it must see the whole document to decide which width is the
+//! minority. It registers [`NodeKind::ROOT`] and walks the subtree from its single `check` call
+//! (the `Context` has no cross-call scratch and `&self` is immutable), pruning code subtrees and
+//! collecting letter spans from text nodes.
+
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+use crate::util::is_fullwidth_alpha;
+
+/// The rule id.
+pub const ID: &str = "no-mixed-zenkaku-hankaku-alphabet";
+
+/// Flags the minority-width Latin letters when both half- and full-width letters appear.
+pub struct NoMixedZenkakuHankakuAlphabet {
+    meta: RuleMeta,
+}
+
+impl NoMixedZenkakuHankakuAlphabet {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        NoMixedZenkakuHankakuAlphabet {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::ROOT]),
+        }
+    }
+}
+
+impl Default for NoMixedZenkakuHankakuAlphabet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoMixedZenkakuHankakuAlphabet {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, root: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let mut half_hits: Vec<Span> = Vec::new();
+        let mut full_hits: Vec<Span> = Vec::new();
+
+        // Visited-guarded DFS, not descending into code (its literal is node text, not child
+        // TEXT). The bitmap bounds work to the node count and makes a byte-valid but cyclic /
+        // shared-child archive (`access` validates bytes, not the link graph) neither loop nor
+        // OOM — mirroring the engine's traversal.
+        let mut visited = vec![false; cx.ast().len()];
+        if let Some(slot) = visited.get_mut(root.id().0 as usize) {
+            *slot = true;
+        }
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            match node.kind() {
+                NodeKind::CODE | NodeKind::INLINE_CODE => {}
+                NodeKind::TEXT => {
+                    let base = node.span().start;
+                    for (i, c) in node.text().char_indices() {
+                        let span = Span::new(
+                            base.saturating_add(i as u32),
+                            base.saturating_add((i + c.len_utf8()) as u32),
+                        );
+                        if c.is_ascii_alphabetic() {
+                            half_hits.push(span);
+                        } else if is_fullwidth_alpha(c) {
+                            full_hits.push(span);
+                        }
+                    }
+                }
+                _ => {
+                    for child in node.children() {
+                        if let Some(slot) = visited.get_mut(child.id().0 as usize)
+                            && !*slot
+                        {
+                            *slot = true;
+                            stack.push(child);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Only a mix of both widths is a violation.
+        if half_hits.is_empty() || full_hits.is_empty() {
+            return;
+        }
+        // Report the minority width; ties favor full-width as the minority.
+        let (minority, majority_label) = if full_hits.len() <= half_hits.len() {
+            (&full_hits, "半角英字")
+        } else {
+            (&half_hits, "全角英字")
+        };
+        let message = format!(
+            "半角英字と全角英字が混在しています。文書全体で多く使われている{majority_label}に統一してください。"
+        );
+        for span in minority {
+            cx.report(*span, message.as_str());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_minority_width() {
+        // Two half-width + one full-width → the full-width 'Ｂ' is the minority → one diagnostic.
+        let diags = diagnose(&NoMixedZenkakuHankakuAlphabet::new(), "AＢC\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("半角英字"));
+    }
+
+    #[test]
+    fn majority_full_width_flags_half_width() {
+        // More full-width than half-width → the half-width 'd' is the minority; majority 全角英字.
+        let diags = diagnose(&NoMixedZenkakuHankakuAlphabet::new(), "ＡＢＣd\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("全角英字"));
+    }
+
+    #[test]
+    fn single_width_is_clean() {
+        assert!(diagnose(&NoMixedZenkakuHankakuAlphabet::new(), "ABC\n").is_empty());
+        assert!(diagnose(&NoMixedZenkakuHankakuAlphabet::new(), "ＡＢＣ\n").is_empty());
+    }
+
+    #[test]
+    fn code_is_not_counted() {
+        // The full-width 'Ａ' lives in inline code, so the prose has only half-width → no mix.
+        assert!(diagnose(&NoMixedZenkakuHankakuAlphabet::new(), "`Ａ`ABC\n").is_empty());
+    }
+
+    #[test]
+    fn cyclic_archive_does_not_hang() {
+        // This rule self-walks the tree, so it must be cycle-safe: a byte-valid but cyclic
+        // archive (`access` validates bytes, not the link graph) must not loop. Run on a worker
+        // thread and require it to finish quickly (a clean failure if the visited guard regresses).
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        use tzlint_ast::{Ast, Node, NodeId, OptionNodeId, Span};
+        use tzlint_pdk::Context;
+
+        // ROOT(0) → PARAGRAPH(1) whose first_child points back to itself.
+        let ast = Ast {
+            nodes: vec![
+                Node {
+                    kind: NodeKind::ROOT,
+                    span: Span::new(0, 1),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::some(NodeId(1)),
+                    next_sibling: OptionNodeId::NONE,
+                },
+                Node {
+                    kind: NodeKind::PARAGRAPH,
+                    span: Span::new(0, 1),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::some(NodeId(1)), // self-cycle
+                    next_sibling: OptionNodeId::NONE,
+                },
+            ],
+            text: "x".to_string(),
+            root: NodeId(0),
+        };
+        let bytes = tzlint_ast::to_archive(&ast).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let archived = tzlint_ast::access(&bytes).unwrap();
+            let rule = NoMixedZenkakuHankakuAlphabet::new();
+            let mut cx = Context::new(
+                archived,
+                "no-mixed-zenkaku-hankaku-alphabet".into(),
+                Severity::Warning,
+            );
+            if let Some(root) = NodeRef::root(archived) {
+                rule.check(root, &mut cx);
+            }
+            let _ = tx.send(());
+        });
+        assert!(
+            rx.recv_timeout(Duration::from_secs(5)).is_ok(),
+            "the rule hung on a cyclic archive (visited guard regressed?)"
+        );
+    }
+}

--- a/crates/tzlint_rules/src/rules/sentence_length.rs
+++ b/crates/tzlint_rules/src/rules/sentence_length.rs
@@ -1,0 +1,151 @@
+//! `sentence-length` — flag sentences longer than a character limit.
+
+use serde_json::Value;
+use tzlint_ast::NodeKind;
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+use crate::util::{split_sentences, strip_urls};
+
+/// The rule id.
+pub const ID: &str = "sentence-length";
+/// Default maximum sentence length, in characters.
+const DEFAULT_MAX: usize = 100;
+
+/// Flags any sentence (in a prose block) whose character count exceeds `max`.
+pub struct SentenceLength {
+    meta: RuleMeta,
+    max: usize,
+    skip_urls: bool,
+}
+
+impl SentenceLength {
+    /// Construct with the default options (`max` 100, URLs collapsed before counting).
+    pub fn new() -> Self {
+        SentenceLength {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            ),
+            max: DEFAULT_MAX,
+            skip_urls: true,
+        }
+    }
+
+    /// Construct from config `options`, leniently: a missing or wrong-typed value keeps the
+    /// default. Reads `max` (integer) and `skip_urls` (bool).
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        if let Some(max) = options.get("max").and_then(Value::as_u64) {
+            // Fail safe toward "no limit" on a 32-bit target rather than truncating.
+            rule.max = usize::try_from(max).unwrap_or(usize::MAX);
+        }
+        if let Some(skip) = options.get("skip_urls").and_then(Value::as_bool) {
+            rule.skip_urls = skip;
+        }
+        rule
+    }
+}
+
+impl Default for SentenceLength {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for SentenceLength {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let text = node.text();
+        // Collapse URLs first (unless disabled) so they neither inflate the length nor split
+        // sentences on the dots inside them.
+        let stripped;
+        let working: &str = if self.skip_urls {
+            stripped = strip_urls(text);
+            &stripped
+        } else {
+            text
+        };
+        for sentence in split_sentences(working) {
+            let char_count = sentence.chars().count();
+            if char_count > self.max {
+                // The span is the whole block (reconciling per-sentence offsets against the
+                // URL-stripped working string is not worth the reader benefit).
+                cx.report(
+                    node.span(),
+                    format!(
+                        "Sentence is too long ({char_count} characters). Maximum allowed is {}.",
+                        self.max
+                    ),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_over_limit_sentence() {
+        let rule = SentenceLength {
+            max: 10,
+            skip_urls: true,
+            ..SentenceLength::new()
+        };
+        let diags = diagnose(&rule, "これはとても長い一文なので警告されます。\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("too long"));
+    }
+
+    #[test]
+    fn exactly_max_passes() {
+        let rule = SentenceLength {
+            max: 5,
+            skip_urls: true,
+            ..SentenceLength::new()
+        };
+        // "12345." → sentence "12345." is 6 chars incl '.', so use 5 letters + no delimiter = 5.
+        assert!(diagnose(&rule, "12345").is_empty());
+    }
+
+    #[test]
+    fn urls_collapse_to_one_char() {
+        let input = "see https://example.com/very/long/path now";
+        // The long URL counts as a single '・', so the sentence stays under the limit.
+        let lenient = SentenceLength {
+            max: 12,
+            skip_urls: true,
+            ..SentenceLength::new()
+        };
+        assert!(diagnose(&lenient, input).is_empty());
+        // With skip_urls off the URL counts in full (and its dots even split sentences), so the
+        // limit is exceeded — at least one diagnostic.
+        let strict = SentenceLength {
+            max: 12,
+            skip_urls: false,
+            ..SentenceLength::new()
+        };
+        assert!(!diagnose(&strict, input).is_empty());
+    }
+
+    #[test]
+    fn from_options_is_lenient() {
+        assert_eq!(
+            SentenceLength::from_options(&serde_json::json!({"max": 5})).max,
+            5
+        );
+        assert!(!SentenceLength::from_options(&serde_json::json!({"skip_urls": false})).skip_urls);
+        // Wrong types / missing keys keep defaults.
+        assert_eq!(
+            SentenceLength::from_options(&serde_json::json!({"max": "x"})).max,
+            DEFAULT_MAX
+        );
+        assert_eq!(SentenceLength::from_options(&Value::Null).max, DEFAULT_MAX);
+    }
+}

--- a/crates/tzlint_rules/src/test_support.rs
+++ b/crates/tzlint_rules/src/test_support.rs
@@ -1,0 +1,16 @@
+//! Test-only helper: run one rule over a markdown source through the real engine.
+//!
+//! `tzlint_core` (the parser + engine) is a dev-dependency only — it is not part of the crate's
+//! normal dependency graph, so the rules crate stays free of the engine (and of any future
+//! `tzlint_core → tzlint_rules` cycle).
+
+use tzlint_pdk::{Diagnostic, Rule};
+
+/// Parse `source`, archive it, and run `rule` through `Engine::lint`, returning its diagnostics
+/// (engine-sorted, kind-filtered exactly as in production).
+pub(crate) fn diagnose(rule: &dyn Rule, source: &str) -> Vec<Diagnostic> {
+    let ast = tzlint_core::parse(source).expect("test source parses");
+    let bytes = tzlint_ast::to_archive(&ast).expect("archive");
+    let archived = tzlint_ast::access(&bytes).expect("access");
+    tzlint_core::Engine::lint(archived, &[rule])
+}

--- a/crates/tzlint_rules/src/util.rs
+++ b/crates/tzlint_rules/src/util.rs
@@ -1,0 +1,115 @@
+//! Shared, pure text helpers used by several rules. No AST, no panics.
+
+/// Sentence-terminating delimiters (ASCII and full-width), delimiter-inclusive when splitting.
+const SENTENCE_DELIMITERS: [char; 6] = ['.', '!', '?', '。', '！', '？'];
+
+/// Split `text` into sentences on [`SENTENCE_DELIMITERS`].
+///
+/// Each sentence includes its terminating delimiter and has leading whitespace trimmed; empty
+/// pieces are dropped. A trailing run with no delimiter is returned as a final sentence.
+pub fn split_sentences(text: &str) -> Vec<&str> {
+    let mut sentences = Vec::new();
+    let mut start = 0;
+    for (i, c) in text.char_indices() {
+        if SENTENCE_DELIMITERS.contains(&c) {
+            let end = i + c.len_utf8();
+            let sentence = text[start..end].trim_start();
+            if !sentence.is_empty() {
+                sentences.push(sentence);
+            }
+            start = end;
+        }
+    }
+    if start < text.len() {
+        let tail = text[start..].trim_start();
+        if !tail.is_empty() {
+            sentences.push(tail);
+        }
+    }
+    sentences
+}
+
+/// Collapse each `http://`/`https://` run to a single `・` so a long URL counts as one character
+/// and the dots inside it are not treated as sentence boundaries.
+pub fn strip_urls(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(c) = rest.chars().next() {
+        if rest.starts_with("http://") || rest.starts_with("https://") {
+            out.push('・');
+            // Consume the URL run up to (but not including) the next whitespace or closing mark.
+            let end = rest
+                .find(|c: char| c.is_whitespace() || matches!(c, '」' | '）' | ')' | '、' | '。'))
+                .unwrap_or(rest.len());
+            rest = &rest[end..];
+        } else {
+            out.push(c);
+            rest = &rest[c.len_utf8()..];
+        }
+    }
+    out
+}
+
+/// Whether `c` is a Han ideograph in CJK Unified (`U+4E00..=U+9FFF`) or Extension A
+/// (`U+3400..=U+4DBF`). Deliberately narrow: the iteration mark `々` (U+3005), CJK Compatibility
+/// Ideographs, and Extension B+ are excluded (preserve for parity — do not widen).
+pub fn is_kanji(c: char) -> bool {
+    matches!(c as u32, 0x4E00..=0x9FFF | 0x3400..=0x4DBF)
+}
+
+/// Whether `c` is in the half-width katakana block (`U+FF61..=U+FF9F`). This is the *whole* block,
+/// so it also includes half-width punctuation/brackets/sound-marks (｡ ｢ ｣ ･ ｰ ﾞ ﾟ) — intentional;
+/// do not tighten.
+pub fn is_halfwidth_kana(c: char) -> bool {
+    matches!(c as u32, 0xFF61..=0xFF9F)
+}
+
+/// Whether `c` is a full-width Latin letter (`Ａ–Ｚ` `U+FF21..=U+FF3A`, `ａ–ｚ` `U+FF41..=U+FF5A`).
+pub fn is_fullwidth_alpha(c: char) -> bool {
+    matches!(c as u32, 0xFF21..=0xFF3A | 0xFF41..=0xFF5A)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_sentences_basic() {
+        assert_eq!(split_sentences("Hello. World!"), vec!["Hello.", "World!"]);
+        assert_eq!(
+            split_sentences("一文目。二文目。"),
+            vec!["一文目。", "二文目。"]
+        );
+        // Trailing remainder with no delimiter is a sentence.
+        assert_eq!(split_sentences("no terminator"), vec!["no terminator"]);
+        // Leading whitespace is trimmed; empty pieces dropped.
+        assert_eq!(split_sentences("a.  b."), vec!["a.", "b."]);
+        assert!(split_sentences("").is_empty());
+    }
+
+    #[test]
+    fn strip_urls_collapses_runs() {
+        assert_eq!(
+            strip_urls("see https://example.com/a.b here"),
+            "see ・ here"
+        );
+        assert_eq!(strip_urls("（http://x.y）after"), "（・）after");
+        // No URL → unchanged.
+        assert_eq!(strip_urls("plain text"), "plain text");
+        // A bare scheme word that is not http(s) is left alone.
+        assert_eq!(strip_urls("ftp://x"), "ftp://x");
+    }
+
+    #[test]
+    fn char_classes() {
+        assert!(is_kanji('漢'));
+        assert!(!is_kanji('々')); // iteration mark excluded
+        assert!(!is_kanji('あ'));
+        assert!(is_halfwidth_kana('ｱ'));
+        assert!(is_halfwidth_kana('｡'));
+        assert!(!is_halfwidth_kana('ア')); // full-width kana is fine
+        assert!(is_fullwidth_alpha('Ａ'));
+        assert!(is_fullwidth_alpha('ｚ'));
+        assert!(!is_fullwidth_alpha('A'));
+    }
+}


### PR DESCRIPTION
## M1f-1 — first batch of native rules

Stands up `tzlint_rules` and ports the first five **morphology-free** legacy native rules
(`tsuzulint-legacy`) to the new `Rule` trait + diagnostic model, covering all three rule shapes:

| rule | shape | options |
|---|---|---|
| `sentence-length` | block (PARAGRAPH/HEADING/TABLE_CELL) | `max`, `skip_urls` |
| `max-ten` | block | `max`, `touten`, `kuten` |
| `max-kanji-continuous-len` | per-TEXT | `max` |
| `no-hankaku-kana` | per-TEXT | — |
| `no-mixed-zenkaku-hankaku-alphabet` | document-level (ROOT self-walk) | — |

### Crate shape
One module per rule under `src/rules/`, shared pure helpers in `src/util.rs`, and
`builtin_rules()` + `RULE_IDS` as the registry. Each rule stores its `RuleMeta` once and reads
node text via `NodeRef::text()` (panic-free), building absolute spans with saturating arithmetic.
Options parse leniently per rule (`from_options`); the engine does not yet route config options
into instances, so `builtin_rules()` uses defaults (TODO when that channel lands).

`tzlint_rules` depends on `tzlint_pdk` + `tzlint_ast` only — **not** `tzlint_core` (avoids a cycle
once the engine wires the registry); `tzlint_core` is a **dev-dependency** for the end-to-end
rule tests. `tzlint_core`'s `ja-basic`/`ja-technical-writing` presets are populated with these rule
ids as plain strings (no crate dependency); a cross-crate test guards id drift.

### Adversarial review (pre-PR)
A multi-lens review (per-rule parity vs the legacy source + robustness + API) surfaced 5
confirmed findings, all addressed:
- **(major)** the document-level rule self-walked the tree with no `visited` guard → a byte-valid
  but **cyclic archive** (`access` validates bytes, not the link graph) could infinite-loop/OOM.
  Added the engine's `visited`-bitmap pattern + a thread/timeout regression test.
- **(minor)** no compile/test link between preset id strings and `RULE_IDS` → added a cross-crate
  guard test (every preset rule id ∈ `RULE_IDS`).
- **(nit ×3)** `max as usize` truncates on a 32-bit target (wasm32) → `usize::try_from(..).unwrap_or(usize::MAX)` (fail safe to "no limit").
- **(nit ×2, intentional parity — no change)** inline-code commas are counted toward `max-ten`,
  and a HEADING span includes its `#` marker — both match the legacy rule exactly.

### Deferred
`no-doubled-joshi` (morphology → M2). The remaining char-class rules (no-nfd, no-zero-width-spaces,
no-exclamation-question-mark, ja-no-mixed-period, no-todo) land in **M1f-2** (a follow-up PR
stacked on this one).

Local gates: rustfmt + clippy (`-D warnings`), tzlint_core + tzlint_rules tests (incl. the new
parity/robustness tests), `cargo deny check`. No new external dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 日本語向けビルトインプリセット（`ja-basic`、`ja-technical-writing`）を追加
  * 5つの新しい日本語チェックルール（連続漢字長、読点数、半角カナ、全角半角英字混在、文字数）を実装

* **Tests**
  * プリセット設定とルール動作の検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->