### PR TITLE
docs: document web dictionary delivery (preload API + opt-in bundle)

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -17,3 +17,23 @@ Three deliberate, semver'd surfaces:
   `tzlint_core` free of native-only hard deps (it must compile to `wasm32`).
 - **Dynamic plugins degrade gracefully** without COOP/COEP → fall back to the bundled
   canonical ruleset; the API exposes whether dynamic plugins are available.
+
+## Dictionary distribution (web)
+
+> Status: design intent (M2/M4). The code-only wasm is light (~157 KiB brotli, measured);
+> the morphology dictionary (tens of MB for Japanese) is the only real bandwidth term and is
+> delivered separately. See [`morphology.md`](morphology.md) for the dictionary model.
+
+- **Default: dictionary fetched at runtime, never embedded.** Hash-pinned, compressed,
+  IndexedDB-cached, per-enabled-language. The npm/wasm artifact ships code only, so a code
+  update never re-downloads the dictionary and a dictionary update never re-downloads the
+  code. Rule sets that need no morphology fetch no dictionary at all.
+- **`preloadDictionary(lang) -> Promise<void>` is part of the JS surface.** A first-class
+  warm-up hook so apps can fetch the dictionary during idle/splash time rather than on the
+  first lint. Pairs with `<link rel="prefetch">` and a Service Worker precache (recommended
+  patterns, not requirements).
+- **Opt-in bundled variant** (e.g. a `@tsuzulint/dict-ja-*` sidecar package, or an
+  all-in-one build) for offline / air-gapped / Electron / zero-config embedders. It is an
+  explicit opt-in, never the default: bundling into the main artifact would force the
+  dictionary on every embedder, break cache granularity, and entangle dictionary licenses
+  with the binary.

--- a/docs/morphology.md
+++ b/docs/morphology.md
@@ -13,3 +13,31 @@
   identity/version is in the cache key.
 - **Licenses vary** per dictionary (IPADIC / UniDic / ko-dic / CC-CEDICT; CC-CEDICT is
   share-alike) — documented here; not embedded in the binary.
+
+## Web delivery & dictionary loading
+
+> Status: design intent (M2/M4). Measured: the code-only wasm payload is ~157 KiB brotli
+> today (parser + config + engine); a Japanese dictionary is tens of MB. The dictionary —
+> not the code — dominates web traffic, so it stays a separately cached artifact and is
+> never embedded in the wasm.
+
+- **Default stays non-embedded.** Bundling a dictionary into the wasm/npm artifact is
+  rejected as the default: it forces tens of MB on every visitor (including dictionary-free
+  rule sets), destroys cache granularity (a one-line code change would invalidate the whole
+  multi-MB blob), blocks independent dictionary updates, and would pull per-dictionary
+  licenses (e.g. share-alike CC-CEDICT) into the binary. A separate, hash-pinned,
+  IndexedDB-cached artifact avoids all four.
+- **Preload / warm-up is first-class.** The JS surface exposes an explicit
+  `preloadDictionary(lang) -> Promise<void>` so embedders can fetch ahead of the first lint
+  (during a splash screen or `requestIdleCallback`) instead of paying the latency inline.
+  Preloading changes *timing*, not architecture — the artifact and cache key are unchanged.
+- **Prefetch & offline hints.** Recommended patterns: `<link rel="prefetch">`
+  (will-need-soon) / `rel="preload"` (need-now) for the dictionary URL, and a Service Worker
+  precache for offline use. Second and later visits hit the IndexedDB cache and transfer zero
+  bytes.
+- **Dictionary size levers** (independent of delivery): prefer a compact base dictionary over
+  expanded variants (plain IPADIC over NEologd; UniDic only when its precision is needed),
+  ship compressed (zstd/gzip, decompressed client-side), trim features to those the enabled
+  rules read, and offer a reduced "lite" dictionary preset for the playground.
+- **Opt-in bundled variant** for offline / air-gapped / Electron / zero-config use is a
+  sidecar package, never the default build — see [`embedding.md`](embedding.md).


### PR DESCRIPTION
## Summary

Documents the design direction for serving the TsuzuLint wasm build on the web, focused on how the **morphology dictionary** — not the code — is delivered. Doc-only; no code changes.

The code-only wasm payload is light (**~157 KiB brotli**, measured for the current parser + config + engine), and is fetched once then immutably cached. The Japanese dictionary is tens of MB, so it is the only real bandwidth term and is treated separately.

### `docs/morphology.md` — new `## Web delivery & dictionary loading`
- **Default stays non-embedded** — bundling a dictionary into the wasm/npm artifact is rejected as the default (forces tens of MB on every visitor, destroys cache granularity, blocks independent dictionary updates, and would pull per-dictionary licenses such as share-alike CC-CEDICT into the binary).
- **Preload / warm-up is first-class** — `preloadDictionary(lang) -> Promise<void>` so embedders fetch ahead of the first lint (splash / `requestIdleCallback`); changes timing, not architecture.
- **Prefetch & offline hints** — `<link rel="prefetch">` / `rel="preload"` and Service Worker precache; repeat visits hit the IndexedDB cache and transfer zero bytes.
- **Dictionary size levers** — compact base dict over expanded variants, compressed transport, feature trimming, optional "lite" preset.

### `docs/embedding.md` — new `## Dictionary distribution (web)`
- Default: dictionary fetched at runtime, never embedded; code and dictionary update independently.
- `preloadDictionary(lang)` documented as part of the JS surface.
- **Opt-in bundled variant** (e.g. a `@tsuzulint/dict-ja-*` sidecar package) for offline / air-gapped / Electron / zero-config — explicit opt-in, never the default.

The two sections cross-reference each other. This is M2/M4 design intent (status notes mark it as such).

🤖 Generated with [Claude Code](https://claude.com/claude-code)