### PR TITLE
feat(cli): wire the tzlint lint/fix/init commands (M1g scaffold)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +234,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +281,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -447,6 +543,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +764,12 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -944,6 +1052,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -1460,6 +1574,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,8 +1786,11 @@ dependencies = [
 name = "tzlint_cli"
 version = "0.0.0"
 dependencies = [
+ "clap",
+ "serde_json",
+ "tzlint_ast",
  "tzlint_core",
- "tzlint_rules",
+ "tzlint_pdk",
 ]
 
 [[package]]
@@ -1747,6 +1870,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid-simd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,11 @@ yaml_serde = "0.10"
 # job greps that the `pure` feature stays set.)
 blake3 = { version = "1.8.5", default-features = false, features = ["pure"] }
 
+# Argument parsing for the native `tzlint` CLI (the `derive` API: `Parser`/`Subcommand`/
+# `ValueEnum`). CLI-only — it never reaches the AST or the `wasm32` core (the wasm CI job
+# builds `tzlint_core` lib-only), so a native-only dependency here is fine.
+clap = { version = "4", features = ["derive"] }
+
 # Lints applied workspace-wide. `unwrap`/`expect`/`panic` are denied in library code
 # (per the design's error-handling rules); the io-guard CI job adds the disallowed-methods
 # checks via clippy.toml.

--- a/crates/tzlint_cli/Cargo.toml
+++ b/crates/tzlint_cli/Cargo.toml
@@ -16,5 +16,16 @@ name = "tzlint"
 path = "src/main.rs"
 
 [dependencies]
+# The lint pipeline: parser, engine, autofix, config (+ discovery), document cache, the
+# position mapper, and the centralized `Host` I/O boundary (the CLI does all of its file
+# access through `Host`, never raw `std::fs` — enforced by clippy + the io-guard CI job).
 tzlint_core = { path = "../tzlint_core", version = "0.0.0" }
-tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
+# The diagnostic model and `Rule` trait the engine works in terms of.
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
+# `to_archive`/`access` (the parse → archive → lint bridge for the no-cache path) and `Span`.
+tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+# Argument parsing (derive API).
+clap = { workspace = true }
+# JSON output. The diagnostic model is serde-free (it is `no_std`/ABI-frozen), so the CLI
+# builds the JSON document itself from the diagnostic fields rather than deriving `Serialize`.
+serde_json = { workspace = true }

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -1,0 +1,572 @@
+//! Command orchestration: resolve the config, run the pipeline over each file, and report.
+//!
+//! Every filesystem touch goes through the injected [`Host`], and the working directory is
+//! passed in rather than read from the process, so the whole flow is unit-testable against an
+//! in-memory host (see the tests) and reused unchanged by any embedder. Each command returns an
+//! [`ExitStatus`]; [`run`] turns an unexpected error into a message on stderr and the `Error`
+//! status.
+//!
+//! Output policy: writes to **stdout** are user-facing results, so their errors propagate (a
+//! failed result write becomes `Error`). Writes to **stderr** (errors, notes) are best-effort
+//! `let _ = writeln!(…)`: a failed stderr write must not abort the run or change the exit code,
+//! which already signals the outcome.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use tzlint_ast::{access, to_archive};
+use tzlint_core::io::{MAX_CONFIG, MAX_FILE};
+use tzlint_core::{
+    Config, ConfigFormat, DocumentCache, Engine, Host, discover, lint_cached, parse,
+};
+use tzlint_pdk::{Diagnostic, Rule};
+
+use crate::cli::{Cli, Command, OutputFormat};
+use crate::output::{self, FileReport};
+use crate::rules::resolve_rules;
+
+/// The process exit status, mapped to a code by [`ExitStatus::code`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExitStatus {
+    /// No diagnostics and no errors.
+    Clean,
+    /// Linting completed but reported one or more diagnostics.
+    Findings,
+    /// An operational error occurred (bad config, unreadable file, write failure, …).
+    Error,
+}
+
+impl ExitStatus {
+    /// The conventional process exit code. `Error` (2) takes precedence over `Findings` (1)
+    /// over `Clean` (0).
+    #[must_use]
+    pub fn code(self) -> u8 {
+        match self {
+            ExitStatus::Clean => 0,
+            ExitStatus::Findings => 1,
+            ExitStatus::Error => 2,
+        }
+    }
+}
+
+/// The started config used when init writes a new file. Minimal but valid: an empty rule map
+/// (so nothing is overridden) and the document language. Plain `.json` (strict), so no comments.
+const STARTER_CONFIG: &str = "{\n  \"language\": \"ja\",\n  \"rules\": {}\n}\n";
+
+/// Dispatch the parsed [`Cli`] to its subcommand, writing output to `stdout`/`stderr`.
+///
+/// A subcommand's unexpected error is rendered as `error: …` on stderr and becomes
+/// [`ExitStatus::Error`]; per-file problems are reported inline and do not abort the run.
+pub fn run(
+    cli: &Cli,
+    host: &dyn Host,
+    cwd: &Path,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> ExitStatus {
+    let result = match &cli.command {
+        Command::Lint { paths, format } => lint(cli, host, cwd, paths, *format, stdout, stderr),
+        Command::Fix { paths, dry_run } => fix(cli, host, cwd, paths, *dry_run, stdout, stderr),
+        Command::Init { force } => init(host, cwd, *force, stdout, stderr),
+    };
+    match result {
+        Ok(status) => status,
+        Err(message) => {
+            // stderr is best-effort (see the module's output policy); the `Error` status below
+            // is the authoritative signal regardless of whether this message lands.
+            let _ = writeln!(stderr, "error: {message}");
+            ExitStatus::Error
+        }
+    }
+}
+
+/// `lint`: read, lint, and render each file; exit `Findings` if any diagnostics, `Error` if any
+/// file could not be read or linted.
+fn lint(
+    cli: &Cli,
+    host: &dyn Host,
+    cwd: &Path,
+    paths: &[PathBuf],
+    format: OutputFormat,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> Result<ExitStatus, String> {
+    let config = load_config(cli, host, cwd, stderr)?;
+    let rules = resolve_rules(&config);
+    note_if_no_rules(&rules, stderr);
+    let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
+
+    let mut cache = (!cli.no_cache).then(DocumentCache::new);
+    let mut reports = Vec::with_capacity(paths.len());
+    let mut had_error = false;
+    for path in paths {
+        match read_and_lint(host, cache.as_mut(), path, &config, &rule_refs) {
+            Ok(report) => reports.push(report),
+            Err(message) => {
+                let _ = writeln!(stderr, "error: {}: {message}", path.display());
+                had_error = true;
+            }
+        }
+    }
+
+    match format {
+        OutputFormat::Text => output::render_text(stdout, &reports).map_err(|e| e.to_string())?,
+        OutputFormat::Json => output::render_json(stdout, &reports).map_err(|e| e.to_string())?,
+    }
+
+    let has_findings = reports.iter().any(|report| !report.diagnostics.is_empty());
+    Ok(lint_exit_status(had_error, has_findings))
+}
+
+/// Combine the per-file outcome flags into the lint exit status, with `Error` taking precedence
+/// over `Findings` over `Clean`.
+fn lint_exit_status(had_error: bool, has_findings: bool) -> ExitStatus {
+    if had_error {
+        ExitStatus::Error
+    } else if has_findings {
+        ExitStatus::Findings
+    } else {
+        ExitStatus::Clean
+    }
+}
+
+/// Read `path` through the host and lint it, via the cache when enabled or the direct
+/// parse→archive→lint bridge otherwise.
+fn read_and_lint(
+    host: &dyn Host,
+    cache: Option<&mut DocumentCache>,
+    path: &Path,
+    config: &Config,
+    rules: &[&dyn Rule],
+) -> Result<FileReport, String> {
+    let source = host
+        .read_to_string(path, MAX_FILE)
+        .map_err(|e| e.to_string())?;
+    let diagnostics = match cache {
+        Some(cache) => lint_cached(cache, &source, config, rules).map_err(|e| e.to_string())?,
+        None => lint_direct(&source, rules)?,
+    };
+    Ok(FileReport {
+        path: path.to_path_buf(),
+        source,
+        diagnostics,
+    })
+}
+
+/// The no-cache path: parse → archive → access → [`Engine::lint`], surfacing parse/archive
+/// failures as a message (mirrors what [`lint_cached`] reports on the cached path).
+fn lint_direct(source: &str, rules: &[&dyn Rule]) -> Result<Vec<Diagnostic>, String> {
+    let ast = parse(source).map_err(|e| e.to_string())?;
+    let bytes = to_archive(&ast).map_err(|e| format!("archive failed: {e}"))?;
+    let archived = access(&bytes).map_err(|e| format!("archive failed: {e}"))?;
+    Ok(Engine::lint(archived, rules))
+}
+
+/// `fix`: lint-and-fix each file to a fixpoint; write changed files in place (or just report
+/// them under `--dry-run`).
+fn fix(
+    cli: &Cli,
+    host: &dyn Host,
+    cwd: &Path,
+    paths: &[PathBuf],
+    dry_run: bool,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> Result<ExitStatus, String> {
+    let config = load_config(cli, host, cwd, stderr)?;
+    let rules = resolve_rules(&config);
+    note_if_no_rules(&rules, stderr);
+    let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
+
+    let mut changed = 0usize;
+    let mut had_error = false;
+    for path in paths {
+        let source = match host.read_to_string(path, MAX_FILE) {
+            Ok(source) => source,
+            Err(e) => {
+                let _ = writeln!(stderr, "error: {}: {e}", path.display());
+                had_error = true;
+                continue;
+            }
+        };
+        // `fix` parses internally and returns the source unchanged on a parse failure, so the
+        // only failure to handle here is the write below.
+        let fixed = tzlint_core::fix(&source, &rule_refs);
+        if fixed == source {
+            continue;
+        }
+        if dry_run {
+            writeln!(stdout, "would fix {}", path.display()).map_err(|e| e.to_string())?;
+        } else if let Err(e) = host.write_atomic(path, fixed.as_bytes()) {
+            let _ = writeln!(stderr, "error: {}: {e}", path.display());
+            had_error = true;
+            continue;
+        } else {
+            writeln!(stdout, "fixed {}", path.display()).map_err(|e| e.to_string())?;
+        }
+        changed += 1;
+    }
+
+    let verb = if dry_run {
+        "would be changed"
+    } else {
+        "changed"
+    };
+    writeln!(stdout, "{changed} file(s) {verb}").map_err(|e| e.to_string())?;
+    Ok(if had_error {
+        ExitStatus::Error
+    } else {
+        ExitStatus::Clean
+    })
+}
+
+/// `init`: write [`STARTER_CONFIG`] to `.tzlintrc.json` in the working directory, refusing to
+/// clobber an existing file unless `force`.
+fn init(
+    host: &dyn Host,
+    cwd: &Path,
+    force: bool,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> Result<ExitStatus, String> {
+    let path = cwd.join(".tzlintrc.json");
+    // Best-effort guard: there is a small TOCTOU window between this check and the write (the
+    // `Host` write does not expose create-new semantics yet). Acceptable for `init`.
+    if host.exists(&path) && !force {
+        let _ = writeln!(
+            stderr,
+            "error: {} already exists (use --force to overwrite)",
+            path.display()
+        );
+        return Ok(ExitStatus::Error);
+    }
+    host.write_atomic(&path, STARTER_CONFIG.as_bytes())
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    writeln!(stdout, "created {}", path.display()).map_err(|e| e.to_string())?;
+    Ok(ExitStatus::Clean)
+}
+
+/// Resolve the configuration: read `--config` if given (format inferred from its name, JSONC
+/// otherwise), else walk up from the working directory via [`discover`], else the default.
+fn load_config(
+    cli: &Cli,
+    host: &dyn Host,
+    cwd: &Path,
+    stderr: &mut dyn Write,
+) -> Result<Config, String> {
+    if let Some(path) = &cli.config {
+        // Infer the format from the name and fail loudly on an unrecognized one, rather than
+        // silently assuming JSONC and surfacing a confusing parse error downstream.
+        let format = ConfigFormat::from_path(path).ok_or_else(|| {
+            format!(
+                "{}: unrecognized config format (expected .json, .jsonc, .yaml, .yml, or .tzlintrc)",
+                path.display()
+            )
+        })?;
+        let text = host
+            .read_to_string(path, MAX_CONFIG)
+            .map_err(|e| format!("{}: {e}", path.display()))?;
+        let config =
+            Config::parse(&text, format).map_err(|e| format!("{}: {e}", path.display()))?;
+        if cli.verbose {
+            let _ = writeln!(stderr, "note: using config {}", path.display());
+        }
+        return Ok(config);
+    }
+
+    match discover(host, cwd) {
+        Ok(Some(found)) => {
+            if cli.verbose {
+                let _ = writeln!(stderr, "note: using config {}", found.path.display());
+                for warning in &found.warnings {
+                    let _ = writeln!(stderr, "note: {warning}");
+                }
+            }
+            Ok(found.config)
+        }
+        Ok(None) => {
+            if cli.verbose {
+                let _ = writeln!(stderr, "note: no config file found; using defaults");
+            }
+            Ok(Config::default())
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Print a one-line note to stderr when no rules are wired, so an empty result is not mistaken
+/// for "your text is clean". Removed once the rule registry lands.
+fn note_if_no_rules(rules: &[Box<dyn Rule>], stderr: &mut dyn Write) {
+    if rules.is_empty() {
+        let _ = writeln!(
+            stderr,
+            "note: no rules are enabled yet (the built-in rule registry lands in a later step); \
+             the pipeline runs but reports nothing"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    use tzlint_core::IoError;
+
+    use crate::cli::Command;
+
+    /// An in-memory [`Host`]: only registered paths exist; writes are recorded so tests can
+    /// assert on them.
+    struct MockHost {
+        files: RefCell<HashMap<PathBuf, String>>,
+    }
+
+    impl MockHost {
+        fn new() -> Self {
+            MockHost {
+                files: RefCell::new(HashMap::new()),
+            }
+        }
+        fn with(path: &str, contents: &str) -> Self {
+            let host = MockHost::new();
+            host.put(path, contents);
+            host
+        }
+        fn put(&self, path: &str, contents: &str) {
+            self.files
+                .borrow_mut()
+                .insert(PathBuf::from(path), contents.to_string());
+        }
+        fn read(&self, path: &str) -> Option<String> {
+            self.files.borrow().get(&PathBuf::from(path)).cloned()
+        }
+    }
+
+    impl Host for MockHost {
+        fn read_to_string(&self, path: &Path, limit: usize) -> Result<String, IoError> {
+            match self.files.borrow().get(path) {
+                Some(content) if content.len() > limit => Err(IoError::TooLarge { limit }),
+                Some(content) => Ok(content.clone()),
+                None => Err(IoError::NotFound),
+            }
+        }
+        fn write_atomic(&self, path: &Path, contents: &[u8]) -> Result<(), IoError> {
+            let text =
+                String::from_utf8(contents.to_vec()).map_err(|e| IoError::Other(e.to_string()))?;
+            self.files.borrow_mut().insert(path.to_path_buf(), text);
+            Ok(())
+        }
+        fn exists(&self, path: &Path) -> bool {
+            self.files.borrow().contains_key(path)
+        }
+    }
+
+    fn cli(command: Command) -> Cli {
+        Cli {
+            command,
+            config: None,
+            verbose: false,
+            no_cache: false,
+        }
+    }
+
+    fn lint_cli(path: &str, format: OutputFormat) -> Cli {
+        cli(Command::Lint {
+            paths: vec![PathBuf::from(path)],
+            format,
+        })
+    }
+
+    /// A fixed, absolute working directory for hermetic discovery/init tests (the orchestration
+    /// never touches the real process cwd — it is injected).
+    const TEST_CWD: &str = "/work";
+
+    fn run_capture(cli: &Cli, host: &dyn Host) -> (ExitStatus, String, String) {
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let status = run(cli, host, Path::new(TEST_CWD), &mut out, &mut err);
+        (
+            status,
+            String::from_utf8(out).unwrap(),
+            String::from_utf8(err).unwrap(),
+        )
+    }
+
+    #[test]
+    fn exit_status_codes() {
+        assert_eq!(ExitStatus::Clean.code(), 0);
+        assert_eq!(ExitStatus::Findings.code(), 1);
+        assert_eq!(ExitStatus::Error.code(), 2);
+    }
+
+    /// Where `init` writes under the injected [`TEST_CWD`].
+    const TEST_CONFIG_PATH: &str = "/work/.tzlintrc.json";
+
+    #[test]
+    fn init_writes_a_valid_starter_config() {
+        let host = MockHost::new();
+        let (status, out, _err) = run_capture(&cli(Command::Init { force: false }), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(out.contains("created /work/.tzlintrc.json"), "{out}");
+        let written = host.read(TEST_CONFIG_PATH).unwrap();
+        let config = Config::parse(&written, ConfigFormat::Json).unwrap();
+        assert_eq!(config.language.as_deref(), Some("ja"));
+    }
+
+    #[test]
+    fn init_refuses_to_clobber_without_force() {
+        let host = MockHost::with(TEST_CONFIG_PATH, "{ \"language\": \"en\" }");
+        let (status, _out, err) = run_capture(&cli(Command::Init { force: false }), &host);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("already exists"), "{err}");
+        // The existing file is untouched.
+        assert_eq!(
+            host.read(TEST_CONFIG_PATH).as_deref(),
+            Some("{ \"language\": \"en\" }")
+        );
+    }
+
+    #[test]
+    fn init_force_overwrites() {
+        let host = MockHost::with(TEST_CONFIG_PATH, "{ \"language\": \"en\" }");
+        let (status, _out, _err) = run_capture(&cli(Command::Init { force: true }), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(host.read(TEST_CONFIG_PATH).unwrap().contains("\"ja\""));
+    }
+
+    #[test]
+    fn lint_clean_file_exits_clean() {
+        let host = MockHost::with("a.md", "ただのテキストです。\n");
+        let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
+        // No rules wired → no diagnostics → Clean.
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(out.contains("1 file(s) checked, 0 issue(s) found"), "{out}");
+    }
+
+    #[test]
+    fn lint_missing_file_exits_error() {
+        let host = MockHost::new();
+        let (status, _out, err) = run_capture(&lint_cli("nope.md", OutputFormat::Text), &host);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("nope.md"), "{err}");
+    }
+
+    #[test]
+    fn lint_json_output_is_an_array() {
+        let host = MockHost::with("a.md", "# 見出し\n\n本文。\n");
+        let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Json), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(value.is_array());
+        assert_eq!(value[0]["path"], "a.md");
+        assert_eq!(value[0]["diagnostics"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn no_cache_path_matches_cached_path() {
+        // Both code paths (cached vs. direct bridge) must produce identical output. Today the
+        // rule set is empty, so this compares the clean case; the diagnostic-bearing equivalence
+        // is added alongside the rule-registry wiring (when a rule can emit a diagnostic).
+        let host = MockHost::with("a.md", "段落です。\n別の段落。\n");
+        let (_s1, cached_out, _e1) = run_capture(&lint_cli("a.md", OutputFormat::Json), &host);
+        let mut direct = lint_cli("a.md", OutputFormat::Json);
+        direct.no_cache = true;
+        let (_s2, direct_out, _e2) = run_capture(&direct, &host);
+        assert_eq!(cached_out, direct_out);
+    }
+
+    #[test]
+    fn explicit_config_is_loaded_and_noted_when_verbose() {
+        let host = MockHost::new();
+        host.put("custom.json", "{ \"language\": \"ja\" }");
+        host.put("a.md", "x\n");
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("custom.json"));
+        c.verbose = true;
+        let (status, _out, err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(err.contains("using config custom.json"), "{err}");
+    }
+
+    #[test]
+    fn bad_explicit_config_exits_error() {
+        let host = MockHost::with("bad.json", "{ not json");
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("bad.json"));
+        let (status, _out, err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("bad.json"), "{err}");
+    }
+
+    #[test]
+    fn fix_is_a_noop_without_rules() {
+        // Without rules `fix` makes no change, so the write branch (`fixed != source`) is not
+        // reachable here; it is exercised alongside the rule-registry wiring.
+        let host = MockHost::with("a.md", "本文。\n");
+        let (status, out, _err) = run_capture(
+            &cli(Command::Fix {
+                paths: vec![PathBuf::from("a.md")],
+                dry_run: false,
+            }),
+            &host,
+        );
+        assert_eq!(status, ExitStatus::Clean);
+        // Unchanged: no rules → no fixes.
+        assert_eq!(host.read("a.md").as_deref(), Some("本文。\n"));
+        assert!(out.contains("0 file(s) changed"), "{out}");
+    }
+
+    #[test]
+    fn lint_exit_status_precedence() {
+        // Error > Findings > Clean. (Exercises the `Findings` arm without a rule, which the
+        // command path cannot reach until the rule registry is wired.)
+        assert_eq!(lint_exit_status(false, false), ExitStatus::Clean);
+        assert_eq!(lint_exit_status(false, true), ExitStatus::Findings);
+        assert_eq!(lint_exit_status(true, false), ExitStatus::Error);
+        assert_eq!(lint_exit_status(true, true), ExitStatus::Error);
+    }
+
+    #[test]
+    fn unrecognized_explicit_config_format_errors() {
+        // An explicit --config with an unknown extension fails loudly rather than being
+        // mis-parsed as JSONC.
+        let host = MockHost::with("config.toml", "x = 1\n");
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("config.toml"));
+        let (status, _out, err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("unrecognized config format"), "{err}");
+    }
+
+    #[test]
+    fn verbose_notes_discovered_config() {
+        // With no explicit --config, discovery walks up from the injected cwd and finds the
+        // registered file; verbose mode reports it.
+        let host = MockHost::new();
+        host.put(TEST_CONFIG_PATH, "{ \"language\": \"ja\" }");
+        host.put("a.md", "x\n");
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.verbose = true;
+        let (status, _out, err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(err.contains("using config /work/.tzlintrc.json"), "{err}");
+    }
+
+    #[test]
+    fn fix_reports_error_for_unreadable_file_among_others() {
+        // One readable (no-op) file and one missing file: the read error makes the run `Error`,
+        // and the missing path is named on stderr; nothing is changed (no rules).
+        let host = MockHost::with("ok.md", "本文。\n");
+        let (status, out, err) = run_capture(
+            &cli(Command::Fix {
+                paths: vec![PathBuf::from("ok.md"), PathBuf::from("missing.md")],
+                dry_run: false,
+            }),
+            &host,
+        );
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("missing.md"), "{err}");
+        assert!(out.contains("0 file(s) changed"), "{out}");
+    }
+}

--- a/crates/tzlint_cli/src/cli.rs
+++ b/crates/tzlint_cli/src/cli.rs
@@ -1,0 +1,74 @@
+//! Command-line argument definitions (clap derive).
+//!
+//! The surface mirrors the established `tzlint` UX: a few global options (`--config`,
+//! `--verbose`, `--no-cache`) and the `lint` / `fix` / `init` subcommands. Plugin, rule-
+//! management, and LSP subcommands, plus the SARIF output format, are intentionally out of
+//! scope here and arrive with later milestones.
+
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
+
+/// TsuzuLint — a high-performance natural-language linter for CJK.
+#[derive(Parser, Debug)]
+#[command(name = "tzlint", version, about, long_about = None)]
+pub struct Cli {
+    /// The subcommand to run.
+    #[command(subcommand)]
+    pub command: Command,
+
+    /// Use this configuration file instead of discovering one by walking up from the
+    /// working directory.
+    #[arg(short, long, global = true, value_name = "PATH")]
+    pub config: Option<PathBuf>,
+
+    /// Print extra notes (which config was used, shadowed candidates) to stderr.
+    #[arg(short, long, global = true)]
+    pub verbose: bool,
+
+    /// Disable the in-memory document cache (lint each file from scratch).
+    #[arg(long, global = true)]
+    pub no_cache: bool,
+}
+
+/// The available subcommands.
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Lint files and report diagnostics.
+    Lint {
+        /// Files to lint.
+        #[arg(required = true, value_name = "PATH")]
+        paths: Vec<PathBuf>,
+
+        /// Output format.
+        #[arg(short, long, default_value = "text")]
+        format: OutputFormat,
+    },
+
+    /// Apply autofixes to files (in place, unless `--dry-run`).
+    Fix {
+        /// Files to fix.
+        #[arg(required = true, value_name = "PATH")]
+        paths: Vec<PathBuf>,
+
+        /// Report which files would change without writing them.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Write a starter `.tzlintrc.json` in the working directory.
+    Init {
+        /// Overwrite an existing config file.
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+/// How `lint` renders its diagnostics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    /// One grep-friendly `path:line:col: severity: message [rule]` line per diagnostic.
+    Text,
+    /// A JSON array of `{ path, diagnostics }` objects.
+    Json,
+}

--- a/crates/tzlint_cli/src/main.rs
+++ b/crates/tzlint_cli/src/main.rs
@@ -1,8 +1,34 @@
-//! `tzlint` — the `TsuzuLint` command-line binary.
+//! `tzlint` — the TsuzuLint command-line binary.
 //!
-//! TODO(M1): wire `lint` / `fix` / `init` subcommands over `tzlint_core::Engine::lint`,
-//! with pretty/json/sarif output via the position mapper.
+//! Wires the `lint` / `fix` / `init` subcommands over `tzlint_core`: config discovery, the
+//! parse → archive → `Engine::lint` pipeline (with the in-memory document cache), autofix, and
+//! text/JSON output via the position mapper. All file access goes through the `Host` boundary
+//! (`NativeHost`), never raw `std::fs`.
+//!
+//! Resolving a config to the actual rule set is the one piece still stubbed (see
+//! [`rules::resolve_rules`]): the built-in rule registry lives in `tzlint_rules`, which is a
+//! skeleton until the rules milestone, so today the engine runs with an empty rule set.
 
-fn main() {
-    println!("tzlint (skeleton) — see docs/roadmap.md for milestones.");
+use std::process::ExitCode;
+
+use clap::Parser;
+use tzlint_core::io::NativeHost;
+
+use crate::cli::Cli;
+
+mod app;
+mod cli;
+mod output;
+mod rules;
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let host = NativeHost;
+    // Resolve the working directory once, here at the edge, and pass it in — the orchestration
+    // stays independent of process-global state (and so hermetically testable).
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let mut stdout = std::io::stdout().lock();
+    let mut stderr = std::io::stderr().lock();
+    let status = app::run(&cli, &host, &cwd, &mut stdout, &mut stderr);
+    ExitCode::from(status.code())
 }

--- a/crates/tzlint_cli/src/output.rs
+++ b/crates/tzlint_cli/src/output.rs
@@ -1,0 +1,218 @@
+//! Rendering lint results to stdout, in either the human-readable text format or JSON.
+//!
+//! Byte spans are mapped to 1-based `(line, column)` positions with [`LineIndex`] at render
+//! time (the source is kept alongside the diagnostics for exactly this). Diagnostics arrive
+//! already in the engine's stable total order, so no re-sorting happens here.
+
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use serde_json::{Value, json};
+use tzlint_core::LineIndex;
+use tzlint_pdk::{Diagnostic, Severity};
+
+/// One linted file: its path, the exact source that was linted (needed to map byte offsets to
+/// line/column), and the diagnostics the engine produced for it.
+pub struct FileReport {
+    /// The path as the user supplied it.
+    pub path: PathBuf,
+    /// The source text that was linted (BOM-stripped by the parser, but byte-for-byte what the
+    /// spans index into).
+    pub source: String,
+    /// Diagnostics in the engine's stable total order.
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// The lowercase wire name for a severity (stable: used in both text and JSON output).
+fn severity_str(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+        Severity::Info => "info",
+        Severity::Hint => "hint",
+    }
+}
+
+/// Render `reports` as text: one `path:line:col: severity: message [rule]` line per
+/// diagnostic, then a one-line summary.
+pub fn render_text(writer: &mut dyn Write, reports: &[FileReport]) -> io::Result<()> {
+    let mut total_issues = 0usize;
+    for report in reports {
+        let index = LineIndex::new(&report.source);
+        for diagnostic in &report.diagnostics {
+            let (line, column) = index.position(&report.source, diagnostic.span.start);
+            writeln!(
+                writer,
+                "{}:{}:{}: {}: {} [{}]",
+                report.path.display(),
+                line,
+                column,
+                severity_str(diagnostic.severity),
+                diagnostic.message,
+                diagnostic.rule_id,
+            )?;
+            total_issues += 1;
+        }
+    }
+    writeln!(
+        writer,
+        "{} file(s) checked, {} issue(s) found",
+        reports.len(),
+        total_issues,
+    )
+}
+
+/// Render `reports` as a pretty-printed JSON array of `{ path, diagnostics }` objects.
+///
+/// Each diagnostic carries the raw byte `span`, the mapped 1-based line/column `position`,
+/// the lowercase `severity`, the `rule_id`, the `message`, and any `fixes`.
+pub fn render_json(writer: &mut dyn Write, reports: &[FileReport]) -> io::Result<()> {
+    let files: Vec<Value> = reports
+        .iter()
+        .map(|report| {
+            let index = LineIndex::new(&report.source);
+            let diagnostics: Vec<Value> = report
+                .diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic_json(&report.source, &index, diagnostic))
+                .collect();
+            json!({
+                "path": report.path.display().to_string(),
+                "diagnostics": diagnostics,
+            })
+        })
+        .collect();
+
+    // `serde_json` only fails here on an underlying writer error, which is already `io`.
+    serde_json::to_writer_pretty(&mut *writer, &Value::Array(files)).map_err(io::Error::other)?;
+    writeln!(writer)
+}
+
+/// The JSON object for a single diagnostic.
+fn diagnostic_json(source: &str, index: &LineIndex, diagnostic: &Diagnostic) -> Value {
+    let (start_line, start_col) = index.position(source, diagnostic.span.start);
+    let (end_line, end_col) = index.position(source, diagnostic.span.end);
+    let fixes: Vec<Value> = diagnostic
+        .fixes
+        .iter()
+        .map(|fix| {
+            let (fix_start_line, fix_start_col) = index.position(source, fix.span.start);
+            let (fix_end_line, fix_end_col) = index.position(source, fix.span.end);
+            json!({
+                "span": { "start": fix.span.start, "end": fix.span.end },
+                "position": {
+                    "start": { "line": fix_start_line, "column": fix_start_col },
+                    "end": { "line": fix_end_line, "column": fix_end_col },
+                },
+                "replacement": fix.replacement,
+            })
+        })
+        .collect();
+    json!({
+        "rule_id": diagnostic.rule_id.as_str(),
+        "severity": severity_str(diagnostic.severity),
+        "message": diagnostic.message,
+        "span": { "start": diagnostic.span.start, "end": diagnostic.span.end },
+        "position": {
+            "start": { "line": start_line, "column": start_col },
+            "end": { "line": end_line, "column": end_col },
+        },
+        "fixes": fixes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tzlint_ast::Span;
+    use tzlint_pdk::Fix;
+
+    fn report(path: &str, source: &str, diagnostics: Vec<Diagnostic>) -> FileReport {
+        FileReport {
+            path: PathBuf::from(path),
+            source: source.to_string(),
+            diagnostics,
+        }
+    }
+
+    fn render_text_string(reports: &[FileReport]) -> String {
+        let mut buf = Vec::new();
+        render_text(&mut buf, reports).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn render_json_value(reports: &[FileReport]) -> Value {
+        let mut buf = Vec::new();
+        render_json(&mut buf, reports).unwrap();
+        serde_json::from_slice(&buf).unwrap()
+    }
+
+    #[test]
+    fn text_summary_for_no_diagnostics() {
+        let out = render_text_string(&[report("a.md", "ok\n", vec![])]);
+        assert_eq!(out, "1 file(s) checked, 0 issue(s) found\n");
+    }
+
+    #[test]
+    fn text_renders_line_col_severity_message_rule() {
+        // A diagnostic on the second line: "壱\n" is 4 bytes (3 for 壱 + newline), so offset 4
+        // is the first char of line 2 → 2:1.
+        let diag = Diagnostic::new("no-todo", Severity::Warning, Span::new(4, 8), "found TODO");
+        let out = render_text_string(&[report("doc.md", "壱\nTODO\n", vec![diag])]);
+        assert!(
+            out.contains("doc.md:2:1: warning: found TODO [no-todo]"),
+            "{out}"
+        );
+        assert!(out.contains("1 file(s) checked, 1 issue(s) found"), "{out}");
+    }
+
+    #[test]
+    fn text_counts_issues_across_files() {
+        let d = |msg: &str| Diagnostic::new("r", Severity::Error, Span::new(0, 1), msg);
+        let out = render_text_string(&[
+            report("a.md", "x", vec![d("one"), d("two")]),
+            report("b.md", "y", vec![]),
+        ]);
+        assert!(out.contains("2 file(s) checked, 2 issue(s) found"), "{out}");
+    }
+
+    #[test]
+    fn json_shape_for_no_diagnostics() {
+        let value = render_json_value(&[report("a.md", "ok\n", vec![])]);
+        assert_eq!(
+            value,
+            json!([{ "path": "a.md", "diagnostics": [] }]),
+            "{value}"
+        );
+    }
+
+    #[test]
+    fn json_includes_span_position_severity_and_fix() {
+        let diag = Diagnostic::new("max-ten", Severity::Info, Span::new(4, 7), "msg")
+            .with_fix(Fix::replace(Span::new(4, 7), "、"));
+        let value = render_json_value(&[report("doc.md", "壱\nabc\n", vec![diag])]);
+        let d = &value[0]["diagnostics"][0];
+        assert_eq!(d["rule_id"], "max-ten");
+        assert_eq!(d["severity"], "info");
+        assert_eq!(d["span"], json!({ "start": 4, "end": 7 }));
+        assert_eq!(d["position"]["start"], json!({ "line": 2, "column": 1 }));
+        assert_eq!(d["fixes"][0]["replacement"], "、");
+        assert_eq!(d["fixes"][0]["span"], json!({ "start": 4, "end": 7 }));
+        assert_eq!(
+            d["fixes"][0]["position"]["start"],
+            json!({ "line": 2, "column": 1 })
+        );
+        assert_eq!(
+            d["fixes"][0]["position"]["end"],
+            json!({ "line": 2, "column": 4 })
+        );
+    }
+
+    #[test]
+    fn severity_names_are_lowercase() {
+        assert_eq!(severity_str(Severity::Error), "error");
+        assert_eq!(severity_str(Severity::Warning), "warning");
+        assert_eq!(severity_str(Severity::Info), "info");
+        assert_eq!(severity_str(Severity::Hint), "hint");
+    }
+}

--- a/crates/tzlint_cli/src/rules.rs
+++ b/crates/tzlint_cli/src/rules.rs
@@ -1,0 +1,36 @@
+//! Resolving a [`Config`] to the set of [`Rule`]s the engine should run.
+//!
+//! This is the one part of the pipeline that is *not* wired yet. The built-in rule registry
+//! lives in `tzlint_rules`, which is still a skeleton on `main` (its `Rule` impls and the
+//! `builtin_rules()` constructor land with the rules milestone). Until then there are no
+//! native rules to construct, so this returns an empty set: the rest of the pipeline
+//! (read → parse → archive → engine → output, plus config discovery and the cache) is fully
+//! wired and exercised, and the engine simply reports nothing.
+//!
+//! When the registry lands, this function maps `config.rules` (and any preset) onto the
+//! built-in rules — turning settings on/off, applying severity overrides, and threading each
+//! rule's `options` through. That is a localized change to this single file.
+
+use tzlint_core::Config;
+use tzlint_pdk::Rule;
+
+/// Build the boxed rule set to run for `config`.
+///
+/// Currently always empty — see the module docs. `config` is accepted now so the signature
+/// is stable across the registry-wiring change.
+#[must_use]
+pub fn resolve_rules(_config: &Config) -> Vec<Box<dyn Rule>> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_rules_are_wired_yet() {
+        // A guard on the documented current state: the registry is not wired, so any config
+        // resolves to zero rules. Update this when `tzlint_rules` lands its registry.
+        assert!(resolve_rules(&Config::default()).is_empty());
+    }
+}


### PR DESCRIPTION
## What

M1g: implement the `tzlint` binary over `tzlint_core`, replacing the skeleton `main.rs`.

- **clap** subcommands: `lint <paths>… [-f text|json]`, `fix <paths>… [--dry-run]`, `init [--force]`; global `-c/--config`, `-v/--verbose`, `--no-cache`.
- **Pipeline**: config discovery/loading → read (via `Host`) → `parse` → `to_archive`/`access` → `Engine::lint`, with the in-memory document cache (`lint_cached`); `--no-cache` takes the direct bridge instead.
- **Autofix** (`fix`): lint-and-fix to a fixpoint (`tzlint_core::fix`), written in place via `Host::write_atomic` (or reported under `--dry-run`).
- **Output**: text (`path:line:col: severity: message [rule]` + summary) and JSON (`[{ path, diagnostics }]` with byte `span`, mapped line/col `position`, `severity`, `rule_id`, `message`, `fixes`), line/col via `LineIndex`.
- **Exit codes**: `Error(2) > Findings(1) > Clean(0)`.
- All file access goes through the `Host` boundary (no raw `std::fs`); the working directory is injected, so the orchestration is hermetically unit-testable against an in-memory host.

Adds `clap` to the workspace. The CLI is native-only and never enters the `wasm32` core build.

## Deferred (intentional) seam

Resolving a config to the actual rule set (`rules::resolve_rules`) returns an empty set for now: the built-in rule registry lives in `tzlint_rules`, still a skeleton on `main` (its `Rule` impls + `builtin_rules()` land with the rules milestone, currently in #19). So today the engine runs with no rules — the rest of the pipeline is fully wired and exercised. Wiring the registry is a localized follow-up to this one function. A one-line stderr note makes the "no rules yet" state explicit so an empty result is not mistaken for "clean".

This PR is based on `main` and is **independent of #19**.

## Review

Ran an adversarial multi-lens review (correctness / error-handling / API-contract / CLI-UX-security / tests) with per-finding verification. Addressed:

- **Unrecognized `--config` extension** no longer silently defaults to JSONC — it fails with a clear "unrecognized config format" error (fail-fast, before reading).
- **Output policy made consistent + documented**: stdout result writes propagate (a failed write becomes `Error`); stderr notes are deliberately best-effort (a failed stderr write must not change the exit code, which already signals the outcome).
- **JSON fixes** now also carry the mapped line/col `position` (consistent with the diagnostic).
- **Testability**: extracted the exit-status precedence into a pure function (covers the `Findings` arm without a rule); injected the cwd to add a hermetic config-discovery test; added unrecognized-format and fix mixed-failure tests.

Two test gaps are genuinely **deferred to the rules-wiring step** (they require a rule that emits a diagnostic, which the command path cannot construct yet): exercising the `fix` write path (`fixed != source`) and re-checking cache vs. no-cache equivalence with diagnostics present. Both are noted in-code.

## Checks (local)

`just check` green: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (CLI: **22** tests). Plus `cargo build -p tzlint_core --target wasm32-unknown-unknown`, io-guard grep (no raw fs), and `cargo deny check` (advisories/bans/licenses/sources ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `lint` コマンドで対象ファイルの診断を実行し、テキストまたはJSON形式で結果を出力可能
  * `fix` コマンドで検出された問題の自動修正に対応（`--dry-run` オプションで変更内容を確認可能）
  * `init` コマンドで初期設定ファイルを生成
  * グローバルオプション（`--config`, `--verbose`, `--no-cache`）で動作をカスタマイズ可能
  * 適切な終了コードにより、スクリプトやCI/CDでの統合に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->