### PR TITLE
feat(rules): migrate the remaining native rules (M1f-2)

### DIFF
--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -65,6 +65,9 @@ fn ja_basic() -> BTreeMap<RuleId, RuleSetting> {
     [
         ("no-hankaku-kana", on(Value::Null)),
         ("no-mixed-zenkaku-hankaku-alphabet", on(Value::Null)),
+        ("no-nfd", on(Value::Null)),
+        ("no-zero-width-spaces", on(Value::Null)),
+        ("ja-no-mixed-period", on(Value::Null)),
     ]
     .into_iter()
     .map(|(id, setting)| (RuleId::from(id), setting))
@@ -80,6 +83,10 @@ fn ja_technical_writing() -> BTreeMap<RuleId, RuleSetting> {
         ("max-kanji-continuous-len", on(json!({ "max": 6 }))),
         ("no-hankaku-kana", on(Value::Null)),
         ("no-mixed-zenkaku-hankaku-alphabet", on(Value::Null)),
+        ("no-nfd", on(Value::Null)),
+        ("no-zero-width-spaces", on(Value::Null)),
+        ("no-exclamation-question-mark", on(Value::Null)),
+        ("ja-no-mixed-period", on(Value::Null)),
     ]
     .into_iter()
     .map(|(id, setting)| (RuleId::from(id), setting))

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -21,14 +21,16 @@ mod test_support;
 use tzlint_pdk::Rule;
 
 use rules::{
-    max_kanji_continuous_len, max_ten, no_hankaku_kana, no_mixed_zenkaku_hankaku_alphabet,
+    ja_no_mixed_period, max_kanji_continuous_len, max_ten, no_exclamation_question_mark,
+    no_hankaku_kana, no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_zero_width_spaces,
     sentence_length,
 };
 pub use rules::{
-    max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
+    ja_no_mixed_period::JaNoMixedPeriod, max_kanji_continuous_len::MaxKanjiContinuousLen,
+    max_ten::MaxTen, no_exclamation_question_mark::NoExclamationQuestionMark,
     no_hankaku_kana::NoHankakuKana,
-    no_mixed_zenkaku_hankaku_alphabet::NoMixedZenkakuHankakuAlphabet,
-    sentence_length::SentenceLength,
+    no_mixed_zenkaku_hankaku_alphabet::NoMixedZenkakuHankakuAlphabet, no_nfd::NoNfd,
+    no_todo::NoTodo, no_zero_width_spaces::NoZeroWidthSpaces, sentence_length::SentenceLength,
 };
 
 /// The ids of every built-in rule, in [`builtin_rules`] order. Single source of truth — preset
@@ -39,6 +41,11 @@ pub const RULE_IDS: &[&str] = &[
     max_kanji_continuous_len::ID,
     no_hankaku_kana::ID,
     no_mixed_zenkaku_hankaku_alphabet::ID,
+    no_nfd::ID,
+    no_zero_width_spaces::ID,
+    no_exclamation_question_mark::ID,
+    ja_no_mixed_period::ID,
+    no_todo::ID,
 ];
 
 /// Every built-in rule, default-constructed.
@@ -52,6 +59,11 @@ pub fn builtin_rules() -> Vec<Box<dyn Rule>> {
         Box::new(MaxKanjiContinuousLen::new()),
         Box::new(NoHankakuKana::new()),
         Box::new(NoMixedZenkakuHankakuAlphabet::new()),
+        Box::new(NoNfd::new()),
+        Box::new(NoZeroWidthSpaces::new()),
+        Box::new(NoExclamationQuestionMark::new()),
+        Box::new(JaNoMixedPeriod::new()),
+        Box::new(NoTodo::new()),
     ]
 }
 
@@ -88,6 +100,20 @@ mod tests {
             NoMixedZenkakuHankakuAlphabet::default().meta().id.as_str(),
             "no-mixed-zenkaku-hankaku-alphabet"
         );
+        assert_eq!(NoNfd::default().meta().id.as_str(), "no-nfd");
+        assert_eq!(
+            NoZeroWidthSpaces::default().meta().id.as_str(),
+            "no-zero-width-spaces"
+        );
+        assert_eq!(
+            NoExclamationQuestionMark::default().meta().id.as_str(),
+            "no-exclamation-question-mark"
+        );
+        assert_eq!(
+            JaNoMixedPeriod::default().meta().id.as_str(),
+            "ja-no-mixed-period"
+        );
+        assert_eq!(NoTodo::default().meta().id.as_str(), "no-todo");
     }
 
     #[test]

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -2,8 +2,9 @@
 //!
 //! Each rule implements the [`Rule`](tzlint_pdk::Rule) trait (from `tzlint_pdk`) and declares
 //! the [`NodeKind`](tzlint_ast::NodeKind)s it visits, which the single-traversal scheduler in
-//! `tzlint_core` dispatches. Per-node rules act in `check`; the one document-level rule
-//! ([`NoMixedZenkakuHankakuAlphabet`]) registers `ROOT` and walks the subtree from `check`.
+//! `tzlint_core` dispatches. Per-node rules act in `check`; document-level rules (e.g.
+//! [`NoMixedZenkakuHankakuAlphabet`] and [`JaNoMixedPeriod`]) register `ROOT` and walk the
+//! subtree from `check`.
 //!
 //! [`builtin_rules`] returns every shipped rule (the registry the engine is wired through);
 //! [`RULE_IDS`] is the matching id list. Rule options are parsed leniently per rule

--- a/crates/tzlint_rules/src/rules/ja_no_mixed_period.rs
+++ b/crates/tzlint_rules/src/rules/ja_no_mixed_period.rs
@@ -1,0 +1,203 @@
+//! `ja-no-mixed-period` — flag mixing Japanese `。` and ASCII `.` as sentence terminators.
+//!
+//! Document-level: it registers [`NodeKind::ROOT`] and walks the subtree from its single
+//! `check` call (visited-guarded, so a byte-valid but cyclic archive can neither loop nor OOM),
+//! collecting `。` and qualifying `.` terminators, then reports the minority style.
+
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "ja-no-mixed-period";
+
+/// Flags the minority period style when both `。` and `.` terminators appear.
+pub struct JaNoMixedPeriod {
+    meta: RuleMeta,
+}
+
+impl JaNoMixedPeriod {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        JaNoMixedPeriod {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::ROOT]),
+        }
+    }
+
+    /// Collect `。` (Japanese) and qualifying `.` (English) terminator spans from one text node.
+    fn collect(base: u32, text: &str, ja_hits: &mut Vec<Span>, en_hits: &mut Vec<Span>) {
+        let mut byte_pos = 0usize;
+        let mut prev: Option<char> = None;
+        let mut chars = text.chars().peekable();
+        while let Some(c) = chars.next() {
+            let len = c.len_utf8();
+            let span = Span::new(
+                base.saturating_add(byte_pos as u32),
+                base.saturating_add((byte_pos + len) as u32),
+            );
+            match c {
+                '。' => ja_hits.push(span),
+                '.' => {
+                    // A `.` counts as a sentence end only when followed by whitespace / end of
+                    // text, and not between digits (a decimal like "1.5").
+                    let after = chars.peek().copied();
+                    let looks_like_sentence_end = after.is_none_or(char::is_whitespace);
+                    let looks_numeric = prev.is_some_and(|p| p.is_ascii_digit())
+                        && after.is_some_and(|a| a.is_ascii_digit());
+                    if looks_like_sentence_end && !looks_numeric {
+                        en_hits.push(span);
+                    }
+                }
+                _ => {}
+            }
+            byte_pos += len;
+            prev = Some(c);
+        }
+    }
+}
+
+impl Default for JaNoMixedPeriod {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for JaNoMixedPeriod {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, root: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let mut ja_hits: Vec<Span> = Vec::new();
+        let mut en_hits: Vec<Span> = Vec::new();
+
+        let mut visited = vec![false; cx.ast().len()];
+        if let Some(slot) = visited.get_mut(root.id().0 as usize) {
+            *slot = true;
+        }
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            match node.kind() {
+                NodeKind::CODE | NodeKind::INLINE_CODE => {}
+                NodeKind::TEXT => {
+                    Self::collect(node.span().start, node.text(), &mut ja_hits, &mut en_hits);
+                }
+                _ => {
+                    for child in node.children() {
+                        if let Some(slot) = visited.get_mut(child.id().0 as usize)
+                            && !*slot
+                        {
+                            *slot = true;
+                            stack.push(child);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Only a mix of both styles is a violation.
+        if ja_hits.is_empty() || en_hits.is_empty() {
+            return;
+        }
+        // Report the less-frequent style; on a tie, flag the ASCII `.`.
+        let (minority, minority_label, majority_label) = if ja_hits.len() < en_hits.len() {
+            (&ja_hits, "。", ".")
+        } else {
+            (&en_hits, ".", "。")
+        };
+        let message = format!(
+            "句点の表記が混在しています。文書全体で多く使われている「{majority_label}」に合わせて「{minority_label}」を書き換えてください。"
+        );
+        for span in minority {
+            cx.report(*span, message.as_str());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_minority_period_style() {
+        // Two `。` and one `.` → the ASCII `.` is the minority → one diagnostic.
+        let diags = diagnose(&JaNoMixedPeriod::new(), "これは一文目。次の文。最後の文.\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("。"));
+    }
+
+    #[test]
+    fn flags_japanese_period_when_it_is_the_minority() {
+        // Two ASCII `.` and one `。` → the `。` is the minority → reported.
+        let diags = diagnose(&JaNoMixedPeriod::new(), "First. Second. 日本語。\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("."));
+    }
+
+    #[test]
+    fn single_style_is_clean() {
+        assert!(diagnose(&JaNoMixedPeriod::new(), "一文目。二文目。\n").is_empty());
+        assert!(diagnose(&JaNoMixedPeriod::new(), "First. Second.\n").is_empty());
+    }
+
+    #[test]
+    fn periods_inside_code_are_not_counted() {
+        // The `.` inside inline code is pruned (CODE/INLINE_CODE arm); only the prose `。` and
+        // `.` are counted, so this still flags the minority.
+        let diags = diagnose(&JaNoMixedPeriod::new(), "`x.y` の結果。Then done.\n");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn decimal_dot_is_not_a_terminator() {
+        // The `.` in "3.14" is between digits → not counted, so no mix with `。`.
+        assert!(diagnose(&JaNoMixedPeriod::new(), "円周率は 3.14 です。\n").is_empty());
+    }
+
+    #[test]
+    fn cyclic_archive_does_not_hang() {
+        // Like no-mixed, this rule self-walks the tree, so it must be cycle-safe.
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        use tzlint_ast::{Ast, Node, NodeId, OptionNodeId};
+        use tzlint_pdk::Context;
+
+        let ast = Ast {
+            nodes: vec![
+                Node {
+                    kind: NodeKind::ROOT,
+                    span: Span::new(0, 1),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::some(NodeId(1)),
+                    next_sibling: OptionNodeId::NONE,
+                },
+                Node {
+                    kind: NodeKind::PARAGRAPH,
+                    span: Span::new(0, 1),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::some(NodeId(1)), // self-cycle
+                    next_sibling: OptionNodeId::NONE,
+                },
+            ],
+            text: "x".to_string(),
+            root: NodeId(0),
+        };
+        let bytes = tzlint_ast::to_archive(&ast).unwrap();
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let archived = tzlint_ast::access(&bytes).unwrap();
+            let rule = JaNoMixedPeriod::new();
+            let mut cx = Context::new(archived, "ja-no-mixed-period".into(), Severity::Warning);
+            if let Some(root) = NodeRef::root(archived) {
+                rule.check(root, &mut cx);
+            }
+            let _ = tx.send(());
+        });
+        assert!(
+            rx.recv_timeout(Duration::from_secs(5)).is_ok(),
+            "the rule hung on a cyclic archive (visited guard regressed?)"
+        );
+    }
+}

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -1,7 +1,12 @@
 //! The built-in rules, one module each.
 
+pub mod ja_no_mixed_period;
 pub mod max_kanji_continuous_len;
 pub mod max_ten;
+pub mod no_exclamation_question_mark;
 pub mod no_hankaku_kana;
 pub mod no_mixed_zenkaku_hankaku_alphabet;
+pub mod no_nfd;
+pub mod no_todo;
+pub mod no_zero_width_spaces;
 pub mod sentence_length;

--- a/crates/tzlint_rules/src/rules/no_exclamation_question_mark.rs
+++ b/crates/tzlint_rules/src/rules/no_exclamation_question_mark.rs
@@ -1,0 +1,133 @@
+//! `no-exclamation-question-mark` — flag `!`/`?` (half- and full-width) in technical prose.
+
+use serde_json::Value;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-exclamation-question-mark";
+
+/// Flags exclamation/question marks; each of the four marks can be individually allowed.
+pub struct NoExclamationQuestionMark {
+    meta: RuleMeta,
+    allow_halfwidth_exclamation: bool,
+    allow_fullwidth_exclamation: bool,
+    allow_halfwidth_question: bool,
+    allow_fullwidth_question: bool,
+}
+
+impl NoExclamationQuestionMark {
+    /// Construct with the default options (all four marks flagged).
+    pub fn new() -> Self {
+        NoExclamationQuestionMark {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]),
+            allow_halfwidth_exclamation: false,
+            allow_fullwidth_exclamation: false,
+            allow_halfwidth_question: false,
+            allow_fullwidth_question: false,
+        }
+    }
+
+    /// Construct from config `options`, leniently. Each `allow_*` boolean defaults to `false`.
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        let get = |key: &str| options.get(key).and_then(Value::as_bool);
+        if let Some(b) = get("allow_halfwidth_exclamation") {
+            rule.allow_halfwidth_exclamation = b;
+        }
+        if let Some(b) = get("allow_fullwidth_exclamation") {
+            rule.allow_fullwidth_exclamation = b;
+        }
+        if let Some(b) = get("allow_halfwidth_question") {
+            rule.allow_halfwidth_question = b;
+        }
+        if let Some(b) = get("allow_fullwidth_question") {
+            rule.allow_fullwidth_question = b;
+        }
+        rule
+    }
+
+    /// The mark to flag for `c`, or `None` if `c` is not a (disallowed) mark.
+    fn flagged_mark(&self, c: char) -> Option<&'static str> {
+        match c {
+            '!' if !self.allow_halfwidth_exclamation => Some("!"),
+            '！' if !self.allow_fullwidth_exclamation => Some("！"),
+            '?' if !self.allow_halfwidth_question => Some("?"),
+            '？' if !self.allow_fullwidth_question => Some("？"),
+            _ => None,
+        }
+    }
+}
+
+impl Default for NoExclamationQuestionMark {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoExclamationQuestionMark {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        for (i, c) in node.text().char_indices() {
+            if let Some(mark) = self.flagged_mark(c) {
+                cx.report(
+                    Span::new(
+                        base.saturating_add(i as u32),
+                        base.saturating_add((i + c.len_utf8()) as u32),
+                    ),
+                    format!("「{mark}」は技術文書では使用を避けてください。"),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_all_marks_by_default() {
+        let diags = diagnose(&NoExclamationQuestionMark::new(), "すごい！ほんと?\n");
+        assert_eq!(diags.len(), 2);
+    }
+
+    #[test]
+    fn allow_options_suppress_specific_marks() {
+        let rule = NoExclamationQuestionMark::from_options(
+            &serde_json::json!({"allow_fullwidth_exclamation": true}),
+        );
+        // The full-width ！ is allowed; the half-width ? is still flagged.
+        assert_eq!(diagnose(&rule, "やった！でも本当に?\n").len(), 1);
+    }
+
+    #[test]
+    fn flags_each_of_the_four_marks() {
+        // Half/full-width exclamation and question are all flagged by default.
+        assert_eq!(
+            diagnose(&NoExclamationQuestionMark::new(), "!！?？\n").len(),
+            4
+        );
+    }
+
+    #[test]
+    fn each_mark_can_be_individually_allowed() {
+        let rule = NoExclamationQuestionMark::from_options(&serde_json::json!({
+            "allow_halfwidth_exclamation": true,
+            "allow_fullwidth_exclamation": true,
+            "allow_halfwidth_question": true,
+            "allow_fullwidth_question": true,
+        }));
+        assert!(diagnose(&rule, "!！?？\n").is_empty());
+    }
+
+    #[test]
+    fn plain_text_is_clean() {
+        assert!(diagnose(&NoExclamationQuestionMark::new(), "ふつうの文。\n").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/no_nfd.rs
+++ b/crates/tzlint_rules/src/rules/no_nfd.rs
@@ -1,0 +1,91 @@
+//! `no-nfd` — flag decomposed (NFD) text via its combining marks.
+
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-nfd";
+
+/// Whether `c` is a combining mark used here as a proxy for "text is in NFD form".
+fn is_combining_mark(c: char) -> bool {
+    matches!(
+        c as u32,
+        0x0300..=0x036F   // Combining Diacritical Marks
+        | 0x1AB0..=0x1AFF // … Extended
+        | 0x1DC0..=0x1DFF // … Supplement
+        | 0x20D0..=0x20FF // … for Symbols
+        | 0xFE20..=0xFE2F // Combining Half Marks
+        | 0x3099..=0x309A // Japanese combining (han)dakuten
+    )
+}
+
+/// Flags each combining mark (a proxy for decomposed/NFD text).
+pub struct NoNfd {
+    meta: RuleMeta,
+}
+
+impl NoNfd {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        NoNfd {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]),
+        }
+    }
+}
+
+impl Default for NoNfd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoNfd {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        for (i, c) in node.text().char_indices() {
+            if is_combining_mark(c) {
+                cx.report(
+                    Span::new(
+                        base.saturating_add(i as u32),
+                        base.saturating_add((i + c.len_utf8()) as u32),
+                    ),
+                    format!(
+                        "Combining mark U+{:04X} detected; normalize text to NFC.",
+                        c as u32
+                    ),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_decomposed_text() {
+        // か + combining dakuten (U+3099) instead of the precomposed が.
+        assert_eq!(diagnose(&NoNfd::new(), "か\u{3099}\n").len(), 1);
+    }
+
+    #[test]
+    fn flags_a_mark_from_every_configured_range() {
+        // One representative combining mark from each block `is_combining_mark` covers.
+        for cp in [0x0300u32, 0x1AB0, 0x1DC0, 0x20D0, 0xFE20, 0x3099] {
+            let mark = char::from_u32(cp).unwrap();
+            let src = format!("a{mark}\n");
+            assert_eq!(diagnose(&NoNfd::new(), &src).len(), 1, "U+{cp:04X}");
+        }
+    }
+
+    #[test]
+    fn precomposed_text_is_clean() {
+        assert!(diagnose(&NoNfd::new(), "がぎ漢字\n").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/no_todo.rs
+++ b/crates/tzlint_rules/src/rules/no_todo.rs
@@ -1,0 +1,213 @@
+//! `no-todo` — flag task markers (TODO/FIXME/XXX/HACK) in prose.
+
+use serde_json::Value;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-todo";
+/// Default marker patterns (trailing space/colon distinguishes a marker from a word).
+const DEFAULT_PATTERNS: &[&str] = &[
+    "TODO:", "TODO ", "FIXME:", "FIXME ", "XXX:", "XXX ", "HACK:",
+];
+
+/// Flags configured task-marker substrings in prose.
+pub struct NoTodo {
+    meta: RuleMeta,
+    patterns: Vec<String>,
+    ignore_patterns: Vec<String>,
+    case_sensitive: bool,
+}
+
+impl NoTodo {
+    /// Construct with the default markers (case-insensitive, no ignore list).
+    pub fn new() -> Self {
+        NoTodo {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]),
+            patterns: DEFAULT_PATTERNS.iter().map(|s| (*s).to_string()).collect(),
+            ignore_patterns: Vec::new(),
+            case_sensitive: false,
+        }
+    }
+
+    /// Construct from config `options`, leniently. Reads `patterns` (string[]),
+    /// `ignore_patterns` (string[]), and `case_sensitive` (bool). Empty pattern strings are
+    /// dropped (an empty pattern would match everywhere); if no usable pattern remains, the
+    /// defaults are kept.
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        if let Some(arr) = options.get("patterns").and_then(Value::as_array) {
+            let patterns: Vec<String> = arr
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect();
+            if !patterns.is_empty() {
+                rule.patterns = patterns;
+            }
+        }
+        if let Some(arr) = options.get("ignore_patterns").and_then(Value::as_array) {
+            rule.ignore_patterns = arr
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect();
+        }
+        if let Some(b) = options.get("case_sensitive").and_then(Value::as_bool) {
+            rule.case_sensitive = b;
+        }
+        rule
+    }
+}
+
+impl Default for NoTodo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoTodo {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+        for pattern in &self.patterns {
+            let mut search_start = 0;
+            while let Some((start, end)) =
+                find_pattern(text, pattern, search_start, self.case_sensitive)
+            {
+                let matched = &text[start..end];
+                let ignored = self
+                    .ignore_patterns
+                    .iter()
+                    .any(|ignore| find_pattern(matched, ignore, 0, self.case_sensitive).is_some());
+                if !ignored {
+                    let display = pattern.trim_end();
+                    cx.report(
+                        Span::new(
+                            base.saturating_add(start as u32),
+                            base.saturating_add(end as u32),
+                        ),
+                        format!(
+                            "Found '{display}' marker. Consider resolving this before committing."
+                        ),
+                    );
+                }
+                search_start = end; // `end > start` for a non-empty pattern, so this terminates
+            }
+        }
+    }
+}
+
+/// Find the first occurrence of `pattern` in `haystack[start..]`, returning byte offsets into
+/// `haystack`. Case-insensitive matching is anchored to the original bytes (never slicing a
+/// lowercased copy, whose byte length can differ), so all offsets stay on char boundaries.
+/// An empty pattern never matches (returns `None`) so callers cannot loop forever.
+fn find_pattern(
+    haystack: &str,
+    pattern: &str,
+    start: usize,
+    case_sensitive: bool,
+) -> Option<(usize, usize)> {
+    if pattern.is_empty() || start > haystack.len() {
+        return None;
+    }
+    if case_sensitive {
+        let idx = haystack[start..].find(pattern)?;
+        let match_start = start + idx;
+        return Some((match_start, match_start + pattern.len()));
+    }
+
+    let pattern_chars: Vec<char> = pattern.chars().collect();
+    for (offset, _) in haystack[start..].char_indices() {
+        let anchor = start + offset;
+        let mut cursor = anchor;
+        let mut matched = true;
+        for &pc in &pattern_chars {
+            match haystack[cursor..].chars().next() {
+                Some(hc) if chars_equal_ignore_case(pc, hc) => cursor += hc.len_utf8(),
+                _ => {
+                    matched = false;
+                    break;
+                }
+            }
+        }
+        if matched {
+            return Some((anchor, cursor));
+        }
+    }
+    None
+}
+
+/// Case-insensitive char equality for single-char comparisons. Characters whose lowercase
+/// expands to multiple chars (e.g. `İ`) are treated as non-matching (the markers are ASCII).
+fn chars_equal_ignore_case(a: char, b: char) -> bool {
+    if a == b {
+        return true;
+    }
+    let (mut la, mut lb) = (a.to_lowercase(), b.to_lowercase());
+    match (la.next(), lb.next()) {
+        (Some(ca), Some(cb)) => ca == cb && la.next().is_none() && lb.next().is_none(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_default_markers_case_insensitively() {
+        assert_eq!(diagnose(&NoTodo::new(), "todo: あとで直す\n").len(), 1);
+        assert_eq!(diagnose(&NoTodo::new(), "FIXME これ\n").len(), 1);
+        // Two markers → two diagnostics.
+        assert_eq!(diagnose(&NoTodo::new(), "TODO: a と XXX: b\n").len(), 2);
+    }
+
+    #[test]
+    fn plain_prose_is_clean() {
+        // "todo" without a trailing space/colon is not a default marker.
+        assert!(diagnose(&NoTodo::new(), "今日のtodoリスト\n").is_empty());
+    }
+
+    #[test]
+    fn case_sensitive_and_custom_patterns() {
+        let cs = NoTodo::from_options(&serde_json::json!({"case_sensitive": true}));
+        assert!(diagnose(&cs, "todo: lower\n").is_empty()); // lowercase not matched
+        assert_eq!(diagnose(&cs, "TODO: upper\n").len(), 1);
+
+        let custom = NoTodo::from_options(&serde_json::json!({"patterns": ["WIP"]}));
+        assert_eq!(diagnose(&custom, "WIP の節\n").len(), 1);
+        assert!(diagnose(&custom, "TODO: not configured\n").is_empty());
+    }
+
+    #[test]
+    fn ignore_patterns_suppress_matches() {
+        // `ignore_patterns` are matched against the matched MARKER text (e.g. "FIXME "), not the
+        // surrounding prose — faithful to the legacy rule.
+        let rule = NoTodo::from_options(&serde_json::json!({"ignore_patterns": ["FIXME"]}));
+        assert!(diagnose(&rule, "FIXME これ\n").is_empty()); // "FIXME " contains "FIXME"
+        assert_eq!(diagnose(&rule, "TODO: あれ\n").len(), 1); // "TODO: " does not
+    }
+
+    #[test]
+    fn find_pattern_guards_empty_and_out_of_bounds() {
+        // The early return that prevents an empty-pattern infinite loop and an out-of-range start.
+        assert_eq!(find_pattern("abc", "", 0, false), None);
+        assert_eq!(find_pattern("abc", "x", 99, true), None);
+    }
+
+    #[test]
+    fn empty_pattern_is_dropped_not_looped() {
+        // An empty pattern must not be kept (it would match everywhere / loop); defaults remain.
+        let rule = NoTodo::from_options(&serde_json::json!({"patterns": [""]}));
+        assert_eq!(diagnose(&rule, "TODO: x\n").len(), 1); // fell back to defaults
+        assert!(diagnose(&rule, "plain\n").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/no_zero_width_spaces.rs
+++ b/crates/tzlint_rules/src/rules/no_zero_width_spaces.rs
@@ -1,0 +1,82 @@
+//! `no-zero-width-spaces` — flag invisible / zero-width codepoints in prose.
+
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-zero-width-spaces";
+
+/// Whether `c` is one of the disallowed invisible codepoints.
+fn is_invisible(c: char) -> bool {
+    matches!(
+        c,
+        '\u{200B}' // ZERO WIDTH SPACE
+        | '\u{200C}' // ZERO WIDTH NON-JOINER
+        | '\u{200D}' // ZERO WIDTH JOINER
+        | '\u{2060}' // WORD JOINER
+        | '\u{FEFF}' // ZERO WIDTH NO-BREAK SPACE (BOM)
+    )
+}
+
+/// Flags each invisible / zero-width codepoint.
+pub struct NoZeroWidthSpaces {
+    meta: RuleMeta,
+}
+
+impl NoZeroWidthSpaces {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        NoZeroWidthSpaces {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]),
+        }
+    }
+}
+
+impl Default for NoZeroWidthSpaces {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoZeroWidthSpaces {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        for (i, c) in node.text().char_indices() {
+            if is_invisible(c) {
+                cx.report(
+                    Span::new(
+                        base.saturating_add(i as u32),
+                        base.saturating_add((i + c.len_utf8()) as u32),
+                    ),
+                    format!(
+                        "Invisible codepoint U+{:04X} is not allowed in prose.",
+                        c as u32
+                    ),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_zero_width_space() {
+        assert_eq!(
+            diagnose(&NoZeroWidthSpaces::new(), "hello\u{200B}world\n").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn plain_text_is_clean() {
+        assert!(diagnose(&NoZeroWidthSpaces::new(), "ふつうの文章\n").is_empty());
+    }
+}


### PR DESCRIPTION
## What

M1f-2: port the remaining five morphology-free legacy native rules into `tzlint_rules`, completing the M1f starter set. Stacked on M1f-1 (#19, now merged) and rebased onto `main`.

- **no-nfd** (per-`TEXT`): flag combining marks as a proxy for decomposed/NFD text.
- **no-zero-width-spaces** (per-`TEXT`): flag invisible / zero-width codepoints.
- **no-exclamation-question-mark** (per-`TEXT`): flag `!`/`?` (half/full-width); each of the four marks can be individually allowed.
- **ja-no-mixed-period** (document-level `ROOT` self-walk, visited-guarded): flag the minority period style when both `。` and a qualifying `.` terminator appear.
- **no-todo** (per-`TEXT`): flag TODO/FIXME/XXX/HACK markers; configurable `patterns` / `ignore_patterns` / `case_sensitive`, with a char-anchored case-insensitive matcher (never slicing a lowercased copy) and empty patterns dropped so a match can't loop.

**Presets**: `ja-basic` and `ja-technical-writing` gain no-nfd / no-zero-width-spaces / ja-no-mixed-period (and no-exclamation-question-mark for ja-technical-writing); `no-todo` stays opt-in (in neither preset), matching the legacy. The `ROOT` self-walk reuses the engine's visited-bitmap pattern with a cyclic-archive regression test.

The morphology-dependent `no-doubled-joshi` stays deferred to **M2**. M1f is now complete (all 10 morphology-free rules).

## Review

This change was adversarially reviewed earlier (5 confirmed findings fixed in the original M1f-2 work: the `ja-no-mixed-period` `ROOT` self-walk visited-guard for cyclic archives + regression test, char-anchored case-insensitive matcher, empty-pattern drop, preset↔`RULE_IDS` cross-check). Cherry-picked cleanly onto current `main` (touches only `tzlint_rules` + `config/preset.rs`; no manifest/lockfile changes).

## Checks (local)

`just check` green. `tzlint_rules`: **47** tests pass (all 10 rules). `cargo build -p tzlint_core --target wasm32-unknown-unknown`, io-guard, and `cargo deny check` all ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 日本語の句点とASCIIピリオドの混在を検出する `ja-no-mixed-period` ルール
  * 技術文書内の感嘆符・疑問符の使用を検出する `no-exclamation-question-mark` ルール
  * テキストの正規化が必要な結合文字を検出する `no-nfd` ルール
  * TODO/FIXME などのマーカーを検出する `no-todo` ルール
  * ゼロ幅スペースなど不可視文字を検出する `no-zero-width-spaces` ルール

<!-- end of auto-generated comment: release notes by coderabbit.ai -->