### PR TITLE
test(cli): make init/discovery path assertions OS-agnostic (Windows CI)

### DIFF
--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -408,7 +408,13 @@ mod tests {
         let host = MockHost::new();
         let (status, out, _err) = run_capture(&cli(Command::Init { force: false }), &host);
         assert_eq!(status, ExitStatus::Clean);
-        assert!(out.contains("created /work/.tzlintrc.json"), "{out}");
+        // Build the expected path the same way the code does, so the separator matches the
+        // platform (`\` on Windows) — the message echoes `path.display()`.
+        let expected = Path::new(TEST_CWD).join(".tzlintrc.json");
+        assert!(
+            out.contains(&format!("created {}", expected.display())),
+            "{out}"
+        );
         let written = host.read(TEST_CONFIG_PATH).unwrap();
         let config = Config::parse(&written, ConfigFormat::Json).unwrap();
         assert_eq!(config.language.as_deref(), Some("ja"));
@@ -550,7 +556,13 @@ mod tests {
         c.verbose = true;
         let (status, _out, err) = run_capture(&c, &host);
         assert_eq!(status, ExitStatus::Clean);
-        assert!(err.contains("using config /work/.tzlintrc.json"), "{err}");
+        // The discovered path echoes `path.display()`, so build the expectation with the same
+        // join to match the platform separator (`\` on Windows).
+        let expected = Path::new(TEST_CWD).join(".tzlintrc.json");
+        assert!(
+            err.contains(&format!("using config {}", expected.display())),
+            "{err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Two M1g CLI tests assert a hard-coded forward-slash path string:

- `init_writes_a_valid_starter_config` → `out.contains("created /work/.tzlintrc.json")`
- `verbose_notes_discovered_config` → `err.contains("using config /work/.tzlintrc.json")`

`init` and config discovery echo `path.display()`, which renders with the **platform separator** — `\` on Windows, where `cwd.join(".tzlintrc.json")` produces `\work\.tzlintrc.json`-style output. So these pass on Linux/macOS but fail on the Windows job that the CI OS matrix (added in #21) now runs. M1g (#22) was merged before that matrix existed, so the bug was latent until now; it currently reds the Windows job on every open PR (e.g. #23), not just this one.

## Fix

Build the expected substring with the same `Path::join` the code uses, so the separator matches the platform. **Test-only — production behavior is unchanged.** The host-keyed assertions already work cross-platform (`Path` equality is separator-insensitive on Windows).

Unblocks #23 (M1f-2, otherwise green) and the in-flight M1g rules-wiring branch.

## Checks (local, macOS)

`cargo fmt --all --check`, `cargo clippy -p tzlint_cli --all-targets -- -D warnings`, `cargo test -p tzlint_cli` (22 pass). The change makes the expected string match `path.display()` on every platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)