### PR TITLE
feat(cli): resolve config to the built-in rule set (M1g rules-wiring)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,6 +1791,7 @@ dependencies = [
  "tzlint_ast",
  "tzlint_core",
  "tzlint_pdk",
+ "tzlint_rules",
 ]
 
 [[package]]

--- a/crates/tzlint_cli/Cargo.toml
+++ b/crates/tzlint_cli/Cargo.toml
@@ -22,6 +22,8 @@ path = "src/main.rs"
 tzlint_core = { path = "../tzlint_core", version = "0.0.0" }
 # The diagnostic model and `Rule` trait the engine works in terms of.
 tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
+# The built-in rule registry (`builtin_rules`/`RULE_IDS`) the config selects from.
+tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # `to_archive`/`access` (the parse → archive → lint bridge for the no-cache path) and `Span`.
 tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
 # Argument parsing (derive API).

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -94,12 +94,7 @@ fn lint(
     let config = load_config(cli, host, cwd, stderr)?;
     let rules = resolve_rules(&config);
     note_if_no_rules(&rules, stderr);
-    for id in unknown_rule_ids(&config) {
-        let _ = writeln!(
-            stderr,
-            "note: config references unknown rule '{id}' (ignored)"
-        );
-    }
+    note_unknown_rules(&config, stderr);
     let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
 
     let mut cache = (!cli.no_cache).then(DocumentCache::new);
@@ -182,12 +177,7 @@ fn fix(
     let config = load_config(cli, host, cwd, stderr)?;
     let rules = resolve_rules(&config);
     note_if_no_rules(&rules, stderr);
-    for id in unknown_rule_ids(&config) {
-        let _ = writeln!(
-            stderr,
-            "note: config references unknown rule '{id}' (ignored)"
-        );
-    }
+    note_unknown_rules(&config, stderr);
     let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
 
     let mut changed = 0usize;
@@ -313,6 +303,17 @@ fn note_if_no_rules(rules: &[Box<dyn Rule>], stderr: &mut dyn Write) {
         let _ = writeln!(
             stderr,
             "note: every built-in rule is disabled by config; the pipeline runs but reports nothing"
+        );
+    }
+}
+
+/// Print a stderr note for each `config.rules` id that is not a built-in rule (likely a typo),
+/// so a misspelled setting is not silently ignored. Shared by `lint` and `fix`.
+fn note_unknown_rules(config: &Config, stderr: &mut dyn Write) {
+    for id in unknown_rule_ids(config) {
+        let _ = writeln!(
+            stderr,
+            "note: config references unknown rule '{id}' (ignored)"
         );
     }
 }

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -23,7 +23,7 @@ use tzlint_pdk::{Diagnostic, Rule};
 
 use crate::cli::{Cli, Command, OutputFormat};
 use crate::output::{self, FileReport};
-use crate::rules::resolve_rules;
+use crate::rules::{resolve_rules, unknown_rule_ids};
 
 /// The process exit status, mapped to a code by [`ExitStatus::code`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -94,6 +94,12 @@ fn lint(
     let config = load_config(cli, host, cwd, stderr)?;
     let rules = resolve_rules(&config);
     note_if_no_rules(&rules, stderr);
+    for id in unknown_rule_ids(&config) {
+        let _ = writeln!(
+            stderr,
+            "note: config references unknown rule '{id}' (ignored)"
+        );
+    }
     let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
 
     let mut cache = (!cli.no_cache).then(DocumentCache::new);
@@ -176,6 +182,12 @@ fn fix(
     let config = load_config(cli, host, cwd, stderr)?;
     let rules = resolve_rules(&config);
     note_if_no_rules(&rules, stderr);
+    for id in unknown_rule_ids(&config) {
+        let _ = writeln!(
+            stderr,
+            "note: config references unknown rule '{id}' (ignored)"
+        );
+    }
     let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
 
     let mut changed = 0usize;
@@ -294,14 +306,13 @@ fn load_config(
     }
 }
 
-/// Print a one-line note to stderr when no rules are wired, so an empty result is not mistaken
-/// for "your text is clean". Removed once the rule registry lands.
+/// Print a one-line note to stderr when the resolved rule set is empty (every built-in rule was
+/// turned off by config), so an empty result is not mistaken for "your text is clean".
 fn note_if_no_rules(rules: &[Box<dyn Rule>], stderr: &mut dyn Write) {
     if rules.is_empty() {
         let _ = writeln!(
             stderr,
-            "note: no rules are enabled yet (the built-in rule registry lands in a later step); \
-             the pipeline runs but reports nothing"
+            "note: every built-in rule is disabled by config; the pipeline runs but reports nothing"
         );
     }
 }
@@ -408,7 +419,13 @@ mod tests {
         let host = MockHost::new();
         let (status, out, _err) = run_capture(&cli(Command::Init { force: false }), &host);
         assert_eq!(status, ExitStatus::Clean);
-        assert!(out.contains("created /work/.tzlintrc.json"), "{out}");
+        // Build the expected path the same way the code does, so the separator matches the
+        // platform (`\` on Windows) — the message echoes `path.display()`.
+        let expected = Path::new(TEST_CWD).join(".tzlintrc.json");
+        assert!(
+            out.contains(&format!("created {}", expected.display())),
+            "{out}"
+        );
         let written = host.read(TEST_CONFIG_PATH).unwrap();
         let config = Config::parse(&written, ConfigFormat::Json).unwrap();
         assert_eq!(config.language.as_deref(), Some("ja"));
@@ -464,16 +481,20 @@ mod tests {
     }
 
     #[test]
-    fn no_cache_path_matches_cached_path() {
-        // Both code paths (cached vs. direct bridge) must produce identical output. Today the
-        // rule set is empty, so this compares the clean case; the diagnostic-bearing equivalence
-        // is added alongside the rule-registry wiring (when a rule can emit a diagnostic).
-        let host = MockHost::with("a.md", "段落です。\n別の段落。\n");
+    fn no_cache_path_matches_cached_path_with_diagnostics() {
+        // Both code paths (cached vs. direct bridge) must produce identical output, including when
+        // rules emit diagnostics — half-width kana triggers `no-hankaku-kana` under the default
+        // (all-on) rule set.
+        let host = MockHost::with("a.md", "ﾊﾛｰ\n");
         let (_s1, cached_out, _e1) = run_capture(&lint_cli("a.md", OutputFormat::Json), &host);
         let mut direct = lint_cli("a.md", OutputFormat::Json);
         direct.no_cache = true;
         let (_s2, direct_out, _e2) = run_capture(&direct, &host);
         assert_eq!(cached_out, direct_out);
+        assert!(
+            cached_out.contains("no-hankaku-kana"),
+            "expected a diagnostic in the output: {cached_out}"
+        );
     }
 
     #[test]
@@ -500,9 +521,9 @@ mod tests {
     }
 
     #[test]
-    fn fix_is_a_noop_without_rules() {
-        // Without rules `fix` makes no change, so the write branch (`fixed != source`) is not
-        // reachable here; it is exercised alongside the rule-registry wiring.
+    fn fix_makes_no_change_when_there_are_no_fixes() {
+        // The built-in rules run, but none produces an autofix for this input, so the file is
+        // left untouched and the write branch (`fixed != source`) is not taken.
         let host = MockHost::with("a.md", "本文。\n");
         let (status, out, _err) = run_capture(
             &cli(Command::Fix {
@@ -512,15 +533,93 @@ mod tests {
             &host,
         );
         assert_eq!(status, ExitStatus::Clean);
-        // Unchanged: no rules → no fixes.
         assert_eq!(host.read("a.md").as_deref(), Some("本文。\n"));
         assert!(out.contains("0 file(s) changed"), "{out}");
     }
 
     #[test]
+    fn lint_reports_a_violation_and_exits_findings() {
+        // Half-width kana triggers `no-hankaku-kana` under the default (all-on) rule set, so the
+        // command path reaches `Findings` and renders a real diagnostic.
+        let host = MockHost::with("a.md", "ﾊﾛｰ\n");
+        let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
+        assert_eq!(status, ExitStatus::Findings);
+        assert!(out.contains("no-hankaku-kana"), "{out}");
+        assert!(out.contains("1 file(s) checked,"), "{out}");
+    }
+
+    #[test]
+    fn config_off_disables_a_rule_end_to_end() {
+        // Turning the rule off in config makes the same input clean — exercises the full
+        // config -> resolve_rules -> engine path.
+        let host = MockHost::new();
+        host.put("a.md", "ﾊﾛｰ\n");
+        host.put("off.json", "{ \"rules\": { \"no-hankaku-kana\": false } }");
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("off.json"));
+        let (status, out, _err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(out.contains("0 issue(s) found"), "{out}");
+    }
+
+    #[test]
+    fn unknown_config_rule_id_is_noted() {
+        // A misspelled rule id in config is reported (not silently ignored).
+        let host = MockHost::new();
+        host.put("a.md", "x\n");
+        host.put("c.json", "{ \"rules\": { \"no-such-rule\": false } }");
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("c.json"));
+        let (_status, _out, err) = run_capture(&c, &host);
+        assert!(err.contains("unknown rule 'no-such-rule'"), "{err}");
+    }
+
+    #[test]
+    fn unknown_config_rule_id_is_noted_in_fix() {
+        // The same unknown-rule-id warning applies to `fix`, not just `lint`.
+        let host = MockHost::new();
+        host.put("a.md", "本文。\n");
+        host.put("c.json", "{ \"rules\": { \"no-such-rule\": false } }");
+        let mut c = cli(Command::Fix {
+            paths: vec![PathBuf::from("a.md")],
+            dry_run: false,
+        });
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, _out, err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(err.contains("unknown rule 'no-such-rule'"), "{err}");
+    }
+
+    #[test]
+    fn note_when_every_rule_is_disabled() {
+        // Disabling all built-in rules yields an empty rule set, so even an input that would
+        // otherwise trigger a rule (half-width kana) is clean — and the "all disabled" note fires.
+        use tzlint_rules::RULE_IDS;
+        let host = MockHost::new();
+        host.put("a.md", "ﾊﾛｰ\n");
+        let entries: Vec<String> = RULE_IDS
+            .iter()
+            .map(|id| format!("\"{id}\": false"))
+            .collect();
+        host.put(
+            "off.json",
+            &format!("{{ \"rules\": {{ {} }} }}", entries.join(", ")),
+        );
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("off.json"));
+        let (status, out, err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(
+            err.contains("every built-in rule is disabled by config"),
+            "{err}"
+        );
+        assert!(out.contains("0 issue(s) found"), "{out}");
+    }
+
+    #[test]
     fn lint_exit_status_precedence() {
-        // Error > Findings > Clean. (Exercises the `Findings` arm without a rule, which the
-        // command path cannot reach until the rule registry is wired.)
+        // Error > Findings > Clean. (The pure-function form covers every combination; the
+        // command path reaching `Findings` is covered by `lint_reports_a_violation_*`.)
         assert_eq!(lint_exit_status(false, false), ExitStatus::Clean);
         assert_eq!(lint_exit_status(false, true), ExitStatus::Findings);
         assert_eq!(lint_exit_status(true, false), ExitStatus::Error);
@@ -550,7 +649,13 @@ mod tests {
         c.verbose = true;
         let (status, _out, err) = run_capture(&c, &host);
         assert_eq!(status, ExitStatus::Clean);
-        assert!(err.contains("using config /work/.tzlintrc.json"), "{err}");
+        // The discovered path echoes `path.display()`, so build the expectation with the same
+        // join to match the platform separator (`\` on Windows).
+        let expected = Path::new(TEST_CWD).join(".tzlintrc.json");
+        assert!(
+            err.contains(&format!("using config {}", expected.display())),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/tzlint_cli/src/main.rs
+++ b/crates/tzlint_cli/src/main.rs
@@ -5,9 +5,9 @@
 //! text/JSON output via the position mapper. All file access goes through the `Host` boundary
 //! (`NativeHost`), never raw `std::fs`.
 //!
-//! Resolving a config to the actual rule set is the one piece still stubbed (see
-//! [`rules::resolve_rules`]): the built-in rule registry lives in `tzlint_rules`, which is a
-//! skeleton until the rules milestone, so today the engine runs with an empty rule set.
+//! The rule set is resolved from config by [`rules::resolve_rules`]: every built-in rule
+//! (`tzlint_rules::builtin_rules`) runs by default, and a `config.rules` entry can disable one.
+//! Routing per-rule `options`/severity overrides into rule construction is a follow-up.
 
 use std::process::ExitCode;
 

--- a/crates/tzlint_cli/src/rules.rs
+++ b/crates/tzlint_cli/src/rules.rs
@@ -1,36 +1,119 @@
 //! Resolving a [`Config`] to the set of [`Rule`]s the engine should run.
 //!
-//! This is the one part of the pipeline that is *not* wired yet. The built-in rule registry
-//! lives in `tzlint_rules`, which is still a skeleton on `main` (its `Rule` impls and the
-//! `builtin_rules()` constructor land with the rules milestone). Until then there are no
-//! native rules to construct, so this returns an empty set: the rest of the pipeline
-//! (read → parse → archive → engine → output, plus config discovery and the cache) is fully
-//! wired and exercised, and the engine simply reports nothing.
+//! Activation model: **every built-in rule is on by default**; a `config.rules` entry set to
+//! `false` (→ [`RuleSetting::Off`]) disables that rule. So a bare `tzlint lint` runs the full
+//! built-in set, and a config narrows it.
 //!
-//! When the registry lands, this function maps `config.rules` (and any preset) onto the
-//! built-in rules — turning settings on/off, applying severity overrides, and threading each
-//! rule's `options` through. That is a localized change to this single file.
+//! Per-rule `options` and severity overrides are *not* applied yet: [`builtin_rules`] constructs
+//! each rule with its defaults, and there is no construction-time seam to route config
+//! `options`/`severity` through (the `Rule` trait exposes only an immutable
+//! [`RuleMeta`](tzlint_pdk::RuleMeta)). That routing is a follow-up that adds a config-aware
+//! constructor to `tzlint_rules`; until then a rule runs with its own defaults regardless of the
+//! `options`/`severity` set in config. Unknown rule ids in config are surfaced via
+//! [`unknown_rule_ids`] so a typo'd setting is not silently ignored.
 
-use tzlint_core::Config;
+use std::collections::BTreeSet;
+
+use tzlint_core::{Config, RuleSetting};
 use tzlint_pdk::Rule;
+use tzlint_rules::{RULE_IDS, builtin_rules};
 
-/// Build the boxed rule set to run for `config`.
-///
-/// Currently always empty — see the module docs. `config` is accepted now so the signature
-/// is stable across the registry-wiring change.
+/// Build the boxed rule set to run for `config`: every built-in rule except those a
+/// `config.rules` entry turns off.
 #[must_use]
-pub fn resolve_rules(_config: &Config) -> Vec<Box<dyn Rule>> {
-    Vec::new()
+pub fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
+    builtin_rules()
+        .into_iter()
+        .filter(|rule| !matches!(config.rules.get(&rule.meta().id), Some(RuleSetting::Off)))
+        .collect()
+}
+
+/// The rule ids referenced in `config.rules` that are not built-in rules — most likely typos.
+/// The CLI reports these so a misspelled setting is not silently ignored.
+#[must_use]
+pub fn unknown_rule_ids(config: &Config) -> Vec<String> {
+    let known: BTreeSet<&str> = RULE_IDS.iter().copied().collect();
+    config
+        .rules
+        .keys()
+        .map(|id| id.as_str())
+        .filter(|id| !known.contains(id))
+        .map(str::to_string)
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+
+    use serde_json::Value;
+    use tzlint_pdk::RuleId;
+
+    fn config_with(rules: &[(&str, RuleSetting)]) -> Config {
+        let mut map = BTreeMap::new();
+        for (id, setting) in rules {
+            map.insert(RuleId::from(*id), setting.clone());
+        }
+        Config {
+            language: None,
+            message_language: None,
+            rules: map,
+        }
+    }
+
+    fn ids(rules: &[Box<dyn Rule>]) -> Vec<String> {
+        rules
+            .iter()
+            .map(|r| r.meta().id.as_str().to_string())
+            .collect()
+    }
 
     #[test]
-    fn no_rules_are_wired_yet() {
-        // A guard on the documented current state: the registry is not wired, so any config
-        // resolves to zero rules. Update this when `tzlint_rules` lands its registry.
-        assert!(resolve_rules(&Config::default()).is_empty());
+    fn default_config_runs_every_built_in_rule() {
+        let rules = resolve_rules(&Config::default());
+        assert_eq!(rules.len(), RULE_IDS.len());
+        assert_eq!(ids(&rules), RULE_IDS);
+    }
+
+    #[test]
+    fn off_setting_disables_only_that_rule() {
+        let target = RULE_IDS[0];
+        let config = config_with(&[(target, RuleSetting::Off)]);
+        let remaining = ids(&resolve_rules(&config));
+        assert_eq!(remaining.len(), RULE_IDS.len() - 1);
+        assert!(
+            !remaining.contains(&target.to_string()),
+            "{target} should be disabled"
+        );
+    }
+
+    #[test]
+    fn on_setting_keeps_the_rule() {
+        // An explicit `On` (with options/severity that are not routed yet) still runs the rule.
+        let target = RULE_IDS[0];
+        let config = config_with(&[(
+            target,
+            RuleSetting::On {
+                severity: None,
+                options: Value::Null,
+            },
+        )]);
+        assert!(ids(&resolve_rules(&config)).contains(&target.to_string()));
+    }
+
+    #[test]
+    fn unknown_rule_ids_are_reported() {
+        let config = config_with(&[
+            ("definitely-not-a-rule", RuleSetting::Off),
+            (RULE_IDS[0], RuleSetting::Off),
+        ]);
+        assert_eq!(unknown_rule_ids(&config), vec!["definitely-not-a-rule"]);
+    }
+
+    #[test]
+    fn known_rule_ids_are_not_reported() {
+        let config = config_with(&[(RULE_IDS[0], RuleSetting::Off)]);
+        assert!(unknown_rule_ids(&config).is_empty());
     }
 }


### PR DESCRIPTION
## What

Wires the previously-stubbed rule seam in the `tzlint` CLI to the real registry, so the CLI now actually emits diagnostics. Builds on the merged M1g scaffold (#22) and M1f rules (#19).

- `resolve_rules(config)` returns `tzlint_rules::builtin_rules()` filtered by config.
- **Activation model** (maintainer's choice): every built-in rule is **on by default**; a `config.rules` entry of `false` disables that rule. A bare `tzlint lint` runs the full built-in set; a config narrows it.
- `unknown_rule_ids(config)` surfaces config rule ids that aren't built-in (typos) so a misspelled setting is reported, not silently ignored — in both `lint` and `fix`.

### Deferred (documented)

Per-rule `options` and severity overrides are **not** routed into rule construction yet: `builtin_rules()` builds each rule with its defaults and the `Rule` trait exposes only an immutable `RuleMeta`. Routing them is a follow-up that adds a config-aware constructor to `tzlint_rules`. So today a rule runs with its defaults regardless of the `options`/`severity` in config (this matches the existing notes in `tzlint_rules`/`preset.rs`).

## Review

Adversarial multi-lens review (correctness / config-contract+UX / tests) with per-finding verification: no correctness/contract defects; 2 confirmed test-coverage gaps, both now closed — the "all rules disabled" note, and the unknown-rule-id warning in `fix`.

New/updated tests: default = all-on; `false` disables one rule; unknown id reported (lint **and** fix); end-to-end `Findings` exit on a real violation (half-width kana → `no-hankaku-kana`); config-off disables end-to-end; cache vs no-cache equivalence **with diagnostics**; all-disabled note.

## Note on the Windows fix

This branch also makes two M1g path assertions OS-agnostic (build the expected string via `Path::join` instead of a hard-coded `/`), so the Windows CI job is green. That is the **same fix as #24** (the standalone hotfix that unblocks #23); it is included here so this branch is green on its own. Whichever of #24 / this PR merges first, the other's identical hunk drops cleanly on rebase.

## Checks (local)

`just check` green (nextest, 193 workspace tests; `tzlint_cli`: 31). `cargo build -p tzlint_core --target wasm32-unknown-unknown`, io-guard, and `cargo deny check` all ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 設定に含まれる未知のルールIDを検出し、stderr に警告メッセージを表示するようになりました。

* **改善**
  * ルール解決の処理を改善し、デフォルトで全組み込みルールが有効になるようになりました。
  * ルールセットが空の場合のエラーメッセージを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->