### PR TITLE
feat(core): select presets via `extends` (M1g-b)

### DIFF
--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -581,6 +581,26 @@ mod tests {
     }
 
     #[test]
+    fn extends_known_preset_loads_and_unknown_errors() {
+        // A config that extends a known preset loads cleanly; an unknown preset id is a fatal
+        // config error surfaced by the CLI.
+        let host = MockHost::new();
+        host.put("a.md", "ふつうの文。\n");
+        host.put("good.json", "{ \"extends\": \"ja-technical-writing\" }");
+        host.put("bad.json", "{ \"extends\": \"no-such-preset\" }");
+
+        let mut good = lint_cli("a.md", OutputFormat::Text);
+        good.config = Some(PathBuf::from("good.json"));
+        assert_eq!(run_capture(&good, &host).0, ExitStatus::Clean);
+
+        let mut bad = lint_cli("a.md", OutputFormat::Text);
+        bad.config = Some(PathBuf::from("bad.json"));
+        let (status, _out, err) = run_capture(&bad, &host);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("unknown preset"), "{err}");
+    }
+
+    #[test]
     fn unknown_config_rule_id_is_noted() {
         // A misspelled rule id in config is reported (not silently ignored).
         let host = MockHost::new();

--- a/crates/tzlint_core/src/config/config.schema.json
+++ b/crates/tzlint_core/src/config/config.schema.json
@@ -18,11 +18,20 @@
       "$ref": "#/$defs/rules"
     },
     "extends": {
-      "description": "Reserved for a future milestone and not yet supported. Only null (equivalent to absent) is accepted; any non-null value is rejected by the loader as a reserved key.",
-      "type": "null"
+      "description": "Preset(s) whose rule settings form a base layer under this file's own `rules` (this file wins on overlap; later array entries win over earlier). A preset id, an array of ids, or null/absent for none.",
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/presetId" },
+        { "type": "array", "items": { "$ref": "#/$defs/presetId" } }
+      ]
     }
   },
   "$defs": {
+    "presetId": {
+      "description": "A built-in preset id.",
+      "type": "string",
+      "enum": ["ja-basic", "ja-technical-writing"]
+    },
     "rules": {
       "description": "Map of rule id to its setting. Rule ids are arbitrary strings; they are not validated against a known-rule set yet (that arrives with the rules crate).",
       "type": "object",

--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -14,8 +14,8 @@
 //!   `.tzlintrc.jsonc` → `.tzlintrc.json` → `.tzlintrc.yaml` → `.tzlintrc.yml` → `.tzlintrc`
 //!   (the extensionless file is parsed as JSONC).
 //! - **Presets** ([`Preset`], [`resolve`]) provide a base rule set that the user config
-//!   overrides by id. The `extends` key is reserved for a later milestone and is rejected
-//!   with a clear error rather than silently ignored.
+//!   overrides by id. A config selects them with `extends` (a preset id or a list of them);
+//!   they are layered under the file's own `rules`, and an unknown id is a clear error.
 
 mod discover;
 mod format;
@@ -54,14 +54,14 @@ pub struct Config {
 impl Config {
     /// Parse a config from `text` in the given [`ConfigFormat`].
     ///
-    /// Strict: unknown top-level keys, malformed values, or a (reserved) `extends` key are
-    /// errors. Rule-specific `options` are preserved verbatim as JSON values.
+    /// Strict: unknown top-level keys, malformed values, or an `extends` naming an unknown
+    /// preset are errors. Rule-specific `options` are preserved verbatim as JSON values.
     pub fn parse(text: &str, format: ConfigFormat) -> Result<Self, ConfigError> {
         format::parse(text, format)
     }
 }
 
-/// A configuration failure: an I/O error, a parse/validation error, or use of a reserved key.
+/// A configuration failure: an I/O error, a parse/validation error, or an unknown preset id.
 #[derive(Debug)]
 pub enum ConfigError {
     /// Reading a discovered config file failed.
@@ -73,8 +73,8 @@ pub enum ConfigError {
         /// A human-readable reason from the underlying deserializer.
         message: String,
     },
-    /// A key that is recognized but reserved for a future milestone (e.g. `extends`).
-    Reserved(&'static str),
+    /// `extends` referenced a preset id that is not a known [`Preset`].
+    UnknownPreset(String),
 }
 
 impl fmt::Display for ConfigError {
@@ -84,8 +84,8 @@ impl fmt::Display for ConfigError {
             ConfigError::Parse { format, message } => {
                 write!(f, "failed to parse {format} config: {message}")
             }
-            ConfigError::Reserved(key) => {
-                write!(f, "`{key}` is reserved and not supported yet")
+            ConfigError::UnknownPreset(id) => {
+                write!(f, "`extends` references unknown preset `{id}`")
             }
         }
     }
@@ -125,8 +125,8 @@ mod tests {
             "failed to parse JSON config: boom"
         );
         assert_eq!(
-            ConfigError::Reserved("extends").to_string(),
-            "`extends` is reserved and not supported yet"
+            ConfigError::UnknownPreset("nope".into()).to_string(),
+            "`extends` references unknown preset `nope`"
         );
     }
 
@@ -134,7 +134,7 @@ mod tests {
     fn error_source_chains_io_only() {
         use std::error::Error;
         assert!(ConfigError::Io(IoError::NotFound).source().is_some());
-        assert!(ConfigError::Reserved("extends").source().is_none());
+        assert!(ConfigError::UnknownPreset("nope".into()).source().is_none());
     }
 
     #[test]

--- a/crates/tzlint_core/src/config/model.rs
+++ b/crates/tzlint_core/src/config/model.rs
@@ -1,8 +1,8 @@
 //! The serde model behind a config file and its conversion to a resolved [`Config`].
 //!
 //! [`RawConfig`] mirrors the on-disk shape (strict: `deny_unknown_fields`, kebab-case keys);
-//! [`RawConfig::into_config`] validates the reserved `extends` key and lifts string rule keys
-//! into [`RuleId`]s. [`RuleSetting`] has a hand-written `Deserialize` so a rule value may be
+//! [`RawConfig::into_config`] resolves `extends` presets (layered under this file's `rules`) and
+//! lifts string rule keys into [`RuleId`]s. [`RuleSetting`] has a hand-written `Deserialize` so a rule value may be
 //! `false`, `true`, or `{ severity?, options? }` while still rejecting unknown keys in the
 //! object form — something `#[serde(untagged)]` cannot enforce.
 
@@ -26,37 +26,68 @@ pub(super) struct RawConfig {
     message_language: Option<String>,
     #[serde(default)]
     rules: BTreeMap<String, RuleSetting>,
-    /// Reserved: composing/extending configs is a later milestone. Accepted into the model (so
-    /// a lone `extends` produces a precise "reserved" error rather than an "unknown field" one)
-    /// and rejected in [`into_config`](RawConfig::into_config). `extends: null` is treated as
-    /// absent (a no-op), matching serde's null→`None` mapping. Note: if the file *also* has an
-    /// unknown key or a type error, serde's `deny_unknown_fields`/type error fires first and
-    /// that message wins over the reserved-key one.
+    /// Preset(s) to extend: a base rule layer this file's own `rules` override. A bare string
+    /// names one preset; an array names several (later entries win over earlier; this file's
+    /// `rules` win over all). `null`/absent means none. Each id must be a known preset (e.g.
+    /// `"ja-basic"`); an unknown id is rejected in [`into_config`](RawConfig::into_config). A
+    /// non-string/array value is a serde type error at parse time.
     #[serde(default)]
-    extends: Option<Value>,
+    extends: Option<Extends>,
+}
+
+/// The shape of the `extends` value: one preset id, or a list of them.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Extends {
+    /// `extends: "ja-basic"`.
+    One(String),
+    /// `extends: ["ja-basic", "ja-technical-writing"]`.
+    Many(Vec<String>),
+}
+
+impl Extends {
+    /// The preset ids in declaration order.
+    fn ids(self) -> Vec<String> {
+        match self {
+            Extends::One(id) => vec![id],
+            Extends::Many(ids) => ids,
+        }
+    }
 }
 
 impl RawConfig {
-    /// Validate reserved keys and lift `rules` keys into [`RuleId`]s.
+    /// Resolve `extends` presets and lift `rules` keys into [`RuleId`]s.
     ///
-    /// Rule ids are not checked against a known-rule set here — that registry does not exist
-    /// until the rules crate lands (M1f), so an unknown id is kept verbatim and simply matches
-    /// no rule. (`deny_unknown_fields` guards the fixed top-level keys, not the dynamic `rules`
-    /// map keys.)
+    /// The presets form base layers under this file's own `rules` (later `extends` entries win
+    /// over earlier; this file's `rules` win over all). An unknown preset id is a
+    /// [`ConfigError::UnknownPreset`]. Rule ids inside `rules` are not checked against the
+    /// known-rule set here (`deny_unknown_fields` guards only the fixed top-level keys); an
+    /// unknown rule id is kept verbatim and simply matches no rule.
     pub(super) fn into_config(self) -> Result<Config, ConfigError> {
-        if self.extends.is_some() {
-            return Err(ConfigError::Reserved("extends"));
-        }
+        let preset_ids = self.extends.map(Extends::ids).unwrap_or_default();
+        let presets = preset_ids
+            .into_iter()
+            .map(|id| super::Preset::from_id(&id).ok_or(ConfigError::UnknownPreset(id)))
+            .collect::<Result<Vec<_>, _>>()?;
+
         let rules = self
             .rules
             .into_iter()
             .map(|(id, setting)| (RuleId::from(id), setting))
             .collect();
-        Ok(Config {
+        let user = Config {
             language: self.language,
             message_language: self.message_language,
             rules,
-        })
+        };
+
+        // Layer presets under the user config. Folding in reverse makes the precedence (low to
+        // high) `extends[0] < … < extends[n] < user`: each `resolve` puts its preset *under* the
+        // accumulator.
+        Ok(presets
+            .into_iter()
+            .rev()
+            .fold(user, |acc, preset| super::resolve(Some(preset), acc)))
     }
 }
 
@@ -334,14 +365,49 @@ mod tests {
     }
 
     #[test]
-    fn into_config_rejects_reserved_extends() {
-        let raw: RawConfig = serde_json::from_str(r#"{ "extends": ["ja-basic"] }"#).unwrap();
+    fn into_config_resolves_extends_under_user_rules() {
+        // `extends` contributes the preset's rules as a base; this file's `rules` win on overlap.
+        let raw: RawConfig = serde_json::from_str(
+            r#"{ "extends": "ja-basic", "rules": { "no-hankaku-kana": false } }"#,
+        )
+        .unwrap();
+        let config = raw.into_config().unwrap();
+        // ja-basic enables no-mixed-zenkaku-hankaku-alphabet (kept) ...
+        assert!(
+            config
+                .rules
+                .get(&RuleId::from("no-mixed-zenkaku-hankaku-alphabet"))
+                .is_some_and(RuleSetting::is_enabled)
+        );
+        // ... and no-hankaku-kana, which this file overrides to off (user wins).
+        assert_eq!(
+            config.rules.get(&RuleId::from("no-hankaku-kana")),
+            Some(&RuleSetting::Off)
+        );
+    }
+
+    #[test]
+    fn into_config_array_extends_later_preset_wins() {
+        // Both presets set sentence-length differently in spirit; the later (ja-technical-writing)
+        // contributes it, so it is present after resolution.
+        let raw: RawConfig =
+            serde_json::from_str(r#"{ "extends": ["ja-basic", "ja-technical-writing"] }"#).unwrap();
+        let config = raw.into_config().unwrap();
+        assert!(config.rules.contains_key(&RuleId::from("sentence-length")));
+    }
+
+    #[test]
+    fn into_config_rejects_unknown_preset() {
+        let raw: RawConfig = serde_json::from_str(r#"{ "extends": "nope" }"#).unwrap();
         assert!(matches!(
             raw.into_config(),
-            Err(ConfigError::Reserved("extends"))
+            Err(ConfigError::UnknownPreset(id)) if id == "nope"
         ));
-        // `extends: null` is treated as absent (a no-op), not reserved.
-        let null_extends: RawConfig = serde_json::from_str(r#"{ "extends": null }"#).unwrap();
-        assert!(null_extends.into_config().is_ok());
+    }
+
+    #[test]
+    fn into_config_null_extends_is_a_noop() {
+        let raw: RawConfig = serde_json::from_str(r#"{ "extends": null }"#).unwrap();
+        assert!(raw.into_config().unwrap().rules.is_empty());
     }
 }

--- a/crates/tzlint_core/src/config/model.rs
+++ b/crates/tzlint_core/src/config/model.rs
@@ -387,13 +387,18 @@ mod tests {
     }
 
     #[test]
-    fn into_config_array_extends_later_preset_wins() {
-        // Both presets set sentence-length differently in spirit; the later (ja-technical-writing)
-        // contributes it, so it is present after resolution.
+    fn into_config_array_extends_merges_all_presets() {
+        // An array `extends` layers every listed preset's rules. Later entries would win on a
+        // shared id, but the two built-ins never set a shared rule differently, so the only
+        // observable effect here is the union: ja-basic's rules plus ja-technical-writing's extras.
         let raw: RawConfig =
             serde_json::from_str(r#"{ "extends": ["ja-basic", "ja-technical-writing"] }"#).unwrap();
         let config = raw.into_config().unwrap();
+        // Contributed by ja-basic (the earlier entry).
+        assert!(config.rules.contains_key(&RuleId::from("no-hankaku-kana")));
+        // Unique to ja-technical-writing (the later entry).
         assert!(config.rules.contains_key(&RuleId::from("sentence-length")));
+        assert!(config.rules.contains_key(&RuleId::from("max-ten")));
     }
 
     #[test]

--- a/crates/tzlint_core/tests/config_schema.rs
+++ b/crates/tzlint_core/tests/config_schema.rs
@@ -64,9 +64,21 @@ const CORPUS: &[(&str, &str, Mode)] = &[
         r#"{"langauge":"ja"}"#,
         Mode::Reject,
     ),
-    // `extends` is reserved: only null (= absent) is accepted; any non-null value is rejected.
+    // `extends` selects preset(s): a known id (string or array) is accepted; null is a no-op;
+    // an unknown id or a non-string/array value is rejected by both schema and loader.
     ("extends null", r#"{"extends":null}"#, Mode::Accept),
-    ("extends array", r#"{"extends":["ja-basic"]}"#, Mode::Reject),
+    ("extends string", r#"{"extends":"ja-basic"}"#, Mode::Accept),
+    (
+        "extends array",
+        r#"{"extends":["ja-basic","ja-technical-writing"]}"#,
+        Mode::Accept,
+    ),
+    ("extends unknown id", r#"{"extends":"nope"}"#, Mode::Reject),
+    (
+        "extends array unknown id",
+        r#"{"extends":["nope"]}"#,
+        Mode::Reject,
+    ),
     ("extends number", r#"{"extends":42}"#, Mode::Reject),
     // Rules map.
     ("rules empty", r#"{"rules":{}}"#, Mode::Accept),
@@ -224,24 +236,23 @@ fn schema_matches_loader_with_documented_asymmetry() {
 }
 
 #[test]
-fn extends_rejection_is_reserved_not_parse() {
-    // The schema can only say accept/reject; the loader distinguishes a *reserved* key from a
-    // generic parse error. Pin that boundary so a refactor can't silently downgrade it.
-    for text in [r#"{"extends":["ja-basic"]}"#, r#"{"extends":42}"#] {
-        assert!(
-            matches!(
-                Config::parse(text, ConfigFormat::Json),
-                Err(ConfigError::Reserved("extends"))
-            ),
-            "{text} should be a reserved-key error"
-        );
-    }
-    // A generic bad value is a parse error, not reserved.
+fn extends_distinguishes_unknown_preset_from_parse_error() {
+    // The schema can only say accept/reject; the loader distinguishes an *unknown preset* from a
+    // generic parse error (a non-string/array value). Pin that boundary.
+    assert!(
+        matches!(
+            Config::parse(r#"{"extends":"nope"}"#, ConfigFormat::Json),
+            Err(ConfigError::UnknownPreset(id)) if id == "nope"
+        ),
+        "an unknown preset id should be UnknownPreset"
+    );
+    // A non-string/array `extends` is a serde type error → Parse, not UnknownPreset.
     assert!(matches!(
-        Config::parse(r#"{"language":42}"#, ConfigFormat::Json),
+        Config::parse(r#"{"extends":42}"#, ConfigFormat::Json),
         Err(ConfigError::Parse { .. })
     ));
-    // `extends: null` is accepted as a no-op.
+    // A known preset resolves; `extends: null` is a no-op.
+    assert!(Config::parse(r#"{"extends":"ja-basic"}"#, ConfigFormat::Json).is_ok());
     assert!(Config::parse(r#"{"extends":null}"#, ConfigFormat::Json).is_ok());
 }
 


### PR DESCRIPTION
Second of three stacked M1g follow-ups. **Base = `feat/m1g-options` (M1g-a)**; review/merge after it.

## What
`extends` is no longer reserved: a config selects preset(s) with it — a preset id (`"ja-basic"`) or an array. The presets' rule settings form base layers under this file's own `rules` (later `extends` entries win over earlier; this file's `rules` win over all), via the existing `resolve`. An unknown preset id is `ConfigError::UnknownPreset` (the now-unused `Reserved` variant is removed); a non-string/array `extends` is a parse error. The published JSON Schema gains an `extends` definition (null | preset-id | array-of-preset-ids, ids enumerated), and the differential schema⇔loader test covers the accept/reject cases.

## Activation-model note
Rules are on by default (M1g-a), so a preset does **not restrict** the active set — it supplies options/severity for its rules (applied by the resolver). Narrowing the set is still done by turning rules off explicitly. (Flag if you'd prefer `extends` to define the active set instead — that's a different activation model.)

## Checks
`just check` green on the full stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 設定の `extends` プロパティで既知のビルトインプリセット（`ja-basic`、`ja-technical-writing`）を参照できるようになりました。複数のプリセットの指定にも対応しています。

* **Bug Fixes**
  * 未知のプリセットを参照した場合、より明確なエラーメッセージが表示されるようになりました。

* **Tests**
  * `extends` の許容境界と拒否条件を検証するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->