### PR TITLE
feat(cli): accept globs, directories, and stdin for lint/fix (M1g-d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1793,7 @@ name = "tzlint_cli"
 version = "0.0.0"
 dependencies = [
  "clap",
+ "glob",
  "serde_json",
  "tzlint_ast",
  "tzlint_core",

--- a/clippy.toml
+++ b/clippy.toml
@@ -11,4 +11,5 @@ disallowed-methods = [
     { path = "std::fs::read", reason = "use tzlint_core::io::Host::read_to_string" },
     { path = "std::fs::read_to_string", reason = "use tzlint_core::io::Host::read_to_string" },
     { path = "std::fs::write", reason = "use tzlint_core::io::Host::write_atomic" },
+    { path = "std::fs::read_dir", reason = "use tzlint_core::io::Host::list_dir" },
 ]

--- a/crates/tzlint_cli/Cargo.toml
+++ b/crates/tzlint_cli/Cargo.toml
@@ -28,6 +28,11 @@ tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
 # Argument parsing (derive API).
 clap = { workspace = true }
+# Glob pattern matching for `lint`/`fix` PATH arguments. Used ONLY for `Pattern::matches_path`
+# (pure string matching); the directory walk itself goes through `Host::list_dir`, never
+# `glob::glob()` (which would touch `std::fs` directly and bypass the io boundary). CLI-only —
+# it never reaches the AST or the `wasm32` core, so a native-only dependency here is fine.
+glob = "0.3"
 # JSON output. The diagnostic model is serde-free (it is `no_std`/ABI-frozen), so the CLI
 # builds the JSON document itself from the diagnostic fields rather than deriving `Serialize`.
 serde_json = { workspace = true }

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -10,8 +10,13 @@
 //! failed result write becomes `Error`). Writes to **stderr** (errors, notes) are best-effort
 //! `let _ = writeln!(…)`: a failed stderr write must not abort the run or change the exit code,
 //! which already signals the outcome.
+//!
+//! Inputs are expanded by [`expand`] (globs / directories / the `-` stdin sentinel). Stdin is
+//! linted/fixed in memory under the label `<stdin>` and is never cached. `fix -` writes the fixed
+//! document to **stdout** (a pass-through filter), so its progress/summary move to stderr to keep
+//! stdout a pure artifact; file fixes keep their progress on stdout as before.
 
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use tzlint_ast::{access, to_archive};
@@ -22,8 +27,24 @@ use tzlint_core::{
 use tzlint_pdk::{Diagnostic, Rule};
 
 use crate::cli::{Cli, Command, OutputFormat};
+use crate::expand;
 use crate::output::{self, FileReport};
 use crate::rules::{resolve_rules, unknown_rule_ids};
+
+/// The path label used for diagnostics linted from standard input.
+const STDIN_LABEL: &str = "<stdin>";
+
+/// The three standard streams, bundled so the orchestration threads I/O as one value (and stays
+/// under the argument-count lint). `stdin` feeds the `-` source; `stdout` carries results, so its
+/// write errors propagate; `stderr` carries notes/errors and is best-effort.
+pub struct Streams<'a> {
+    /// Standard input — the source for the `-` argument.
+    pub stdin: &'a mut dyn Read,
+    /// Standard output — user-facing results (lint output, the fixed stdin document).
+    pub stdout: &'a mut dyn Write,
+    /// Standard error — notes, warnings, and errors.
+    pub stderr: &'a mut dyn Write,
+}
 
 /// The process exit status, mapped to a code by [`ExitStatus::code`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -57,24 +78,18 @@ const STARTER_CONFIG: &str = "{\n  \"language\": \"ja\",\n  \"rules\": {}\n}\n";
 ///
 /// A subcommand's unexpected error is rendered as `error: …` on stderr and becomes
 /// [`ExitStatus::Error`]; per-file problems are reported inline and do not abort the run.
-pub fn run(
-    cli: &Cli,
-    host: &dyn Host,
-    cwd: &Path,
-    stdout: &mut dyn Write,
-    stderr: &mut dyn Write,
-) -> ExitStatus {
+pub fn run(cli: &Cli, host: &dyn Host, cwd: &Path, streams: &mut Streams) -> ExitStatus {
     let result = match &cli.command {
-        Command::Lint { paths, format } => lint(cli, host, cwd, paths, *format, stdout, stderr),
-        Command::Fix { paths, dry_run } => fix(cli, host, cwd, paths, *dry_run, stdout, stderr),
-        Command::Init { force } => init(host, cwd, *force, stdout, stderr),
+        Command::Lint { paths, format } => lint(cli, host, cwd, paths, *format, streams),
+        Command::Fix { paths, dry_run } => fix(cli, host, cwd, paths, *dry_run, streams),
+        Command::Init { force } => init(host, cwd, *force, streams.stdout, streams.stderr),
     };
     match result {
         Ok(status) => status,
         Err(message) => {
             // stderr is best-effort (see the module's output policy); the `Error` status below
             // is the authoritative signal regardless of whether this message lands.
-            let _ = writeln!(stderr, "error: {message}");
+            let _ = writeln!(streams.stderr, "error: {message}");
             ExitStatus::Error
         }
     }
@@ -88,22 +103,49 @@ fn lint(
     cwd: &Path,
     paths: &[PathBuf],
     format: OutputFormat,
-    stdout: &mut dyn Write,
-    stderr: &mut dyn Write,
+    streams: &mut Streams,
 ) -> Result<ExitStatus, String> {
+    // Reborrow the three streams as locals (disjoint fields, so all three coexist) — the body then
+    // reads exactly as it did when they were separate parameters.
+    let stdin: &mut dyn Read = &mut *streams.stdin;
+    let stdout: &mut dyn Write = &mut *streams.stdout;
+    let stderr: &mut dyn Write = &mut *streams.stderr;
     let config = load_config(cli, host, cwd, stderr)?;
     let rules = resolve_rules(&config);
     note_if_no_rules(&rules, stderr);
     note_unknown_rules(&config, stderr);
     let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
 
+    // Resolve the PATH arguments into concrete files (globs / directories expanded, sorted and
+    // de-duplicated) plus an optional stdin source; surface any discovery notes on stderr.
+    let inputs = expand::expand(host, cwd, paths);
+    note_expansion(&inputs.notes, stderr);
+
     // Persistent cache: load the on-disk file (best-effort) so a repeat run on unchanged content
-    // skips parse+lint, and write it back afterwards. `--no-cache` skips both ends.
+    // skips parse+lint, and write it back afterwards. `--no-cache` skips both ends. (stdin is
+    // never cached — it has no stable path key — so it always takes the direct path below.)
     let cache_path = cwd.join(".tzlintcache");
     let mut cache = (!cli.no_cache).then(|| DocumentCache::load(host, &cache_path));
-    let mut reports = Vec::with_capacity(paths.len());
+    let mut reports = Vec::with_capacity(inputs.files.len() + usize::from(inputs.stdin));
     let mut had_error = false;
-    for path in paths {
+    // stdin is reported first so the work order is fixed and the summary count is stable.
+    if inputs.stdin {
+        match read_stdin(stdin).and_then(|source| {
+            let diagnostics = lint_direct(&source, &rule_refs)?;
+            Ok(FileReport {
+                path: PathBuf::from(STDIN_LABEL),
+                source,
+                diagnostics,
+            })
+        }) {
+            Ok(report) => reports.push(report),
+            Err(message) => {
+                let _ = writeln!(stderr, "error: {STDIN_LABEL}: {message}");
+                had_error = true;
+            }
+        }
+    }
+    for path in &inputs.files {
         match read_and_lint(host, cache.as_mut(), path, &config, &rule_refs) {
             Ok(report) => reports.push(report),
             Err(message) => {
@@ -185,18 +227,63 @@ fn fix(
     cwd: &Path,
     paths: &[PathBuf],
     dry_run: bool,
-    stdout: &mut dyn Write,
-    stderr: &mut dyn Write,
+    streams: &mut Streams,
 ) -> Result<ExitStatus, String> {
+    // Reborrow the three streams as locals (disjoint fields, so all three coexist).
+    let stdin: &mut dyn Read = &mut *streams.stdin;
+    let stdout: &mut dyn Write = &mut *streams.stdout;
+    let stderr: &mut dyn Write = &mut *streams.stderr;
     let config = load_config(cli, host, cwd, stderr)?;
     let rules = resolve_rules(&config);
     note_if_no_rules(&rules, stderr);
     note_unknown_rules(&config, stderr);
     let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
 
+    let inputs = expand::expand(host, cwd, paths);
+    note_expansion(&inputs.notes, stderr);
+
+    // When stdin is a target, stdout carries the fixed stdin document (a pass-through filter), so
+    // ALL progress/summary moves to stderr to keep stdout pure data. Without stdin, progress and
+    // the summary stay on stdout exactly as before.
+    let progress_to_stderr = inputs.stdin;
     let mut changed = 0usize;
     let mut had_error = false;
-    for path in paths {
+
+    // stdin first: fix the buffer and write the result to stdout (even when unchanged, so
+    // `cat x.md | tzlint fix -` is a safe pass-through). `--dry-run` emits no document.
+    if inputs.stdin {
+        match read_stdin(stdin) {
+            Ok(source) => {
+                let fixed = tzlint_core::fix(&source, &rule_refs);
+                let did_change = fixed != source;
+                if dry_run {
+                    if did_change {
+                        let _ = writeln!(stderr, "would fix {STDIN_LABEL}");
+                    }
+                } else {
+                    write!(stdout, "{fixed}").map_err(|e| e.to_string())?;
+                    let _ = writeln!(
+                        stderr,
+                        "{} {STDIN_LABEL}",
+                        if did_change {
+                            "fixed"
+                        } else {
+                            "no changes for"
+                        }
+                    );
+                }
+                if did_change {
+                    changed += 1;
+                }
+            }
+            Err(message) => {
+                let _ = writeln!(stderr, "error: {STDIN_LABEL}: {message}");
+                had_error = true;
+            }
+        }
+    }
+
+    for path in &inputs.files {
         let source = match host.read_to_string(path, MAX_FILE) {
             Ok(source) => source,
             Err(e) => {
@@ -212,13 +299,23 @@ fn fix(
             continue;
         }
         if dry_run {
-            writeln!(stdout, "would fix {}", path.display()).map_err(|e| e.to_string())?;
+            emit_progress(
+                progress_to_stderr,
+                stdout,
+                stderr,
+                &format!("would fix {}", path.display()),
+            )?;
         } else if let Err(e) = host.write_atomic(path, fixed.as_bytes()) {
             let _ = writeln!(stderr, "error: {}: {e}", path.display());
             had_error = true;
             continue;
         } else {
-            writeln!(stdout, "fixed {}", path.display()).map_err(|e| e.to_string())?;
+            emit_progress(
+                progress_to_stderr,
+                stdout,
+                stderr,
+                &format!("fixed {}", path.display()),
+            )?;
         }
         changed += 1;
     }
@@ -228,12 +325,56 @@ fn fix(
     } else {
         "changed"
     };
-    writeln!(stdout, "{changed} file(s) {verb}").map_err(|e| e.to_string())?;
+    emit_progress(
+        progress_to_stderr,
+        stdout,
+        stderr,
+        &format!("{changed} file(s) {verb}"),
+    )?;
     Ok(if had_error {
         ExitStatus::Error
     } else {
         ExitStatus::Clean
     })
+}
+
+/// Write a progress/summary line to stdout, or to stderr (best-effort) when stdout is reserved
+/// for a fixed stdin document. stdout errors propagate (a failed result write becomes `Error`).
+fn emit_progress(
+    to_stderr: bool,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+    message: &str,
+) -> Result<(), String> {
+    if to_stderr {
+        let _ = writeln!(stderr, "{message}");
+        Ok(())
+    } else {
+        writeln!(stdout, "{message}").map_err(|e| e.to_string())
+    }
+}
+
+/// Read standard input into a UTF-8 string, capped at [`MAX_FILE`] bytes (mirroring
+/// [`Host::read_to_string`]) so a runaway pipe cannot exhaust memory.
+fn read_stdin(stdin: &mut dyn Read) -> Result<String, String> {
+    let mut bytes = Vec::new();
+    // Read one past the cap so "exactly at the limit" is distinguishable from "over it".
+    stdin
+        .take((MAX_FILE as u64).saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|e| e.to_string())?;
+    if bytes.len() > MAX_FILE {
+        return Err(format!("input exceeds the {MAX_FILE}-byte limit"));
+    }
+    String::from_utf8(bytes).map_err(|e| format!("invalid UTF-8: {e}"))
+}
+
+/// Surface each input-expansion note (unreadable subdirectory, depth / file caps, an invalid
+/// glob) as a best-effort `warning:` on stderr.
+fn note_expansion(notes: &[String], stderr: &mut dyn Write) {
+    for note in notes {
+        let _ = writeln!(stderr, "warning: {note}");
+    }
 }
 
 /// `init`: write [`STARTER_CONFIG`] to `.tzlintrc.json` in the working directory, refusing to
@@ -338,20 +479,23 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
-    use tzlint_core::IoError;
+    use tzlint_core::{DirEntry, EntryKind, IoError};
 
     use crate::cli::Command;
 
     /// An in-memory [`Host`]: only registered paths exist; writes are recorded so tests can
-    /// assert on them.
+    /// assert on them. [`MockHost::put`] also synthesizes the directory listing for every ancestor
+    /// of the file, so `list_dir` (and thus glob / directory expansion) works hermetically.
     struct MockHost {
         files: RefCell<HashMap<PathBuf, String>>,
+        dirs: RefCell<HashMap<PathBuf, Vec<DirEntry>>>,
     }
 
     impl MockHost {
         fn new() -> Self {
             MockHost {
                 files: RefCell::new(HashMap::new()),
+                dirs: RefCell::new(HashMap::new()),
             }
         }
         fn with(path: &str, contents: &str) -> Self {
@@ -360,9 +504,37 @@ mod tests {
             host
         }
         fn put(&self, path: &str, contents: &str) {
+            let leaf = PathBuf::from(path);
             self.files
                 .borrow_mut()
-                .insert(PathBuf::from(path), contents.to_string());
+                .insert(leaf.clone(), contents.to_string());
+            self.register_dir_entries(&leaf);
+        }
+        /// Register each (parent -> child) hop of `leaf` in the `dirs` index so the file is
+        /// discoverable via `list_dir`. Shared by `put` and `write_atomic` so a file written
+        /// through either path is visible to a later walk — matching `NativeHost`, where any
+        /// created file shows up in `read_dir`.
+        fn register_dir_entries(&self, leaf: &Path) {
+            let mut dirs = self.dirs.borrow_mut();
+            let mut child = leaf.to_path_buf();
+            while let Some(parent) = child.parent() {
+                if parent.as_os_str().is_empty() {
+                    break;
+                }
+                if let Some(name) = child.file_name() {
+                    let name = name.to_string_lossy().into_owned();
+                    let kind = if child == leaf {
+                        EntryKind::File
+                    } else {
+                        EntryKind::Dir
+                    };
+                    let children = dirs.entry(parent.to_path_buf()).or_default();
+                    if !children.iter().any(|e| e.name == name) {
+                        children.push(DirEntry { name, kind });
+                    }
+                }
+                child = parent.to_path_buf();
+            }
         }
         fn read(&self, path: &str) -> Option<String> {
             self.files.borrow().get(&PathBuf::from(path)).cloned()
@@ -381,10 +553,20 @@ mod tests {
             let text =
                 String::from_utf8(contents.to_vec()).map_err(|e| IoError::Other(e.to_string()))?;
             self.files.borrow_mut().insert(path.to_path_buf(), text);
+            // Keep the `dirs` index consistent with a write, so a written file is discoverable by
+            // a later `list_dir` — as it would be under `NativeHost`.
+            self.register_dir_entries(path);
             Ok(())
         }
         fn exists(&self, path: &Path) -> bool {
             self.files.borrow().contains_key(path)
+        }
+        fn list_dir(&self, dir: &Path) -> Result<Vec<DirEntry>, IoError> {
+            self.dirs
+                .borrow()
+                .get(dir)
+                .cloned()
+                .ok_or(IoError::NotFound)
         }
     }
 
@@ -409,9 +591,22 @@ mod tests {
     const TEST_CWD: &str = "/work";
 
     fn run_capture(cli: &Cli, host: &dyn Host) -> (ExitStatus, String, String) {
+        run_capture_stdin(cli, host, b"")
+    }
+
+    /// Like [`run_capture`] but feeds `stdin` to the command (for `-` tests).
+    fn run_capture_stdin(cli: &Cli, host: &dyn Host, stdin: &[u8]) -> (ExitStatus, String, String) {
         let mut out = Vec::new();
         let mut err = Vec::new();
-        let status = run(cli, host, Path::new(TEST_CWD), &mut out, &mut err);
+        let mut input = std::io::Cursor::new(stdin.to_vec());
+        let status = {
+            let mut streams = Streams {
+                stdin: &mut input,
+                stdout: &mut out,
+                stderr: &mut err,
+            };
+            run(cli, host, Path::new(TEST_CWD), &mut streams)
+        };
         (
             status,
             String::from_utf8(out).unwrap(),
@@ -789,5 +984,179 @@ mod tests {
         let (status, _out, err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
         assert_eq!(status, ExitStatus::Findings); // cache write failure did NOT become an error
         assert!(err.contains("could not write"), "{err}");
+    }
+
+    // --- input expansion: globs, directories, stdin (M1g follow-up) ---
+
+    #[test]
+    fn lint_expands_a_glob_to_matching_files() {
+        // `*.md` anchors at the (injected) cwd and matches only top-level Markdown; the `.txt` is
+        // excluded, and two clean files are checked.
+        let host = MockHost::new();
+        host.put("/work/a.md", "本文。\n");
+        host.put("/work/b.md", "別の文。\n");
+        host.put("/work/note.txt", "ignored\n");
+        let (status, out, _err) = run_capture(&lint_cli("*.md", OutputFormat::Text), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(out.contains("2 file(s) checked"), "{out}");
+    }
+
+    #[test]
+    fn lint_directory_arg_lints_markdown_recursively() {
+        // A directory argument recurses for `.md`/`.markdown`; other extensions are skipped.
+        let host = MockHost::new();
+        host.put("docs/a.md", "本文。\n");
+        host.put("docs/sub/b.markdown", "別。\n");
+        host.put("docs/c.txt", "ignored\n");
+        let (status, out, _err) = run_capture(&lint_cli("docs", OutputFormat::Text), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(out.contains("2 file(s) checked"), "{out}");
+    }
+
+    #[test]
+    fn lint_invalid_glob_warns_and_matches_nothing() {
+        // A malformed glob is reported (not silently ignored) and contributes no files.
+        let host = MockHost::new();
+        let (status, out, err) = run_capture(&lint_cli("[bad", OutputFormat::Text), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(err.contains("invalid glob pattern"), "{err}");
+        assert!(out.contains("0 file(s) checked"), "{out}");
+    }
+
+    #[test]
+    fn lint_reads_stdin_under_the_stdin_label() {
+        // `-` reads stdin; the diagnostic is labeled `<stdin>` and counted like a file.
+        let host = MockHost::new();
+        let (status, out, _err) = run_capture_stdin(
+            &lint_cli("-", OutputFormat::Text),
+            &host,
+            "ﾊﾛｰ\n".as_bytes(),
+        );
+        assert_eq!(status, ExitStatus::Findings);
+        assert!(out.contains("<stdin>:"), "{out}");
+        assert!(out.contains("no-hankaku-kana"), "{out}");
+        assert!(out.contains("1 file(s) checked"), "{out}");
+    }
+
+    #[test]
+    fn lint_lints_stdin_and_a_file_together() {
+        // `-` may be combined with file paths; stdin is reported first, then the file.
+        let host = MockHost::with("a.md", "本文。\n");
+        let c = cli(Command::Lint {
+            paths: vec![PathBuf::from("-"), PathBuf::from("a.md")],
+            format: OutputFormat::Text,
+        });
+        let (status, out, _err) = run_capture_stdin(&c, &host, "ﾊﾛｰ\n".as_bytes());
+        assert_eq!(status, ExitStatus::Findings);
+        assert!(out.contains("<stdin>"), "{out}");
+        assert!(out.contains("2 file(s) checked"), "{out}");
+    }
+
+    #[test]
+    fn stdin_and_file_yield_identical_diagnostics() {
+        // Dispatch parity: the same content linted from stdin and from a file produces identical
+        // diagnostics (only the `path` label differs).
+        let content = "ﾊﾛｰ\n";
+        let stdin_host = MockHost::new();
+        let (_s1, stdin_out, _e1) = run_capture_stdin(
+            &lint_cli("-", OutputFormat::Json),
+            &stdin_host,
+            content.as_bytes(),
+        );
+        let file_host = MockHost::with("x.md", content);
+        let (_s2, file_out, _e2) = run_capture(&lint_cli("x.md", OutputFormat::Json), &file_host);
+
+        let stdin_json: serde_json::Value = serde_json::from_str(&stdin_out).unwrap();
+        let file_json: serde_json::Value = serde_json::from_str(&file_out).unwrap();
+        assert_eq!(stdin_json[0]["diagnostics"], file_json[0]["diagnostics"]);
+        assert_eq!(stdin_json[0]["path"], "<stdin>");
+        assert_eq!(file_json[0]["path"], "x.md");
+    }
+
+    #[test]
+    fn fix_stdin_passes_the_document_through_stdout() {
+        // No built-in rule autofixes, so the document is unchanged — but `fix -` still echoes it
+        // to stdout (a safe pass-through filter); the progress/summary moves to stderr so stdout
+        // stays pure data, and nothing is written to the host.
+        let host = MockHost::new();
+        let c = cli(Command::Fix {
+            paths: vec![PathBuf::from("-")],
+            dry_run: false,
+        });
+        let (status, out, err) = run_capture_stdin(&c, &host, "本文。\n".as_bytes());
+        assert_eq!(status, ExitStatus::Clean);
+        assert_eq!(
+            out, "本文。\n",
+            "stdout must be exactly the document, no summary"
+        );
+        assert!(err.contains("<stdin>"), "{err}");
+        assert!(host.read("-").is_none(), "stdin must never be written back");
+    }
+
+    #[test]
+    fn fix_dry_run_stdin_emits_no_document() {
+        // `--dry-run` produces no changed artifact, so stdout stays empty for a stdin target.
+        let host = MockHost::new();
+        let c = cli(Command::Fix {
+            paths: vec![PathBuf::from("-")],
+            dry_run: true,
+        });
+        let (status, out, _err) = run_capture_stdin(&c, &host, "本文。\n".as_bytes());
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(
+            out.is_empty(),
+            "dry-run stdin must not emit the document: {out:?}"
+        );
+    }
+
+    #[test]
+    fn emit_progress_routes_between_stdout_and_stderr() {
+        // The data/metadata split that keeps `fix -`'s stdout pure.
+        let (mut out, mut err) = (Vec::new(), Vec::new());
+        emit_progress(false, &mut out, &mut err, "to-stdout").unwrap();
+        assert_eq!(String::from_utf8(out).unwrap(), "to-stdout\n");
+        assert!(err.is_empty());
+
+        let (mut out, mut err) = (Vec::new(), Vec::new());
+        emit_progress(true, &mut out, &mut err, "to-stderr").unwrap();
+        assert!(out.is_empty());
+        assert_eq!(String::from_utf8(err).unwrap(), "to-stderr\n");
+    }
+
+    #[test]
+    fn read_stdin_reads_and_validates_utf8() {
+        assert_eq!(
+            read_stdin(&mut std::io::Cursor::new(b"hi".to_vec())).unwrap(),
+            "hi"
+        );
+        let err = read_stdin(&mut std::io::Cursor::new(vec![0xff, 0xfe])).unwrap_err();
+        assert!(err.contains("invalid UTF-8"), "{err}");
+    }
+
+    #[test]
+    fn lint_stdin_read_error_exits_error() {
+        // Non-UTF-8 on stdin fails the read; `lint -` reports it under `<stdin>` and exits `Error`
+        // (rather than panicking or silently skipping the input).
+        let host = MockHost::new();
+        let (status, _out, err) =
+            run_capture_stdin(&lint_cli("-", OutputFormat::Text), &host, &[0xff, 0xfe]);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("error: <stdin>"), "{err}");
+        assert!(err.contains("invalid UTF-8"), "{err}");
+    }
+
+    #[test]
+    fn fix_stdin_read_error_exits_error() {
+        // The same failed-read handling for `fix -`: error on stderr, `Error` exit, no document on
+        // stdout.
+        let host = MockHost::new();
+        let c = cli(Command::Fix {
+            paths: vec![PathBuf::from("-")],
+            dry_run: false,
+        });
+        let (status, out, err) = run_capture_stdin(&c, &host, &[0xff, 0xfe]);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("error: <stdin>"), "{err}");
+        assert!(out.is_empty(), "no document should be emitted: {out:?}");
     }
 }

--- a/crates/tzlint_cli/src/cli.rs
+++ b/crates/tzlint_cli/src/cli.rs
@@ -1,9 +1,10 @@
 //! Command-line argument definitions (clap derive).
 //!
 //! The surface mirrors the established `tzlint` UX: a few global options (`--config`,
-//! `--verbose`, `--no-cache`) and the `lint` / `fix` / `init` subcommands. Plugin, rule-
-//! management, and LSP subcommands, plus the SARIF output format, are intentionally out of
-//! scope here and arrive with later milestones.
+//! `--verbose`, `--no-cache`) and the `lint` / `fix` / `init` subcommands. `lint` and `fix` take
+//! files, directories (recursed for Markdown), or glob patterns, and `-` for stdin (see the
+//! per-argument help). Plugin, rule-management, and LSP subcommands, plus the SARIF output
+//! format, are intentionally out of scope here and arrive with later milestones.
 
 use std::path::PathBuf;
 
@@ -36,7 +37,11 @@ pub struct Cli {
 pub enum Command {
     /// Lint files and report diagnostics.
     Lint {
-        /// Files to lint.
+        /// Files, directories, or globs to lint; `-` reads stdin (reported as `<stdin>`).
+        ///
+        /// A directory is searched recursively for `.md`/`.markdown` files (hidden entries and
+        /// symlinks are skipped). Globs (`*`, `?`, `[...]`, `**`) match exactly — quote them so the
+        /// shell does not expand them first.
         #[arg(required = true, value_name = "PATH")]
         paths: Vec<PathBuf>,
 
@@ -47,7 +52,11 @@ pub enum Command {
 
     /// Apply autofixes to files (in place, unless `--dry-run`).
     Fix {
-        /// Files to fix.
+        /// Files, directories, or globs to fix; `-` fixes stdin and writes the result to stdout.
+        ///
+        /// A directory is searched recursively for `.md`/`.markdown` files (hidden entries and
+        /// symlinks are skipped); globs match exactly (quote them). With `--dry-run`, changed files
+        /// are reported instead of written.
         #[arg(required = true, value_name = "PATH")]
         paths: Vec<PathBuf>,
 

--- a/crates/tzlint_cli/src/expand.rs
+++ b/crates/tzlint_cli/src/expand.rs
@@ -1,0 +1,602 @@
+//! Expand the `lint` / `fix` PATH arguments into a concrete, deterministic work list.
+//!
+//! Each argument is one of:
+//! - the stdin sentinel `-` (read once from the injected reader),
+//! - a glob pattern (contains `*`, `?`, or `[`) — matched with `glob::Pattern` against paths
+//!   discovered by walking [`Host::list_dir`] (never `glob::glob()`, which would touch the
+//!   filesystem directly and bypass the io boundary),
+//! - a directory — recursively yields its Markdown files,
+//! - or a literal file path — passed through verbatim (so an existing file behaves exactly as
+//!   before this expansion existed, and a missing one still errors at read time).
+//!
+//! Discovered files are collected into a [`std::collections::BTreeSet`], so the result is sorted
+//! and de-duplicated. Symlinks are never followed (a loop / DoS guard); hidden entries (a leading
+//! `.`) are skipped during discovery, which also keeps `.tzlintcache` / `.tzlintrc*` out.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use tzlint_core::{EntryKind, Host};
+
+/// The stdin sentinel argument.
+const STDIN_ARG: &str = "-";
+/// Hard cap on directory-recursion depth below a search root — cheap insurance against
+/// pathological nesting even though symlinks (the usual cycle source) are never followed.
+const MAX_DEPTH: usize = 64;
+/// Soft cap on discovered files; on reaching it, discovery stops and a note is emitted, so a
+/// run over an unexpectedly huge tree fails visibly rather than exhausting memory.
+const MAX_FILES: usize = 100_000;
+/// Extensions a directory / `**`-recursion picks up, matched case-insensitively.
+const MARKDOWN_EXTENSIONS: [&str; 2] = ["md", "markdown"];
+
+/// The expanded work list.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Inputs {
+    /// Concrete files to lint/fix, lexicographically sorted and de-duplicated.
+    pub files: Vec<PathBuf>,
+    /// Whether stdin (`-`) was among the arguments.
+    pub stdin: bool,
+    /// Best-effort notes to surface on stderr (unreadable subdirectory, depth / file caps).
+    pub notes: Vec<String>,
+}
+
+/// Expand `args` (the user's PATH arguments) relative to `cwd`.
+///
+/// `-` requests stdin (collapsed to a single read). An argument with a glob metacharacter
+/// (`*`, `?`, `[`) is glob-expanded; a listable directory recurses for Markdown files; anything
+/// else is a literal path passed through verbatim (so a missing file still errors at read time).
+pub fn expand(host: &dyn Host, cwd: &Path, args: &[PathBuf]) -> Inputs {
+    let mut walk = Walk {
+        host,
+        files: BTreeSet::new(),
+        notes: Vec::new(),
+        file_cap_hit: false,
+        depth_cap_noted: false,
+    };
+    let mut stdin = false;
+    for arg in args {
+        if arg.as_os_str() == STDIN_ARG {
+            stdin = true;
+            continue;
+        }
+        let as_str = arg.to_string_lossy();
+        if is_glob(&as_str) {
+            walk.glob(cwd, &as_str);
+        } else if host.list_dir(arg).is_ok() {
+            walk.directory(arg);
+        } else {
+            // Not a glob and not a listable directory → a literal file. Pass it through verbatim
+            // (no `cwd.join`, no canonicalization): the read reproduces today's behavior exactly,
+            // surfacing `NotFound` for a genuinely missing path.
+            walk.files.insert(arg.clone());
+        }
+    }
+    Inputs {
+        files: walk.files.into_iter().collect(),
+        stdin,
+        notes: walk.notes,
+    }
+}
+
+/// Whether `s` contains a glob metacharacter.
+fn is_glob(s: &str) -> bool {
+    s.contains(['*', '?', '['])
+}
+
+/// Whether `name` (a single path component) is hidden (a leading dot). Hidden files and
+/// directories are skipped during discovery, which also keeps `.tzlintcache` / `.tzlintrc*` /
+/// `.git` out without special-casing.
+fn is_hidden(name: &str) -> bool {
+    name.starts_with('.')
+}
+
+/// Whether `path`'s extension is a Markdown extension (case-insensitive).
+fn is_markdown(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            MARKDOWN_EXTENSIONS
+                .iter()
+                .any(|candidate| ext.eq_ignore_ascii_case(candidate))
+        })
+}
+
+/// Split a glob pattern into its longest literal directory prefix (used as the walk root, so
+/// `src/**/*.md` does not walk the whole tree) and the remainder after it.
+///
+/// Splitting goes through [`Path::components`] rather than `str::split('/')` so it preserves an
+/// absolute root (`/abs/*.md` → base `/abs`, not the relative `abs`) and recognizes the platform
+/// separator (`\` on Windows). The remainder is rejoined with `/` — the canonical glob separator —
+/// so the `**` / depth detection in [`Walk::glob`] is separator-agnostic.
+fn split_literal_prefix(pattern: &str) -> (PathBuf, String) {
+    use std::path::Component;
+    let mut base = PathBuf::new();
+    let mut remainder: Vec<String> = Vec::new();
+    let mut in_glob = false;
+    for component in Path::new(pattern).components() {
+        let part = component.as_os_str().to_string_lossy();
+        // A root / prefix / `.` / `..` is structural and never a glob; once the glob part has
+        // begun, everything (including a later literal component) belongs to the remainder.
+        let is_literal =
+            !in_glob && (!matches!(component, Component::Normal(_)) || !is_glob(&part));
+        if is_literal {
+            base.push(component.as_os_str());
+        } else {
+            in_glob = true;
+            remainder.push(part.into_owned());
+        }
+    }
+    (base, remainder.join("/"))
+}
+
+/// What a [`Walk`] selects at each file.
+enum Selector<'a> {
+    /// Directory recursion: keep Markdown files.
+    Markdown,
+    /// Glob: keep files whose path matches the pattern.
+    Glob(&'a glob::Pattern),
+}
+
+/// Accumulates discovered files while walking the host's directory tree.
+struct Walk<'a> {
+    host: &'a dyn Host,
+    files: BTreeSet<PathBuf>,
+    notes: Vec<String>,
+    /// Set once the file cap is hit; stops all further discovery.
+    file_cap_hit: bool,
+    /// Set once a depth-cap note has been emitted, to avoid repeating it per branch.
+    depth_cap_noted: bool,
+}
+
+impl Walk<'_> {
+    /// Recurse `dir` for Markdown files.
+    fn directory(&mut self, dir: &Path) {
+        self.descend(dir, dir, 0, MAX_DEPTH, &Selector::Markdown);
+    }
+
+    /// Expand a glob pattern by walking its literal prefix and matching the rest.
+    fn glob(&mut self, cwd: &Path, pattern_str: &str) {
+        let pattern = match glob::Pattern::new(pattern_str) {
+            Ok(pattern) => pattern,
+            Err(error) => {
+                self.notes
+                    .push(format!("invalid glob pattern '{pattern_str}': {error}"));
+                return;
+            }
+        };
+        let (base, remainder) = split_literal_prefix(pattern_str);
+        // `*` / `?` never cross `/` (only `**` does), so a glob with no `**` matches at a fixed
+        // depth below its literal prefix; cap the walk there. With `**`, recurse to the safety cap.
+        let max_depth = if remainder.split('/').any(|component| component == "**") {
+            MAX_DEPTH
+        } else {
+            remainder.matches('/').count().min(MAX_DEPTH)
+        };
+        // A prefix-less pattern (`*.md`, `**/*.md`) anchors its WALK at cwd but matches against
+        // cwd-relative paths, so the matched names line up with the pattern the user wrote.
+        let (emit_root, match_root) = if base.as_os_str().is_empty() {
+            (cwd.to_path_buf(), PathBuf::new())
+        } else {
+            (base.clone(), base)
+        };
+        self.descend(
+            &emit_root,
+            &match_root,
+            0,
+            max_depth,
+            &Selector::Glob(&pattern),
+        );
+    }
+
+    /// List `emit_dir`, select matching files, and recurse into subdirectories (never symlinks,
+    /// never hidden entries) up to `max_depth`. `match_dir` is the path prefix used for glob
+    /// matching (equal to `emit_dir` except for prefix-less globs, which match cwd-relative).
+    fn descend(
+        &mut self,
+        emit_dir: &Path,
+        match_dir: &Path,
+        depth: usize,
+        max_depth: usize,
+        selector: &Selector,
+    ) {
+        if self.file_cap_hit {
+            return;
+        }
+        let mut entries = match self.host.list_dir(emit_dir) {
+            Ok(entries) => entries,
+            Err(error) => {
+                // A glob whose literal prefix does not exist simply matches nothing (like
+                // find/grep) — silent. An unreadable directory reached mid-walk is a warning.
+                if !(depth == 0 && matches!(selector, Selector::Glob(_))) {
+                    self.notes
+                        .push(format!("could not list {}: {error}", emit_dir.display()));
+                }
+                return;
+            }
+        };
+        // Sort so recursion order (and thus any cap notes) is deterministic; the file set is a
+        // BTreeSet, so the final order does not depend on this, but stable behavior is nicer.
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        for entry in entries {
+            if self.file_cap_hit {
+                return;
+            }
+            if is_hidden(&entry.name) {
+                continue;
+            }
+            match entry.kind {
+                // Never follow symlinks: the primary loop / DoS guard.
+                EntryKind::Symlink => continue,
+                EntryKind::File => {
+                    let emit_path = emit_dir.join(&entry.name);
+                    let selected = match selector {
+                        Selector::Markdown => is_markdown(&emit_path),
+                        Selector::Glob(pattern) => {
+                            pattern.matches_path_with(&match_dir.join(&entry.name), match_options())
+                        }
+                    };
+                    if selected {
+                        if self.files.len() >= MAX_FILES {
+                            self.file_cap_hit = true;
+                            self.notes.push(format!(
+                                "stopped after {MAX_FILES} files; narrow the inputs with a more specific glob"
+                            ));
+                            return;
+                        }
+                        self.files.insert(emit_path);
+                    }
+                }
+                EntryKind::Dir => {
+                    if depth + 1 > max_depth {
+                        // Only the safety cap is worth reporting; a glob's natural depth limit
+                        // (e.g. `*.md` not recursing) is expected and silent.
+                        if max_depth == MAX_DEPTH && !self.depth_cap_noted {
+                            self.depth_cap_noted = true;
+                            self.notes
+                                .push(format!("stopped recursing below depth {MAX_DEPTH}"));
+                        }
+                        continue;
+                    }
+                    self.descend(
+                        &emit_dir.join(&entry.name),
+                        &match_dir.join(&entry.name),
+                        depth + 1,
+                        max_depth,
+                        selector,
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Glob match options: `*`/`?` stay within a path component (only `**` crosses `/`); hidden
+/// entries are filtered separately by [`is_hidden`], so leading-dot handling is left default.
+fn match_options() -> glob::MatchOptions {
+    let mut options = glob::MatchOptions::new();
+    options.require_literal_separator = true;
+    options
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tzlint_core::{DirEntry, EntryKind, IoError};
+
+    /// An in-memory tree: `files` maps a path to its contents; `dirs` maps a directory to its
+    /// immediate children. [`TreeHost::new`] synthesizes the `dirs` map from a list of files so a
+    /// test only states the files it cares about.
+    struct TreeHost {
+        files: HashMap<PathBuf, String>,
+        dirs: HashMap<PathBuf, Vec<DirEntry>>,
+    }
+
+    impl TreeHost {
+        fn new(files: &[&str]) -> Self {
+            let mut host = TreeHost {
+                files: HashMap::new(),
+                dirs: HashMap::new(),
+            };
+            for path in files {
+                host.add_file(path);
+            }
+            host
+        }
+
+        /// Register a file and every (parent → child) directory hop up to (but not including) the
+        /// empty root, classifying the leaf as `File` and the intermediates as `Dir`.
+        fn add_file(&mut self, path: &str) {
+            let leaf = PathBuf::from(path);
+            self.files.insert(leaf.clone(), "x".to_string());
+            let mut child = leaf.clone();
+            while let Some(parent) = child.parent() {
+                if parent.as_os_str().is_empty() {
+                    break;
+                }
+                if let Some(name) = child.file_name() {
+                    let name = name.to_string_lossy().into_owned();
+                    let kind = if child == leaf {
+                        EntryKind::File
+                    } else {
+                        EntryKind::Dir
+                    };
+                    let children = self.dirs.entry(parent.to_path_buf()).or_default();
+                    if !children.iter().any(|e| e.name == name) {
+                        children.push(DirEntry { name, kind });
+                    }
+                }
+                child = parent.to_path_buf();
+            }
+        }
+
+        /// Add a raw child entry to `dir` (for symlinks and unreadable-subdir fixtures).
+        fn add_entry(&mut self, dir: &str, name: &str, kind: EntryKind) {
+            self.dirs
+                .entry(PathBuf::from(dir))
+                .or_default()
+                .push(DirEntry {
+                    name: name.to_string(),
+                    kind,
+                });
+        }
+    }
+
+    impl Host for TreeHost {
+        fn read_to_string(&self, path: &Path, _limit: usize) -> Result<String, IoError> {
+            self.files.get(path).cloned().ok_or(IoError::NotFound)
+        }
+        fn write_atomic(&self, _: &Path, _: &[u8]) -> Result<(), IoError> {
+            Ok(())
+        }
+        fn exists(&self, path: &Path) -> bool {
+            self.files.contains_key(path) || self.dirs.contains_key(path)
+        }
+        fn list_dir(&self, dir: &Path) -> Result<Vec<DirEntry>, IoError> {
+            self.dirs.get(dir).cloned().ok_or(IoError::NotFound)
+        }
+    }
+
+    /// `cwd` used when a bare (prefix-less) glob must anchor somewhere.
+    const CWD: &str = "/work";
+
+    fn run(host: &TreeHost, args: &[&str]) -> Inputs {
+        let args: Vec<PathBuf> = args.iter().map(PathBuf::from).collect();
+        expand(host, Path::new(CWD), &args)
+    }
+
+    fn paths(strs: &[&str]) -> Vec<PathBuf> {
+        strs.iter().map(PathBuf::from).collect()
+    }
+
+    #[test]
+    fn bare_glob_matches_top_level_only_anchored_at_cwd() {
+        // A prefix-less `*.md` has no literal directory, so it anchors at cwd and yields cwd-joined
+        // paths; `*` does not cross `/`, so nested files are not matched.
+        let host = TreeHost::new(&["/work/a.md", "/work/b.md", "/work/c.txt", "/work/sub/d.md"]);
+        let out = run(&host, &["*.md"]);
+        assert_eq!(out.files, paths(&["/work/a.md", "/work/b.md"]));
+        assert!(!out.stdin);
+    }
+
+    #[test]
+    fn double_star_glob_with_literal_prefix_recurses() {
+        // `src/**/*.md` walks from the literal prefix `src` and recurses; the top-level `a.md`
+        // outside `src` is not in scope, and `.txt` does not match the pattern.
+        let host = TreeHost::new(&["a.md", "src/a.md", "src/lib/b.md", "src/lib/c.txt"]);
+        let out = run(&host, &["src/**/*.md"]);
+        assert_eq!(out.files, paths(&["src/a.md", "src/lib/b.md"]));
+    }
+
+    #[test]
+    fn glob_matches_exactly_no_implicit_markdown_filter() {
+        // A glob means exactly what it says: `docs/**` matches every file under docs, including
+        // `.txt`. (Only DIRECTORY args default to Markdown — see `directory_arg_*`.)
+        let host = TreeHost::new(&["docs/a.md", "docs/lib/b.markdown", "docs/c.txt"]);
+        let out = run(&host, &["docs/**"]);
+        assert_eq!(
+            out.files,
+            paths(&["docs/a.md", "docs/c.txt", "docs/lib/b.markdown"])
+        );
+    }
+
+    #[test]
+    fn directory_arg_recurses_markdown_only() {
+        // A literal directory yields its `.md`/`.markdown` files recursively; other extensions,
+        // hidden files, and hidden subdirectories are skipped.
+        let mut host = TreeHost::new(&[
+            "docs/a.md",
+            "docs/lib/b.markdown",
+            "docs/c.txt",
+            "docs/.hidden.md",
+            "docs/.git/x.md",
+        ]);
+        // `.git` is registered as a hidden dir via add_file already; make sure a normal file there
+        // would be excluded too (it is, since `.git` is skipped before recursion).
+        let _ = &mut host;
+        let out = run(&host, &["docs"]);
+        assert_eq!(out.files, paths(&["docs/a.md", "docs/lib/b.markdown"]));
+    }
+
+    #[test]
+    fn directory_arg_markdown_extension_is_case_insensitive() {
+        let host = TreeHost::new(&["docs/README.MD", "docs/x.MARKDOWN", "docs/y.TXT"]);
+        let out = run(&host, &["docs"]);
+        assert_eq!(out.files, paths(&["docs/README.MD", "docs/x.MARKDOWN"]));
+    }
+
+    #[test]
+    fn directory_arg_never_yields_cache_or_config_dotfiles() {
+        let host = TreeHost::new(&[
+            "p/a.md",
+            "p/.tzlintcache",
+            "p/.tzlintrc.json",
+            "p/.gitignore",
+        ]);
+        let out = run(&host, &["p"]);
+        assert_eq!(out.files, paths(&["p/a.md"]));
+    }
+
+    #[test]
+    fn literal_file_is_passed_through_verbatim() {
+        // No glob chars and not a listable directory → the exact PathBuf, so existing single-file
+        // behavior (and labeling) is unchanged.
+        let host = TreeHost::new(&["a.md"]);
+        let out = run(&host, &["a.md"]);
+        assert_eq!(out.files, paths(&["a.md"]));
+        assert!(out.notes.is_empty());
+    }
+
+    #[test]
+    fn missing_literal_is_passed_through_for_the_reader_to_error() {
+        // expand does not probe file existence; a missing literal flows through and the caller's
+        // read surfaces the NotFound error (preserving today's missing-file behavior).
+        let host = TreeHost::new(&[]);
+        let out = run(&host, &["nope.md"]);
+        assert_eq!(out.files, paths(&["nope.md"]));
+    }
+
+    #[test]
+    fn glob_matching_nothing_yields_no_files() {
+        let host = TreeHost::new(&["/work/a.txt"]);
+        let out = run(&host, &["*.md"]);
+        assert!(out.files.is_empty());
+        assert!(out.notes.is_empty());
+    }
+
+    #[test]
+    fn glob_with_nonexistent_base_is_silent() {
+        // A glob whose literal prefix does not exist matches nothing WITHOUT a note (like
+        // find/grep) — the unreadable-directory warning is only for subdirectories reached
+        // mid-walk, not the top-level base.
+        let host = TreeHost::new(&["docs/a.md"]);
+        let out = run(&host, &["nope/**/*.md"]);
+        assert!(out.files.is_empty(), "{:?}", out.files);
+        assert!(
+            out.notes.is_empty(),
+            "no warning for an absent base: {:?}",
+            out.notes
+        );
+    }
+
+    #[test]
+    fn overlapping_dir_and_glob_lint_each_file_once() {
+        // `docs` (dir) and `docs/**/*.md` (glob) both yield docs/a.md → deduped by the BTreeSet.
+        let host = TreeHost::new(&["docs/a.md", "docs/lib/b.md"]);
+        let out = run(&host, &["docs", "docs/**/*.md"]);
+        assert_eq!(out.files, paths(&["docs/a.md", "docs/lib/b.md"]));
+    }
+
+    #[test]
+    fn result_is_deterministic_and_sorted() {
+        let host = TreeHost::new(&["docs/z.md", "docs/a.md", "docs/m.md"]);
+        let first = run(&host, &["docs"]);
+        let second = run(&host, &["docs"]);
+        assert_eq!(first.files, second.files);
+        assert_eq!(first.files, paths(&["docs/a.md", "docs/m.md", "docs/z.md"]));
+    }
+
+    #[test]
+    fn directory_symlink_is_not_followed() {
+        // `docs` contains a symlink child `link` (to anything). The walker must not descend into
+        // it, so a file that would only be reachable through the link is absent.
+        let mut host = TreeHost::new(&["docs/a.md", "linktarget/secret.md"]);
+        host.add_entry("docs", "link", EntryKind::Symlink);
+        // Even if the link "pointed" at linktarget (registered as a real dir), we never recurse.
+        let out = run(&host, &["docs"]);
+        assert_eq!(out.files, paths(&["docs/a.md"]));
+    }
+
+    #[test]
+    fn recursion_depth_is_capped_with_a_note() {
+        // Build a chain deeper than the cap under `deep/`; discovery stops and notes it, without
+        // panicking, and still completes.
+        let mut deep = String::from("deep");
+        for i in 0..70 {
+            deep.push_str(&format!("/d{i}"));
+        }
+        let leaf = format!("{deep}/x.md");
+        let host = TreeHost::new(&[&leaf]);
+        let out = run(&host, &["deep"]);
+        // The deeply-nested file is beyond the cap, so it is not collected, and a note explains it.
+        assert!(out.files.is_empty(), "{:?}", out.files);
+        assert!(
+            out.notes.iter().any(|n| n.contains("depth")),
+            "expected a depth-cap note, got {:?}",
+            out.notes
+        );
+    }
+
+    #[test]
+    fn unreadable_nested_subdir_notes_and_continues() {
+        // `docs` lists a `secret` subdir that cannot be listed (no dirs entry → Err); its sibling
+        // file is still collected and a warning note is emitted.
+        let mut host = TreeHost::new(&["docs/a.md"]);
+        host.add_entry("docs", "secret", EntryKind::Dir); // but no dirs[docs/secret] registered
+        let out = run(&host, &["docs"]);
+        assert_eq!(out.files, paths(&["docs/a.md"]));
+        assert!(
+            out.notes.iter().any(|n| n.contains("secret")),
+            "expected an unreadable-subdir note, got {:?}",
+            out.notes
+        );
+    }
+
+    #[test]
+    fn unreadable_or_missing_top_level_dir_becomes_a_literal() {
+        // A non-glob arg that is not a listable directory is treated as a literal path (the read
+        // will error later); expand itself does not fail.
+        let host = TreeHost::new(&[]);
+        let out = run(&host, &["unreadable"]);
+        assert_eq!(out.files, paths(&["unreadable"]));
+    }
+
+    #[test]
+    fn stdin_sentinel_sets_the_flag_and_is_not_a_file() {
+        let host = TreeHost::new(&["a.md"]);
+        let out = run(&host, &["-", "a.md"]);
+        assert!(out.stdin);
+        assert_eq!(out.files, paths(&["a.md"]));
+    }
+
+    #[test]
+    fn repeated_stdin_sentinels_collapse() {
+        let host = TreeHost::new(&[]);
+        let out = run(&host, &["-", "-"]);
+        assert!(out.stdin);
+        assert!(out.files.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn absolute_glob_preserves_the_root() {
+        // The leading `/` must survive prefix extraction so the walk anchors at the real root and
+        // the pattern matches the absolute candidate (regression: a naive `split('/')` +
+        // `PathBuf::push("")` dropped the slash, silently matching nothing).
+        let host = TreeHost::new(&["/abs/a.md", "/abs/b.txt"]);
+        let out = run(&host, &["/abs/*.md"]);
+        assert_eq!(out.files, paths(&["/abs/a.md"]));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn split_literal_prefix_keeps_an_absolute_base() {
+        let (base, remainder) = split_literal_prefix("/abs/*.md");
+        assert!(base.is_absolute(), "base should stay absolute: {base:?}");
+        assert_eq!(base, PathBuf::from("/abs"));
+        assert_eq!(remainder, "*.md");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn split_literal_prefix_handles_backslash_separators() {
+        // On Windows the platform separator is `\`; the prefix split must recognize it so a
+        // backslash glob is not collapsed into a single (non-recursing) component.
+        let (base, remainder) = split_literal_prefix(r"src\**\*.md");
+        assert_eq!(base, PathBuf::from("src"));
+        assert!(
+            remainder.split('/').any(|component| component == "**"),
+            "remainder should expose the `**` component: {remainder}"
+        );
+    }
+}

--- a/crates/tzlint_cli/src/main.rs
+++ b/crates/tzlint_cli/src/main.rs
@@ -18,6 +18,7 @@ use crate::cli::Cli;
 
 mod app;
 mod cli;
+mod expand;
 mod output;
 mod rules;
 
@@ -27,8 +28,14 @@ fn main() -> ExitCode {
     // Resolve the working directory once, here at the edge, and pass it in — the orchestration
     // stays independent of process-global state (and so hermetically testable).
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let mut stdin = std::io::stdin().lock();
     let mut stdout = std::io::stdout().lock();
     let mut stderr = std::io::stderr().lock();
-    let status = app::run(&cli, &host, &cwd, &mut stdout, &mut stderr);
+    let mut streams = app::Streams {
+        stdin: &mut stdin,
+        stdout: &mut stdout,
+        stderr: &mut stderr,
+    };
+    let status = app::run(&cli, &host, &cwd, &mut streams);
     ExitCode::from(status.code())
 }

--- a/crates/tzlint_core/src/io.rs
+++ b/crates/tzlint_core/src/io.rs
@@ -69,6 +69,29 @@ mod error_tests {
     }
 }
 
+/// One immediate child returned by [`Host::list_dir`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirEntry {
+    /// The final path component only (e.g. `"a.md"`), never a full path.
+    pub name: String,
+    /// What the entry resolves to. A directory walker uses this to decide whether to recurse
+    /// and whether to skip symlinks.
+    pub kind: EntryKind,
+}
+
+/// The classification of a [`DirEntry`]. A symlink is reported as [`EntryKind::Symlink`]
+/// regardless of its target, so a walker can refuse to follow it (loop / DoS guard) without a
+/// second `stat`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    /// A regular file.
+    File,
+    /// A directory.
+    Dir,
+    /// A symlink (to anything). Walkers never follow these.
+    Symlink,
+}
+
 /// The environment a TsuzuLint host provides: bounded reads and atomic writes.
 ///
 /// Embedders (native CLI/LSP, Node, browser) implement this so the core never touches the
@@ -83,13 +106,26 @@ pub trait Host {
     /// files cheaply without reading them — so checking presence still goes through the
     /// boundary rather than touching `std::fs` directly.
     fn exists(&self, path: &Path) -> bool;
+    /// List the immediate children of `dir` (a single level, **not** recursive). The CLI's
+    /// glob / directory expansion drives recursion itself on top of this, so depth, dedup,
+    /// and symlink policy stay out of the boundary.
+    ///
+    /// The default returns an `Err`, so a non-filesystem host (a browser/wasm embedder, the
+    /// LSP scaffold) need not implement it — directory expansion simply isn't available there.
+    /// [`NativeHost`] overrides it. A missing `dir` should map to [`IoError::NotFound`].
+    fn list_dir(&self, dir: &Path) -> Result<Vec<DirEntry>, IoError> {
+        let _ = dir;
+        Err(IoError::Other(
+            "directory listing is not supported by this host".to_string(),
+        ))
+    }
 }
 
 // The real-filesystem host. Not compiled for `wasm32`, where the embedder injects its own
 // `Host` (there is no ambient filesystem in the browser).
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
-    use super::{Host, IoError, Path};
+    use super::{DirEntry, EntryKind, Host, IoError, Path};
     use std::fs::{File, OpenOptions};
     use std::io::{Read, Write};
     use std::path::PathBuf;
@@ -132,6 +168,30 @@ mod native {
             // `try_exists` follows symlinks and distinguishes "absent" from "couldn't tell";
             // a permission/other error is treated as "not present" (best-effort discovery).
             path.try_exists().unwrap_or(false)
+        }
+
+        fn list_dir(&self, dir: &Path) -> Result<Vec<DirEntry>, IoError> {
+            // The single allowed `read_dir` call site (the io boundary); clippy's
+            // `disallowed_methods` bans it everywhere else, mirroring `read`/`write`.
+            #[allow(clippy::disallowed_methods)]
+            let read = std::fs::read_dir(dir)?;
+            let mut entries = Vec::new();
+            for entry in read {
+                let entry = entry?;
+                let name = entry.file_name().to_string_lossy().into_owned();
+                // `file_type()` does NOT follow the link, so a symlink (even to a directory)
+                // is reported as `Symlink` and the walker will not descend into it.
+                let file_type = entry.file_type()?;
+                let kind = if file_type.is_symlink() {
+                    EntryKind::Symlink
+                } else if file_type.is_dir() {
+                    EntryKind::Dir
+                } else {
+                    EntryKind::File
+                };
+                entries.push(DirEntry { name, kind });
+            }
+            Ok(entries)
         }
     }
 
@@ -239,7 +299,7 @@ mod native {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::io::{IoError, MAX_FILE};
+        use crate::io::{DirEntry, EntryKind, IoError, MAX_FILE};
         use std::sync::atomic::{AtomicU64, Ordering};
 
         /// A unique, freshly-created temp directory (cleaned up by the caller).
@@ -308,10 +368,12 @@ mod native {
             let target = dir.join("a-directory");
             std::fs::create_dir_all(&target).unwrap();
             assert!(NativeHost.write_atomic(&target, b"data").is_err());
-            let leaked = std::fs::read_dir(&dir)
+            // Dogfood `list_dir` (rather than raw `read_dir`, now disallowed) to scan for a leak.
+            let leaked = NativeHost
+                .list_dir(&dir)
                 .unwrap()
-                .filter_map(Result::ok)
-                .any(|e| e.file_name().to_string_lossy().contains("tzlint-tmp"));
+                .iter()
+                .any(|e| e.name.contains("tzlint-tmp"));
             assert!(!leaked, "temp file leaked on the error path");
             std::fs::remove_dir_all(&dir).ok();
         }
@@ -400,6 +462,49 @@ mod native {
             host.write_atomic(&path, b"content").unwrap();
             assert_eq!(host.read_to_string(&path, usize::MAX).unwrap(), "content");
             std::fs::remove_dir_all(&dir).ok();
+        }
+
+        /// Index a listing by name so assertions don't depend on `read_dir`'s arbitrary order.
+        fn by_name(entries: Vec<DirEntry>) -> std::collections::BTreeMap<String, EntryKind> {
+            entries.into_iter().map(|e| (e.name, e.kind)).collect()
+        }
+
+        #[test]
+        fn list_dir_classifies_files_dirs_and_symlinks() {
+            // A regular file is `File`, a subdirectory is `Dir`, and (on Unix) a symlink is
+            // `Symlink` — classified WITHOUT following the link, so the walker can refuse it.
+            let dir = temp_dir();
+            let host = NativeHost;
+            host.write_atomic(&dir.join("a.md"), b"x").unwrap();
+            std::fs::create_dir(dir.join("sub")).unwrap();
+
+            let entries = by_name(host.list_dir(&dir).unwrap());
+            assert_eq!(entries.get("a.md"), Some(&EntryKind::File));
+            assert_eq!(entries.get("sub"), Some(&EntryKind::Dir));
+
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::symlink;
+                symlink(dir.join("a.md"), dir.join("link")).unwrap();
+                let entries = by_name(host.list_dir(&dir).unwrap());
+                assert_eq!(
+                    entries.get("link"),
+                    Some(&EntryKind::Symlink),
+                    "a symlink must be classified as Symlink, not its target kind"
+                );
+            }
+
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn list_dir_missing_is_not_found() {
+            // Listing a path that does not exist maps to `NotFound` (via `From<io::Error>`).
+            let host = NativeHost;
+            assert!(matches!(
+                host.list_dir(Path::new("/no/such/tzlint/dir/zzz")),
+                Err(IoError::NotFound)
+            ));
         }
     }
 }

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -32,6 +32,6 @@ pub use config::{
 };
 pub use engine::Engine;
 pub use fix::{FixPass, MAX_FIX_PASSES, apply_fixes, fix};
-pub use io::{Host, IoError};
+pub use io::{DirEntry, EntryKind, Host, IoError};
 pub use parse::{ParseError, parse};
 pub use position::LineIndex;


### PR DESCRIPTION
## Summary

Extends the `tzlint` CLI so `lint` / `fix` PATH arguments accept, beyond literal files:

- **Glob patterns** — `*.md`, `src/**/*.md`, `docs/**`. Quote them so the shell doesn't expand first. They match **exactly** (no implicit Markdown filter): `docs/**` matches `.txt` too — use `docs/**/*.md` or a directory arg for Markdown only.
- **Directories** — recursed for `.md` / `.markdown` (case-insensitive); hidden entries (leading `.`) and symlinks are skipped.
- **stdin** via `-` — reported under the label `<stdin>`. `fix -` writes the fixed document to **stdout** (a pass-through filter, echoing even an unchanged document) and routes progress/summary to **stderr** so stdout stays a pure artifact. `fix --dry-run -` emits no document.

This is the user-chosen continuation of the M1g follow-ups (after `options` / `extends` / `cache`); call it **M1g-d**.

## Design

- **I/O boundary preserved.** Directory listing is a new `Host::list_dir(&Path) -> Result<Vec<DirEntry>, IoError>` (`DirEntry { name, kind: EntryKind::{File, Dir, Symlink} }`), **defaulted to an "unsupported" `Err`** so non-filesystem hosts (a wasm/browser embedder, the LSP scaffold) need not implement it. `NativeHost` backs it with `std::fs::read_dir`, which is added to `clippy.toml`'s `disallowed-methods` (the io-guard grep already covers it via the `read` prefix) — so the only `read_dir` call site is the io module.
- **Core stays wasm-clean, zero new core deps.** All walk / glob / stdin logic lives in a **CLI-only** module `crates/tzlint_cli/src/expand.rs`. It matches with `glob::Pattern` (`require_literal_separator: true`, so `*`/`?` stay within a path component and only `**` crosses `/`) over entries discovered through `Host::list_dir` — it **never** calls `glob::glob()` (which would touch `std::fs` directly and bypass the boundary). `glob = "0.3"` is a CLI-only dependency.
- **Safety.** Symlinks are never followed (loop / DoS guard); recursion is capped at depth 64 and 100 000 files (both warn, non-fatal). Discovered files go through a `BTreeSet` → deterministic, sorted, de-duplicated.
- **Backward compatible.** A literal file path is read verbatim (no `cwd.join`, no canonicalization) and labeled verbatim; a missing literal still errors at read time → exit `Error`. The `run` entry point gained an injected `stdin` via a small `Streams { stdin, stdout, stderr }` bundle, keeping the orchestration hermetically testable.

## Process

Designed and reviewed with multi-agent workflows (the repo's practice for substantial logic). The adversarial post-implementation review confirmed and fixed **one real bug**: `split_literal_prefix` dropped the leading `/` on absolute globs (`/abs/*.md`) and missed `\` separators on Windows → a silent zero-match. Fixed by switching to `Path::components()` (preserves the root and the platform separator); regression tests added. Four other findings were refuted on verification.

## Testing

- `just check` green: `rustfmt`, `clippy -D warnings`, `cargo nextest` (264), doctests.
- `tzlint_core` builds for `wasm32-unknown-unknown`; io-guard grep clean; `cargo deny check` ok.
- Real-binary end-to-end check: recursive **absolute** glob, directory recursion, stdin linting, and `fix -` pass-through all behave as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * glob（`*`/`?`/`[...]`/`**`）でのファイル指定を拡張し、ディレクトリ再帰（Markdownのみ）・隠しエントリ/シンボリックリンクのスキップ・探索上限（深さ/件数）を導入しました
  * `-`（stdin）を先に処理し `<stdin>` として扱うように改善、stdin の UTF‑8 検証を追加
  * `fix -` は文書を stdout に出力し、進捗/要約は stderr に表示。`--dry-run` は書き込みせず変更予定のみ報告

* **Documentation**
  * `lint`/`fix` の PATH ヘルプを更新し、受け付け対象（ファイル/ディレクトリ/グロブ/`-`）と挙動を明記しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->