### PR TITLE
feat(cli): SARIF output and a `rules` subcommand (M1g-e/f)

### DIFF
--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -169,6 +169,9 @@ fn lint(
     match format {
         OutputFormat::Text => output::render_text(stdout, &reports).map_err(|e| e.to_string())?,
         OutputFormat::Json => output::render_json(stdout, &reports).map_err(|e| e.to_string())?,
+        OutputFormat::Sarif => {
+            output::render_sarif(stdout, &reports).map_err(|e| e.to_string())?;
+        }
     }
 
     let has_findings = reports.iter().any(|report| !report.diagnostics.is_empty());
@@ -688,6 +691,34 @@ mod tests {
         assert!(value.is_array());
         assert_eq!(value[0]["path"], "a.md");
         assert_eq!(value[0]["diagnostics"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn lint_sarif_output_is_a_valid_log_with_results() {
+        // `--format sarif` emits a SARIF 2.1.0 log; the half-width kana triggers `no-hankaku-kana`,
+        // which surfaces as one result referencing that rule.
+        let host = MockHost::with("a.md", "ﾊﾛｰ\n");
+        let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Sarif), &host);
+        assert_eq!(status, ExitStatus::Findings);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["version"], "2.1.0");
+        assert_eq!(value["runs"][0]["tool"]["driver"]["name"], "tzlint");
+        let result = &value["runs"][0]["results"][0];
+        assert_eq!(result["ruleId"], "no-hankaku-kana");
+        assert_eq!(
+            result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
+            "a.md"
+        );
+    }
+
+    #[test]
+    fn lint_sarif_clean_file_has_no_results() {
+        // A clean file still produces a well-formed (empty-results) SARIF log and exits `Clean`.
+        let host = MockHost::with("a.md", "ただのテキストです。\n");
+        let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Sarif), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(value["runs"][0]["results"], serde_json::json!([]));
     }
 
     #[test]

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -26,10 +26,10 @@ use tzlint_core::{
 };
 use tzlint_pdk::{Diagnostic, Rule};
 
-use crate::cli::{Cli, Command, OutputFormat};
+use crate::cli::{Cli, Command, OutputFormat, RuleListFormat, RulesCommand};
 use crate::expand;
 use crate::output::{self, FileReport};
-use crate::rules::{resolve_rules, unknown_rule_ids};
+use crate::rules::{resolve_rules, rule_info, rule_infos, unknown_rule_ids};
 
 /// The path label used for diagnostics linted from standard input.
 const STDIN_LABEL: &str = "<stdin>";
@@ -83,6 +83,7 @@ pub fn run(cli: &Cli, host: &dyn Host, cwd: &Path, streams: &mut Streams) -> Exi
         Command::Lint { paths, format } => lint(cli, host, cwd, paths, *format, streams),
         Command::Fix { paths, dry_run } => fix(cli, host, cwd, paths, *dry_run, streams),
         Command::Init { force } => init(host, cwd, *force, streams.stdout, streams.stderr),
+        Command::Rules { command } => rules_cmd(cli, host, cwd, command, streams),
     };
     match result {
         Ok(status) => status,
@@ -406,6 +407,49 @@ fn init(
     Ok(ExitStatus::Clean)
 }
 
+/// `rules`: report the built-in rule set under the resolved config — the full list or one rule's
+/// details. Reads the same config as `lint`/`fix` (so it answers "what runs for this project?")
+/// and warns about unknown config rule ids. A clean run exits `Clean`; an unknown `explain` id
+/// exits `Error`.
+fn rules_cmd(
+    cli: &Cli,
+    host: &dyn Host,
+    cwd: &Path,
+    command: &RulesCommand,
+    streams: &mut Streams,
+) -> Result<ExitStatus, String> {
+    let stdout: &mut dyn Write = &mut *streams.stdout;
+    let stderr: &mut dyn Write = &mut *streams.stderr;
+    let config = load_config(cli, host, cwd, stderr)?;
+    note_unknown_rules(&config, stderr);
+    match command {
+        RulesCommand::List { format } => {
+            let infos = rule_infos(&config);
+            match format {
+                RuleListFormat::Text => {
+                    output::render_rule_list_text(stdout, &infos).map_err(|e| e.to_string())?;
+                }
+                RuleListFormat::Json => {
+                    output::render_rule_list_json(stdout, &infos).map_err(|e| e.to_string())?;
+                }
+            }
+            Ok(ExitStatus::Clean)
+        }
+        RulesCommand::Explain { id } => match rule_info(&config, id) {
+            Some(info) => {
+                output::render_rule_explain(stdout, &info).map_err(|e| e.to_string())?;
+                Ok(ExitStatus::Clean)
+            }
+            None => {
+                // Not a built-in rule (likely a typo). Name it and exit `Error` rather than
+                // printing a misleading "all defaults" block for a rule that does not exist.
+                let _ = writeln!(stderr, "error: unknown rule '{id}'");
+                Ok(ExitStatus::Error)
+            }
+        },
+    }
+}
+
 /// Resolve the configuration: read `--config` if given (format inferred from its name, JSONC
 /// otherwise), else walk up from the working directory via [`discover`], else the default.
 fn load_config(
@@ -586,6 +630,18 @@ mod tests {
         cli(Command::Lint {
             paths: vec![PathBuf::from(path)],
             format,
+        })
+    }
+
+    fn rules_list_cli(format: RuleListFormat) -> Cli {
+        cli(Command::Rules {
+            command: RulesCommand::List { format },
+        })
+    }
+
+    fn rules_explain_cli(id: &str) -> Cli {
+        cli(Command::Rules {
+            command: RulesCommand::Explain { id: id.to_string() },
         })
     }
 
@@ -1174,6 +1230,90 @@ mod tests {
         assert_eq!(status, ExitStatus::Error);
         assert!(err.contains("error: <stdin>"), "{err}");
         assert!(err.contains("invalid UTF-8"), "{err}");
+    }
+
+    // --- `rules` subcommand (M1g follow-up) ---
+
+    #[test]
+    fn rules_list_text_defaults_to_all_enabled() {
+        use tzlint_rules::RULE_IDS;
+        let host = MockHost::new();
+        let (status, out, _err) = run_capture(&rules_list_cli(RuleListFormat::Text), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(
+            out.contains(&format!(
+                "{} built-in rule(s), {} enabled",
+                RULE_IDS.len(),
+                RULE_IDS.len()
+            )),
+            "{out}"
+        );
+        assert!(
+            out.lines()
+                .any(|l| l.contains("no-hankaku-kana") && l.contains("on")),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn rules_list_reflects_a_config_disable() {
+        // `rules list` honors the resolved config: a rule turned off shows as disabled.
+        let host = MockHost::new();
+        host.put("off.json", "{ \"rules\": { \"no-hankaku-kana\": false } }");
+        let mut c = rules_list_cli(RuleListFormat::Text);
+        c.config = Some(PathBuf::from("off.json"));
+        let (status, out, _err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(
+            out.lines()
+                .any(|l| l.contains("no-hankaku-kana") && l.contains("off")),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn rules_list_json_is_an_array_of_rule_objects() {
+        let host = MockHost::new();
+        let (status, out, _err) = run_capture(&rules_list_cli(RuleListFormat::Json), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        let value: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(value.is_array());
+        assert_eq!(value[0]["id"], "sentence-length");
+        assert_eq!(value[0]["enabled"], true);
+    }
+
+    #[test]
+    fn rules_explain_known_rule_shows_details() {
+        let host = MockHost::new();
+        let (status, out, _err) = run_capture(&rules_explain_cli("max-ten"), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(out.contains("rule:     max-ten"), "{out}");
+        assert!(out.contains("status:   enabled"), "{out}");
+        assert!(out.contains("severity:"), "{out}");
+    }
+
+    #[test]
+    fn rules_explain_unknown_rule_exits_error() {
+        let host = MockHost::new();
+        let (status, _out, err) = run_capture(&rules_explain_cli("no-such-rule"), &host);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("unknown rule 'no-such-rule'"), "{err}");
+    }
+
+    #[test]
+    fn rules_explain_reflects_config_options() {
+        // `explain` surfaces the config-supplied options for a rule.
+        let host = MockHost::new();
+        host.put(
+            "strict.json",
+            "{ \"rules\": { \"max-ten\": { \"options\": { \"max\": 0 } } } }",
+        );
+        let mut c = rules_explain_cli("max-ten");
+        c.config = Some(PathBuf::from("strict.json"));
+        let (status, out, _err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(out.contains("\"max\":0"), "{out}");
+        assert!(out.contains("from config"), "{out}");
     }
 
     #[test]

--- a/crates/tzlint_cli/src/cli.rs
+++ b/crates/tzlint_cli/src/cli.rs
@@ -3,8 +3,8 @@
 //! The surface mirrors the established `tzlint` UX: a few global options (`--config`,
 //! `--verbose`, `--no-cache`) and the `lint` / `fix` / `init` subcommands. `lint` and `fix` take
 //! files, directories (recursed for Markdown), or glob patterns, and `-` for stdin (see the
-//! per-argument help). Plugin, rule-management, and LSP subcommands, plus the SARIF output
-//! format, are intentionally out of scope here and arrive with later milestones.
+//! per-argument help); `lint` renders text, JSON, or SARIF. Plugin, rule-management, and LSP
+//! subcommands are intentionally out of scope here and arrive with later milestones.
 
 use std::path::PathBuf;
 
@@ -80,4 +80,6 @@ pub enum OutputFormat {
     Text,
     /// A JSON array of `{ path, diagnostics }` objects.
     Json,
+    /// A SARIF 2.1.0 log (for CI integrations such as GitHub code scanning).
+    Sarif,
 }

--- a/crates/tzlint_cli/src/cli.rs
+++ b/crates/tzlint_cli/src/cli.rs
@@ -1,10 +1,11 @@
 //! Command-line argument definitions (clap derive).
 //!
 //! The surface mirrors the established `tzlint` UX: a few global options (`--config`,
-//! `--verbose`, `--no-cache`) and the `lint` / `fix` / `init` subcommands. `lint` and `fix` take
-//! files, directories (recursed for Markdown), or glob patterns, and `-` for stdin (see the
-//! per-argument help); `lint` renders text, JSON, or SARIF. Plugin, rule-management, and LSP
-//! subcommands are intentionally out of scope here and arrive with later milestones.
+//! `--verbose`, `--no-cache`) and the `lint` / `fix` / `init` / `rules` subcommands. `lint` and
+//! `fix` take files, directories (recursed for Markdown), or glob patterns, and `-` for stdin
+//! (see the per-argument help); `lint` renders text, JSON, or SARIF. `rules list` / `rules
+//! explain` report the built-in rule set under the resolved config. Plugin and LSP subcommands
+//! are intentionally out of scope here and arrive with later milestones.
 
 use std::path::PathBuf;
 
@@ -71,6 +72,32 @@ pub enum Command {
         #[arg(long)]
         force: bool,
     },
+
+    /// Inspect the built-in rule set: which rules run, and at what severity, under the
+    /// resolved config (honors `--config` / discovery).
+    Rules {
+        /// What to inspect (`list` or `explain`).
+        #[command(subcommand)]
+        command: RulesCommand,
+    },
+}
+
+/// The `rules` subcommands.
+#[derive(Subcommand, Debug)]
+pub enum RulesCommand {
+    /// List every built-in rule and whether it is enabled under the resolved config.
+    List {
+        /// Output format.
+        #[arg(short, long, default_value = "text")]
+        format: RuleListFormat,
+    },
+
+    /// Show one rule's effective state: status, severity, and config-supplied options.
+    Explain {
+        /// The rule id to explain (e.g. `max-ten`).
+        #[arg(value_name = "RULE")]
+        id: String,
+    },
 }
 
 /// How `lint` renders its diagnostics.
@@ -82,4 +109,13 @@ pub enum OutputFormat {
     Json,
     /// A SARIF 2.1.0 log (for CI integrations such as GitHub code scanning).
     Sarif,
+}
+
+/// How `rules list` renders the rule table. (No SARIF — it is not a diagnostic stream.)
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub enum RuleListFormat {
+    /// Aligned `id  on|off  severity` columns plus a summary line.
+    Text,
+    /// A JSON array of `{ id, enabled, severity }` objects.
+    Json,
 }

--- a/crates/tzlint_cli/src/main.rs
+++ b/crates/tzlint_cli/src/main.rs
@@ -1,9 +1,9 @@
 //! `tzlint` — the TsuzuLint command-line binary.
 //!
-//! Wires the `lint` / `fix` / `init` subcommands over `tzlint_core`: config discovery, the
-//! parse → archive → `Engine::lint` pipeline (with the in-memory document cache), autofix, and
-//! text / JSON / SARIF output via the position mapper. All file access goes through the `Host`
-//! boundary (`NativeHost`), never raw `std::fs`.
+//! Wires the `lint` / `fix` / `init` / `rules` subcommands over `tzlint_core`: config discovery,
+//! the parse → archive → `Engine::lint` pipeline (with the in-memory document cache), autofix,
+//! and text / JSON / SARIF output via the position mapper. `rules` reports the resolved rule set.
+//! All file access goes through the `Host` boundary (`NativeHost`), never raw `std::fs`.
 //!
 //! The rule set is resolved from config by [`rules::resolve_rules`]: every built-in rule
 //! (`tzlint_rules::builtin_rules`) runs by default, and a `config.rules` entry can disable one.

--- a/crates/tzlint_cli/src/main.rs
+++ b/crates/tzlint_cli/src/main.rs
@@ -2,8 +2,8 @@
 //!
 //! Wires the `lint` / `fix` / `init` subcommands over `tzlint_core`: config discovery, the
 //! parse → archive → `Engine::lint` pipeline (with the in-memory document cache), autofix, and
-//! text/JSON output via the position mapper. All file access goes through the `Host` boundary
-//! (`NativeHost`), never raw `std::fs`.
+//! text / JSON / SARIF output via the position mapper. All file access goes through the `Host`
+//! boundary (`NativeHost`), never raw `std::fs`.
 //!
 //! The rule set is resolved from config by [`rules::resolve_rules`]: every built-in rule
 //! (`tzlint_rules::builtin_rules`) runs by default, and a `config.rules` entry can disable one.

--- a/crates/tzlint_cli/src/output.rs
+++ b/crates/tzlint_cli/src/output.rs
@@ -213,6 +213,83 @@ pub fn render_sarif(writer: &mut dyn Write, reports: &[FileReport]) -> io::Resul
     writeln!(writer)
 }
 
+// ── `rules` subcommand output ─────────────────────────────────────────────────────────
+//
+// Renders the effective built-in rule set (see [`RuleInfo`]) for the `rules list` / `rules
+// explain` subcommands — separate from the diagnostic renderers above.
+
+use crate::rules::RuleInfo;
+
+/// Render the rule list as aligned `id  on|off  severity` columns, then a summary line.
+pub fn render_rule_list_text(writer: &mut dyn Write, infos: &[RuleInfo]) -> io::Result<()> {
+    let id_width = infos.iter().map(|info| info.id.len()).max().unwrap_or(0);
+    let enabled = infos.iter().filter(|info| info.enabled).count();
+    for info in infos {
+        writeln!(
+            writer,
+            "{:<id_width$}  {:<3}  {}",
+            info.id,
+            if info.enabled { "on" } else { "off" },
+            severity_str(info.severity),
+        )?;
+    }
+    writeln!(
+        writer,
+        "{} built-in rule(s), {enabled} enabled",
+        infos.len(),
+    )
+}
+
+/// Render the rule list as a JSON array of `{ id, enabled, severity }` objects.
+pub fn render_rule_list_json(writer: &mut dyn Write, infos: &[RuleInfo]) -> io::Result<()> {
+    let rules: Vec<Value> = infos
+        .iter()
+        .map(|info| {
+            json!({
+                "id": info.id,
+                "enabled": info.enabled,
+                "severity": severity_str(info.severity),
+            })
+        })
+        .collect();
+    serde_json::to_writer_pretty(&mut *writer, &Value::Array(rules)).map_err(io::Error::other)?;
+    writeln!(writer)
+}
+
+/// Render one rule's effective state (`rules explain`): status, severity (noting whether it is a
+/// config override or the default), and config-supplied options if any.
+pub fn render_rule_explain(writer: &mut dyn Write, info: &RuleInfo) -> io::Result<()> {
+    writeln!(writer, "rule:     {}", info.id)?;
+    writeln!(
+        writer,
+        "status:   {}",
+        if info.enabled {
+            "enabled"
+        } else {
+            "disabled (by config)"
+        },
+    )?;
+    let severity_note = if info.severity_overridden {
+        "overridden by config"
+    } else {
+        "default"
+    };
+    writeln!(
+        writer,
+        "severity: {} ({severity_note})",
+        severity_str(info.severity),
+    )?;
+    match &info.options {
+        // `serde_json::to_string` only errors on a non-string map key, which a parsed config
+        // value never has; surface it as an io error rather than unwrapping regardless.
+        Some(options) => {
+            let rendered = serde_json::to_string(options).map_err(io::Error::other)?;
+            writeln!(writer, "options:  {rendered} (from config)")
+        }
+        None => writeln!(writer, "options:  (defaults)"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -384,5 +461,137 @@ mod tests {
         assert_eq!(sarif_uri(Path::new("docs/a.md")), "docs/a.md");
         // A backslash path (as Windows `display()` yields) is normalized to URI separators.
         assert_eq!(sarif_uri(Path::new("docs\\a.md")), "docs/a.md");
+    }
+
+    fn ri(id: &'static str, enabled: bool, severity: Severity) -> RuleInfo {
+        RuleInfo {
+            id,
+            enabled,
+            severity,
+            severity_overridden: false,
+            options: None,
+        }
+    }
+
+    fn render_to_string(f: impl FnOnce(&mut Vec<u8>) -> io::Result<()>) -> String {
+        let mut buf = Vec::new();
+        f(&mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn rule_list_text_lists_state_and_summarizes() {
+        let infos = vec![
+            ri("max-ten", true, Severity::Warning),
+            ri("sentence-length", false, Severity::Error),
+        ];
+        let out = render_to_string(|w| render_rule_list_text(w, &infos));
+        let lines: Vec<&str> = out.lines().collect();
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("max-ten") && l.contains("on") && l.contains("warning")),
+            "{out}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("sentence-length") && l.contains("off") && l.contains("error")),
+            "{out}"
+        );
+        assert!(out.contains("2 built-in rule(s), 1 enabled"), "{out}");
+    }
+
+    #[test]
+    fn rule_list_text_aligns_the_severity_column() {
+        // Differing id lengths are padded so the on/off and severity columns line up.
+        let infos = vec![
+            ri("max-ten", true, Severity::Warning),
+            ri("no-mixed-zenkaku-hankaku-alphabet", true, Severity::Warning),
+        ];
+        let out = render_to_string(|w| render_rule_list_text(w, &infos));
+        let cols: Vec<usize> = out
+            .lines()
+            .filter(|l| l.contains("warning"))
+            .map(|l| l.find("warning").unwrap())
+            .collect();
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols[0], cols[1], "severity column should align: {out:?}");
+    }
+
+    #[test]
+    fn rule_list_json_is_an_array_of_objects() {
+        let infos = vec![
+            ri("max-ten", true, Severity::Warning),
+            ri("no-todo", false, Severity::Info),
+        ];
+        let mut buf = Vec::new();
+        render_rule_list_json(&mut buf, &infos).unwrap();
+        let value: Value = serde_json::from_slice(&buf).unwrap();
+        assert_eq!(
+            value[0],
+            json!({ "id": "max-ten", "enabled": true, "severity": "warning" })
+        );
+        assert_eq!(
+            value[1],
+            json!({ "id": "no-todo", "enabled": false, "severity": "info" })
+        );
+    }
+
+    #[test]
+    fn rule_explain_default_shows_defaults() {
+        let out =
+            render_to_string(|w| render_rule_explain(w, &ri("max-ten", true, Severity::Warning)));
+        assert!(out.contains("rule:     max-ten"), "{out}");
+        assert!(out.contains("status:   enabled"), "{out}");
+        assert!(out.contains("severity: warning (default)"), "{out}");
+        assert!(out.contains("options:  (defaults)"), "{out}");
+    }
+
+    #[test]
+    fn rule_explain_shows_override_disabled_and_options() {
+        let info = RuleInfo {
+            id: "max-ten",
+            enabled: false,
+            severity: Severity::Error,
+            severity_overridden: true,
+            options: Some(json!({ "max": 0 })),
+        };
+        let out = render_to_string(|w| render_rule_explain(w, &info));
+        assert!(out.contains("status:   disabled (by config)"), "{out}");
+        assert!(
+            out.contains("severity: error (overridden by config)"),
+            "{out}"
+        );
+        assert!(out.contains("options:  {\"max\":0} (from config)"), "{out}");
+    }
+
+    #[test]
+    fn renderers_propagate_writer_errors() {
+        // A zero-capacity `&mut [u8]` sink fails (`WriteZero`) on any non-empty write, exercising
+        // each renderer's error-propagation arm — the module's output policy is that a failed
+        // result write surfaces as an error (the CLI maps it to `ExitStatus::Error`).
+        fn write_fails(render: impl FnOnce(&mut dyn Write) -> io::Result<()>) -> bool {
+            let mut sink: &mut [u8] = &mut [];
+            render(&mut sink).is_err()
+        }
+        let reports = [report(
+            "a.md",
+            "x\n",
+            vec![Diagnostic::new(
+                "no-todo",
+                Severity::Warning,
+                Span::new(0, 1),
+                "m",
+            )],
+        )];
+        assert!(write_fails(|w| render_text(w, &reports)));
+        assert!(write_fails(|w| render_json(w, &reports)));
+        assert!(write_fails(|w| render_sarif(w, &reports)));
+
+        let infos = [ri("max-ten", true, Severity::Warning)];
+        assert!(write_fails(|w| render_rule_list_text(w, &infos)));
+        assert!(write_fails(|w| render_rule_list_json(w, &infos)));
+        assert!(write_fails(|w| render_rule_explain(w, &infos[0])));
     }
 }

--- a/crates/tzlint_cli/src/output.rs
+++ b/crates/tzlint_cli/src/output.rs
@@ -5,7 +5,7 @@
 //! already in the engine's stable total order, so no re-sorting happens here.
 
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde_json::{Value, json};
 use tzlint_core::LineIndex;
@@ -121,6 +121,98 @@ fn diagnostic_json(source: &str, index: &LineIndex, diagnostic: &Diagnostic) -> 
     })
 }
 
+// ── SARIF 2.1.0 output ────────────────────────────────────────────────────────────────
+//
+// A static analysis interchange format consumed by CI integrations (notably GitHub code
+// scanning). The document is built directly from the diagnostics, so it needs no extra
+// metadata threading: each diagnostic becomes one `result`, and the rule ids that appear are
+// collected into the run's `tool.driver.rules` (referenced by `ruleIndex`).
+
+/// The analysis tool's name, embedded in every SARIF run's `tool.driver`.
+const SARIF_TOOL_NAME: &str = "tzlint";
+/// The tool version (the crate version), embedded in `tool.driver.version`.
+const SARIF_TOOL_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// The project home, embedded in `tool.driver.informationUri`.
+const SARIF_TOOL_INFO_URI: &str = "https://github.com/simorgh3196/tsuzulint";
+
+/// The SARIF 2.1.0 `level` for a [`Severity`]. SARIF defines only `none`/`note`/`warning`/
+/// `error`, so the two informational severities both map to `note`.
+fn sarif_level(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+        Severity::Info | Severity::Hint => "note",
+    }
+}
+
+/// A SARIF `artifactLocation.uri`: the path with `\` normalized to `/`, since SARIF URIs use
+/// forward slashes regardless of the host platform (so a Windows path stays a valid URI).
+fn sarif_uri(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
+/// Render `reports` as a SARIF 2.1.0 log (one `run`, one `result` per diagnostic).
+///
+/// Byte spans map to a 1-based `region`; SARIF's `endColumn` is exclusive (the column after the
+/// region), which is exactly what mapping the exclusive `span.end` yields. Rule ids encountered
+/// are deduplicated into `tool.driver.rules` in first-appearance order and referenced by
+/// `ruleIndex`. Stdin diagnostics keep their `<stdin>` label as the artifact URI.
+pub fn render_sarif(writer: &mut dyn Write, reports: &[FileReport]) -> io::Result<()> {
+    let mut rule_ids: Vec<&str> = Vec::new();
+    let mut results: Vec<Value> = Vec::new();
+    for report in reports {
+        let index = LineIndex::new(&report.source);
+        let uri = sarif_uri(&report.path);
+        for diagnostic in &report.diagnostics {
+            let rule_id = diagnostic.rule_id.as_str();
+            let rule_index = match rule_ids.iter().position(|id| *id == rule_id) {
+                Some(i) => i,
+                None => {
+                    rule_ids.push(rule_id);
+                    rule_ids.len() - 1
+                }
+            };
+            let (start_line, start_col) = index.position(&report.source, diagnostic.span.start);
+            let (end_line, end_col) = index.position(&report.source, diagnostic.span.end);
+            results.push(json!({
+                "ruleId": rule_id,
+                "ruleIndex": rule_index,
+                "level": sarif_level(diagnostic.severity),
+                "message": { "text": diagnostic.message },
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": { "uri": uri },
+                        "region": {
+                            "startLine": start_line,
+                            "startColumn": start_col,
+                            "endLine": end_line,
+                            "endColumn": end_col,
+                        },
+                    },
+                }],
+            }));
+        }
+    }
+    let rules: Vec<Value> = rule_ids.iter().map(|id| json!({ "id": id })).collect();
+    let log = json!({
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": SARIF_TOOL_NAME,
+                    "version": SARIF_TOOL_VERSION,
+                    "informationUri": SARIF_TOOL_INFO_URI,
+                    "rules": rules,
+                },
+            },
+            "results": results,
+        }],
+    });
+    serde_json::to_writer_pretty(&mut *writer, &log).map_err(io::Error::other)?;
+    writeln!(writer)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -214,5 +306,83 @@ mod tests {
         assert_eq!(severity_str(Severity::Warning), "warning");
         assert_eq!(severity_str(Severity::Info), "info");
         assert_eq!(severity_str(Severity::Hint), "hint");
+    }
+
+    fn render_sarif_value(reports: &[FileReport]) -> Value {
+        let mut buf = Vec::new();
+        render_sarif(&mut buf, reports).unwrap();
+        serde_json::from_slice(&buf).unwrap()
+    }
+
+    #[test]
+    fn sarif_has_a_valid_2_1_0_envelope() {
+        let diag = Diagnostic::new("no-todo", Severity::Warning, Span::new(4, 8), "found TODO");
+        let value = render_sarif_value(&[report("doc.md", "壱\nTODO\n", vec![diag])]);
+        assert_eq!(value["version"], "2.1.0");
+        assert!(value["$schema"].is_string(), "{value}");
+        let driver = &value["runs"][0]["tool"]["driver"];
+        assert_eq!(driver["name"], "tzlint");
+        assert!(driver["version"].is_string(), "{driver}");
+        assert!(driver["informationUri"].is_string(), "{driver}");
+    }
+
+    #[test]
+    fn sarif_result_carries_rule_level_message_and_region() {
+        // "壱\n" is 4 bytes, so byte 4 = line 2 col 1; byte 8 = the column after "TODO" =
+        // line 2 col 5 (SARIF's exclusive endColumn).
+        let diag = Diagnostic::new("no-todo", Severity::Warning, Span::new(4, 8), "found TODO");
+        let value = render_sarif_value(&[report("doc.md", "壱\nTODO\n", vec![diag])]);
+        let result = &value["runs"][0]["results"][0];
+        assert_eq!(result["ruleId"], "no-todo");
+        assert_eq!(result["ruleIndex"], 0);
+        assert_eq!(result["level"], "warning");
+        assert_eq!(result["message"]["text"], "found TODO");
+        let physical = &result["locations"][0]["physicalLocation"];
+        assert_eq!(physical["artifactLocation"]["uri"], "doc.md");
+        assert_eq!(
+            physical["region"],
+            json!({ "startLine": 2, "startColumn": 1, "endLine": 2, "endColumn": 5 }),
+            "{physical}"
+        );
+    }
+
+    #[test]
+    fn sarif_dedupes_rules_and_indexes_results() {
+        let d = |rule: &str| Diagnostic::new(rule, Severity::Error, Span::new(0, 1), "m");
+        let value = render_sarif_value(&[report("a.md", "x", vec![d("r1"), d("r2"), d("r1")])]);
+        let rules = value["runs"][0]["tool"]["driver"]["rules"]
+            .as_array()
+            .unwrap()
+            .clone();
+        // First-appearance order, deduplicated.
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0]["id"], "r1");
+        assert_eq!(rules[1]["id"], "r2");
+        let results = value["runs"][0]["results"].as_array().unwrap();
+        assert_eq!(results[0]["ruleIndex"], 0);
+        assert_eq!(results[1]["ruleIndex"], 1);
+        assert_eq!(results[2]["ruleIndex"], 0);
+    }
+
+    #[test]
+    fn sarif_clean_report_has_empty_results_and_rules() {
+        let value = render_sarif_value(&[report("a.md", "ok\n", vec![])]);
+        assert_eq!(value["runs"][0]["results"], json!([]));
+        assert_eq!(value["runs"][0]["tool"]["driver"]["rules"], json!([]));
+    }
+
+    #[test]
+    fn sarif_level_maps_info_and_hint_to_note() {
+        assert_eq!(sarif_level(Severity::Error), "error");
+        assert_eq!(sarif_level(Severity::Warning), "warning");
+        assert_eq!(sarif_level(Severity::Info), "note");
+        assert_eq!(sarif_level(Severity::Hint), "note");
+    }
+
+    #[test]
+    fn sarif_uri_uses_forward_slashes() {
+        assert_eq!(sarif_uri(Path::new("docs/a.md")), "docs/a.md");
+        // A backslash path (as Windows `display()` yields) is normalized to URI separators.
+        assert_eq!(sarif_uri(Path::new("docs\\a.md")), "docs/a.md");
     }
 }

--- a/crates/tzlint_cli/src/rules.rs
+++ b/crates/tzlint_cli/src/rules.rs
@@ -14,7 +14,7 @@ use std::collections::BTreeSet;
 
 use serde_json::Value;
 use tzlint_core::{Config, RuleSetting};
-use tzlint_pdk::{Rule, RuleId};
+use tzlint_pdk::{Rule, RuleId, Severity};
 use tzlint_rules::{RULE_IDS, build_rule};
 
 /// Build the boxed rule set to run for `config`: every built-in rule (in [`RULE_IDS`] order)
@@ -30,6 +30,67 @@ pub fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
             None => build_rule(id, &Value::Null, None),
         })
         .collect()
+}
+
+/// The effective state of one built-in rule under a resolved [`Config`] — what the `rules`
+/// subcommand reports. `severity` is the override when the config sets one (with
+/// `severity_overridden` true), else the rule's default. `options` holds the config-supplied
+/// options only when non-null.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleInfo {
+    /// The rule id (a built-in, from [`RULE_IDS`]).
+    pub id: &'static str,
+    /// Whether the rule runs (false only when `config.rules` turns it off).
+    pub enabled: bool,
+    /// The effective severity: the config override if set, otherwise the rule's default.
+    pub severity: Severity,
+    /// Whether `severity` came from a config override rather than the rule default.
+    pub severity_overridden: bool,
+    /// The config-supplied options for this rule, if it set any (non-null).
+    pub options: Option<Value>,
+}
+
+/// The effective [`RuleInfo`] for every built-in rule, in [`RULE_IDS`] order.
+#[must_use]
+pub fn rule_infos(config: &Config) -> Vec<RuleInfo> {
+    RULE_IDS
+        .iter()
+        .map(|id| rule_info_for(config, id))
+        .collect()
+}
+
+/// The [`RuleInfo`] for one rule id, or `None` if it is not a built-in rule.
+#[must_use]
+pub fn rule_info(config: &Config, id: &str) -> Option<RuleInfo> {
+    RULE_IDS
+        .iter()
+        .find(|known| **known == id)
+        .map(|known| rule_info_for(config, known))
+}
+
+/// Compute the effective state of `id` under `config`. `id` must be a built-in rule id (a
+/// `&'static str` from [`RULE_IDS`]) so the resulting [`RuleInfo`] can borrow it.
+fn rule_info_for(config: &Config, id: &'static str) -> RuleInfo {
+    let setting = config.rules.get(&RuleId::from(id));
+    let enabled = !matches!(setting, Some(RuleSetting::Off));
+    let (override_severity, options) = match setting {
+        Some(RuleSetting::On { severity, options }) => {
+            let options = (!options.is_null()).then(|| options.clone());
+            (*severity, options)
+        }
+        _ => (None, None),
+    };
+    // The default severity comes from the constructed rule's meta; every RULE_IDS entry builds,
+    // so the fallback is unreachable (avoids an unwrap in deny-unwrap code).
+    let default_severity = build_rule(id, &Value::Null, None)
+        .map_or(Severity::Warning, |rule| rule.meta().default_severity);
+    RuleInfo {
+        id,
+        enabled,
+        severity: override_severity.unwrap_or(default_severity),
+        severity_overridden: override_severity.is_some(),
+        options,
+    }
 }
 
 /// The rule ids referenced in `config.rules` that are not built-in rules — most likely typos.
@@ -137,5 +198,79 @@ mod tests {
     fn known_rule_ids_are_not_reported() {
         let config = config_with(&[(RULE_IDS[0], RuleSetting::Off)]);
         assert!(unknown_rule_ids(&config).is_empty());
+    }
+
+    #[test]
+    fn rule_infos_lists_all_in_order_enabled_by_default() {
+        let infos = rule_infos(&Config::default());
+        assert_eq!(infos.len(), RULE_IDS.len());
+        assert_eq!(infos.iter().map(|i| i.id).collect::<Vec<_>>(), RULE_IDS);
+        assert!(
+            infos
+                .iter()
+                .all(|i| i.enabled && !i.severity_overridden && i.options.is_none()),
+            "default config: every rule enabled, default severity, no options"
+        );
+    }
+
+    #[test]
+    fn rule_infos_marks_a_disabled_rule() {
+        let target = RULE_IDS[0];
+        let infos = rule_infos(&config_with(&[(target, RuleSetting::Off)]));
+        let info = infos.iter().find(|i| i.id == target).unwrap();
+        assert!(!info.enabled);
+        // The others stay enabled.
+        assert_eq!(
+            infos.iter().filter(|i| i.enabled).count(),
+            RULE_IDS.len() - 1
+        );
+    }
+
+    #[test]
+    fn rule_infos_applies_and_flags_a_severity_override() {
+        let target = "max-ten";
+        let infos = rule_infos(&config_with(&[(
+            target,
+            RuleSetting::On {
+                severity: Some(Severity::Error),
+                options: Value::Null,
+            },
+        )]));
+        let info = infos.iter().find(|i| i.id == target).unwrap();
+        assert!(info.enabled);
+        assert_eq!(info.severity, Severity::Error);
+        assert!(info.severity_overridden);
+    }
+
+    #[test]
+    fn rule_info_captures_config_options_without_overriding_severity() {
+        let target = "max-ten";
+        let options = serde_json::json!({ "max": 0 });
+        let config = config_with(&[(
+            target,
+            RuleSetting::On {
+                severity: None,
+                options: options.clone(),
+            },
+        )]);
+        let info = rule_info(&config, target).unwrap();
+        assert_eq!(info.options.as_ref(), Some(&options));
+        assert!(!info.severity_overridden);
+    }
+
+    #[test]
+    fn rule_info_unknown_is_none() {
+        assert!(rule_info(&Config::default(), "definitely-not-a-rule").is_none());
+    }
+
+    #[test]
+    fn rule_info_default_severity_matches_the_built_rule() {
+        // The reported default severity equals the constructed rule's meta severity, for every id.
+        for id in RULE_IDS {
+            let info = rule_info(&Config::default(), id).unwrap();
+            let built = build_rule(id, &Value::Null, None).unwrap();
+            assert_eq!(info.severity, built.meta().default_severity, "{id}");
+            assert!(!info.severity_overridden, "{id}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two CLI follow-ups stacked after **M1g-d** (input expansion, #29, merged). Both are CLI-only — `tzlint_core` is untouched, so the `wasm32` core build is unaffected.

### M1g-e — SARIF 2.1.0 output (`lint --format sarif`)

A third `OutputFormat` alongside `text` / `json`, for CI integrations (notably GitHub code scanning).

- Each diagnostic becomes one `result` with `ruleId` / `level` / `message` and a 1-based `region`. SARIF's `endColumn` is **exclusive** (the column after the region), which is exactly what mapping the exclusive `span.end` through `LineIndex::position` yields — no off-by-one.
- Severity → level: `error`/`warning` map to the same; `info`/`hint` map to `note` (SARIF's only informational level).
- Rule ids encountered are deduplicated into `tool.driver.rules` **globally across all files** in first-appearance order and referenced by `ruleIndex`; the driver carries `name` / `version` / `informationUri`.
- Artifact URIs normalize `\` → `/` so a Windows path stays a valid URI; the `<stdin>` label is kept verbatim.

The log is built directly from the diagnostics (`output::render_sarif`), so no extra metadata threading is needed.

> **Usage note:** `artifactLocation.uri` echoes the path you pass on the command line (same as text/JSON). GitHub code scanning prefers **repo-relative** paths, so run e.g. `tzlint lint --format sarif 'docs/**/*.md'` from the repo root rather than passing absolute paths.

### M1g-f — `rules` subcommand

`tzlint rules list` / `tzlint rules explain <id>` report which built-in rules run, and at what severity, under the **resolved config** (honors `--config` / discovery) — answering "what runs for this project?".

- `rules list [--format text|json]` — aligned `id  on|off  severity` columns plus a `N built-in rule(s), M enabled` summary. A `config.rules` entry that turns a rule off shows as disabled; a severity override shows the overridden severity.
- `rules explain <id>` — one rule's status, effective severity (noting *default* vs *overridden by config*), and config-supplied options. An unknown id is named on stderr and exits `Error`.

Effective state is computed in `rules::{RuleInfo, rule_infos, rule_info}` from the config plus each rule's **constructed meta** (default severity via `build_rule(id, Null, None)`) — **no new field on the rule model**. Rendering lives alongside the diagnostic renderers in `output`.

## Testing

- TDD throughout (implementation watched red against stubs, then restored to green).
- `just check` green: `rustfmt`, `clippy -D warnings`, `cargo nextest` (293), doctests.
- `tzlint_core` builds for `wasm32-unknown-unknown`; io-guard grep clean (no raw `std::fs`); `cargo deny` ok.
- Real-binary E2E: SARIF output validated as well-formed SARIF JSON; `rules list`/`explain` confirmed (column alignment, config-driven on/off + severity override, options display, unknown-id `Error` exit).
- Coverage (`llvm-cov --show-missing-lines`): `rules.rs` 100%, `output.rs` 99.5%, `rules` dispatch + SARIF dispatch fully covered. A writer-error test (a zero-capacity `&mut [u8]` sink) covers the renderers' output-policy error arms. The only uncovered new lines are `render_rule_explain`'s 2nd/3rd sequential `writeln!?` arms (unreachable once the first write fails — the same trivial pattern as the covered first arm).

## Review

An adversarial review pass found **zero real bugs** — it verified the SARIF region/`endColumn` semantics at newline / EOF / multibyte boundaries against `LineIndex`, the full `RuleSetting` matrix for the rules state, no `unwrap`/`expect`/`panic` in production code, and that nothing leaks into the wasm core.

## Commits

- `feat(cli): add SARIF 2.1.0 output to lint --format sarif (M1g-e)`
- `feat(cli): add a rules subcommand to inspect the built-in rule set (M1g-f)`

(Two independently reviewable sub-steps; squash or keep as you prefer.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **`rules` サブコマンドを追加**
  * ビルトインルールの一覧表示（テキスト/JSON形式対応）
  * 個別ルールの詳細説明表示（有効/無効状態、重大度、設定オプション含む）

* **SARIF 2.1.0 出力形式に対応**
  * 診断結果をSARIF形式で出力可能に

<!-- end of auto-generated comment: release notes by coderabbit.ai -->