### PR TITLE
docs: document the M1 CLI and refresh the config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,52 @@ textlint and specialized for CJK (Japanese first; Korean/Chinese planned).
   easy rule extension (Rust PDK now; layered ABI for future TS/AssemblyScript), safe
   breaking changes (frozen AST core + additive tables + `bytecheck`), strong tests & docs.
 
+## Usage
+
+Build the binary (`cargo build --release` → `target/release/tzlint`), then:
+
+```sh
+# Lint files, directories (recursed for Markdown), or globs; `-` reads stdin.
+tzlint lint README.md docs/ 'src/**/*.md'
+cat draft.md | tzlint lint -
+
+# Pick an output format (text | json | sarif).
+tzlint lint --format json docs/
+tzlint lint --format sarif docs/ > results.sarif   # e.g. GitHub code scanning
+
+# Apply autofixes in place (preview with --dry-run); `fix -` filters stdin to stdout.
+tzlint fix docs/
+tzlint fix --dry-run docs/
+cat draft.md | tzlint fix - > fixed.md
+
+# Write a starter .tzlintrc.json in the working directory.
+tzlint init
+
+# Inspect the resolved rule set (honors --config / discovery).
+tzlint rules list
+tzlint rules explain max-ten
+```
+
+A directory argument is searched recursively for `.md`/`.markdown` files (hidden entries and
+symlinks are skipped); globs (`*`, `?`, `[...]`, `**`) match exactly, so quote them to keep the
+shell from expanding them first.
+
+Global options: `-c/--config <PATH>` (use a specific config instead of upward discovery),
+`-v/--verbose` (extra notes to stderr), `--no-cache` (skip the document cache).
+
+`lint` exits `0` when clean, `1` when it reports one or more diagnostics, and `2` on an
+operational error (bad config, unreadable file, …) — the conventional codes for CI. The text
+format is `path:line:col: severity: message [rule]`, where `col` is the diagnostic's 1-based
+start column:
+
+```text
+$ printf 'これはﾊﾛｰという文です。\n' | tzlint lint -
+<stdin>:1:4: warning: 半角カタカナは推奨されません。全角カタカナを使ってください。 [no-hankaku-kana]
+1 file(s) checked, 1 issue(s) found
+```
+
+See [`docs/config-reference.md`](docs/config-reference.md) for configuration.
+
 ## Workspace layout
 
 ```

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -8,8 +8,9 @@ use super::{Config, RuleSetting};
 
 /// A built-in preset: a base set of rule settings the user config overrides by id.
 ///
-/// The concrete rule sets are populated when `tzlint_rules` lands (M1f); the resolution
-/// machinery ([`resolve`]) is already complete and tested, so filling them in is additive.
+/// The concrete rule sets reference `tzlint_rules` ids as strings (no crate dependency); the
+/// resolution machinery ([`resolve`]) layers a preset under the user config, and the CLI selects
+/// a preset via the config's `extends` key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Preset {
     /// A small, broadly-applicable base for Japanese prose.
@@ -41,8 +42,8 @@ impl Preset {
     /// Rule ids are referenced as strings (no dependency on `tzlint_rules`); they MUST match the
     /// ids in `tzlint_rules::RULE_IDS` verbatim. Rules whose detection needs morphology (M2),
     /// such as `no-doubled-joshi`, are intentionally omitted until that lands — additively.
-    /// Options here are config-layer metadata; routing them into rule instances is a later step,
-    /// so a rule currently runs with its own defaults regardless of the value set here.
+    /// The options set here are routed into the constructed rule instances (via
+    /// `tzlint_rules::build_rule`) when a config selects this preset through `extends`.
     fn rules(self) -> BTreeMap<RuleId, RuleSetting> {
         match self {
             Preset::JaBasic => ja_basic(),

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,42 +1,62 @@
 # Configuration reference
 
-> Status: the loader (`tzlint_core::config`, M1d-2) and the published JSON Schema
-> (`tzlint_core::CONFIG_SCHEMA`, M1d-3) are implemented. Per-file `overrides` are planned (see
-> *Planned* below).
+> Status: the loader (`tzlint_core::config`), presets, `extends`, per-rule options/severity
+> routing, and the published JSON Schema (`tzlint_core::CONFIG_SCHEMA`) are implemented. Per-file
+> `overrides` are planned (see *Planned* below).
 
 - **Files:** `.tzlintrc.jsonc` → `.tzlintrc.json` → `.tzlintrc.yaml` → `.tzlintrc.yml` →
-  `.tzlintrc` (parsed as JSONC). Discovery walks upward from a start directory; the first
+  `.tzlintrc` (parsed as JSONC). Discovery walks upward from the working directory; the first
   directory holding any candidate wins, the highest-priority candidate in it is loaded, and
   co-located lower-priority candidates are returned as structured warnings (ignored, not
-  merged). A leading UTF-8 BOM is stripped, and an empty/whitespace-only (or comments-only)
-  file is the default config — consistently across all formats.
+  merged — pass `--verbose` to see them). Use `-c/--config <PATH>` to load a specific file and
+  skip discovery; the format is then inferred from the extension. A leading UTF-8 BOM is
+  stripped, and an empty/whitespace-only (or comments-only) file is the default config —
+  consistently across all formats. `tzlint init` writes a minimal starter `.tzlintrc.json`.
 - **Formats:** strict JSON (`.json`); JSONC (`//` and `/* */` comments + trailing commas);
   YAML (`.yaml`/`.yml`). YAML **anchors/aliases are rejected** — they are unnecessary for
   configuration and enable alias-expansion ("billion laughs") memory-exhaustion that the
   config size cap cannot bound.
-- **Validation:** serde `deny_unknown_fields` — an unknown top-level key is an error. (The
-  dynamic `rules` map keys are not yet checked against a known-rule set; that arrives with the
-  rules crate in M1f, after which an unknown rule id can be warned.)
+- **Validation:** serde `deny_unknown_fields` — an unknown top-level key is an error. Keys in
+  the dynamic `rules` map that are not built-in rule ids are not an error but are **warned** by
+  the CLI (`note: config references unknown rule '…'`), so a typo is surfaced rather than
+  silently ignored.
+- **Activation model (opt-out):** every built-in rule is **on by default**. A bare
+  `tzlint lint` runs the full built-in set; a `rules` entry set to `false` disables that rule.
+  So configuration *narrows* the default set rather than opting rules in.
 - **Rules:** map of `rule-id` → `false` (off) | `true` (on, defaults) | `{ severity?, options? }`.
   `severity` is one of `error` | `warning` | `info` | `hint` (overrides the rule's default);
-  `options` is arbitrary JSON passed through to the rule (must be JSON-representable). In YAML,
-  the boolean spellings `yes`/`no`/`on`/`off` are accepted in addition to `true`/`false`.
-- **Presets:** `ja-basic`, `ja-technical-writing` provide a base rule set that the user config
-  overrides by id (user wins). The concrete rule sets are populated once rules land (M1f). The
-  `extends` key is **reserved** and currently rejected with a clear error.
-- **Language:** `language` (e.g. `ja`) and `message_language` (the diagnostic locale,
-  independent of the document language). Config file keys are kebab-case (`message-language`).
+  `options` is arbitrary JSON routed into the rule (each rule reads the keys it understands and
+  ignores the rest). In YAML, the boolean spellings `yes`/`no`/`on`/`off` are accepted in
+  addition to `true`/`false`. Use `tzlint rules list` to see the resolved on/off + severity for
+  every rule, and `tzlint rules explain <id>` for one rule's effective state and options.
+- **Presets & `extends`:** `extends` takes a preset id (string) or an array of ids; the
+  preset's settings form a base layer that your own `rules` override by id (user wins on a
+  collision). Built-in presets:
+  - `ja-basic` — `no-hankaku-kana`, `no-mixed-zenkaku-hankaku-alphabet`, `no-nfd`,
+    `no-zero-width-spaces`, `ja-no-mixed-period`.
+  - `ja-technical-writing` — the above plus `no-exclamation-question-mark`, and thresholds:
+    `sentence-length` `max: 100`, `max-ten` `max: 3`, `max-kanji-continuous-len` `max: 6`.
+
+  Because activation is opt-out, a preset does **not** restrict *which* rules run — every
+  built-in rule is already on, so a preset effectively supplies **options and severities** for
+  the rules it names. To run a narrower set, disable the unwanted rules explicitly. Morphology
+  rules (e.g. `no-doubled-joshi`) are intentionally absent from the presets until M2.
+- **Language:** `language` (e.g. `ja`) and `message-language` (the diagnostic locale,
+  independent of the document language). Config keys are kebab-case (`message-language`).
 - **JSON Schema:** a Draft 2020-12 schema is published as `tzlint_core::CONFIG_SCHEMA`
   (`$id` `https://tsuzulint.dev/schema/config/v1.json`) for editor completion/validation and
   CLI emission. It describes the **JSON-level** contract and is intentionally stricter than the
   loader on one point: it accepts only real booleans for a rule, whereas the loader also accepts
   the YAML string spellings (`"on"`/`"yes"`/…). A differential test pins schema↔loader agreement
   (and that one deliberate asymmetry) so they cannot drift.
-- **Cache key:** `blake3(content)` + config + rule versions + parser/engine version +
-  morphology dictionary fingerprint. *(Cache lands in M1e.)*
+- **Cache:** an in-memory document cache (skips re-linting unchanged content within a run) plus
+  a persistent on-disk cache written to `.tzlintcache` in the working directory, so a repeat run
+  over unchanged files skips parse+lint. `--no-cache` disables both. The cache key is
+  `blake3(content)` + the full config + rule versions + parser/engine version + a morphology
+  dictionary fingerprint (a placeholder until M2), so any change that could alter diagnostics
+  invalidates the entry. A cache read/write failure only warns; results are unaffected.
 
 ## Planned
 
-- Per-file **`overrides`** (glob-scoped `language`/rule settings).
-- `extends` for composing configs and pulling in presets from config.
-- Per-rule **`options`** schemas once rules land (M1f), evolving the schema to a `v2` `$id`.
+- Per-file **`overrides`** (glob-scoped `language`/rule settings), evolving the schema to a
+  `v2` `$id`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,8 +14,9 @@ constraint from day one (the core compiles to `wasm32`, CI builds it); the first
 - **M1 — Lean core**: `tzlint_ast` (frozen AST), `tzlint_core` (markdown-rs parser +
   mdast→index transform, multi-format config + presets, document-level cache,
   single-traversal engine, position mapper, `io` + `Host` abstraction), Diagnostic/Fix
-  model + autofix, `tzlint_rules` starter set, `tzlint_cli` (`lint`/`fix`/`init`), full
-  tests + docs. **Migration parity gate** asserted here.
+  model + autofix, `tzlint_rules` starter set, `tzlint_cli` (`lint`/`fix`/`init`/`rules`,
+  text/JSON/SARIF), full tests + docs. The earlier `tsuzulint` prototype is an implementation
+  reference only — it has no users, so M1 ships no formal migration-parity gate.
 - **M2 — Morphology**: language-neutral provider; Japanese first; `MorphologyV1` table;
   dynamic (non-embedded) dictionary provisioning; dictionary-version cache key.
 - **M3 — Plugin ABI (native)**: `tzlint_abi` transport + calling convention on wasmtime


### PR DESCRIPTION
## Summary

Fills the M1 "tests + docs" gap now that the CLI surface is complete (lint/fix/init/rules, text/JSON/SARIF, globs/dirs/stdin, `extends`, persistent cache). The README had no usage section and the config reference predated several shipped features.

- **README** — add a **Usage** section: `lint`/`fix`/`init`/`rules`, the three output formats, directory/glob/stdin inputs, the global options, and the exit-code policy, with a verified text-output example (shown with its stdin input so the start column reads correctly).
- **config-reference** — sync to the implemented loader: `extends` (a preset id or an array, layered under user rules), unknown rule ids are **warned** (not errored), **opt-out** activation (every rule on by default), per-rule `options`/`severity` routed into rules, the real preset contents (`ja-basic` / `ja-technical-writing` + thresholds), and the in-memory **+ persistent** (`.tzlintcache`, `--no-cache`) cache. Drops the stale "reserved" / "lands in M1f" / "M1e" notes.
- **roadmap** — M1 ships no migration-parity gate; the earlier prototype is an implementation reference only (no users).
- **preset.rs** — fix two Rustdoc comments that claimed presets were unpopulated and that options were not yet routed (both shipped in M1g-a/b).

## Verification

Docs were checked against the **real binary and code** via a doc-accuracy review pass (parallel verifiers ran `--help` / sample lints and read the config loader/preset/cache code). Every command, flag, format value, exit code, preset content, and the example output line were confirmed; one fix applied (the example now shows its stdin input). `build` + `fmt` clean.

Docs are in English per the contributor guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* README に Usage セクションを追加し、基本的な実行方法、設定初期化、ルール一覧表示、グローバルオプション、終了コードを説明
* 設定リファレンスを拡充し、設定ファイル探索・読み込み、ルール有効化モデル（opt-out）、プリセット合成ルール、キャッシュ動作を詳述
* ロードマップを更新し、`rules` サブコマンドと出力フォーマット（text/JSON/SARIF）を明記

<!-- end of auto-generated comment: release notes by coderabbit.ai -->