### PR TITLE
feat(pdk): declare per-rule morphology requirements on RuleMeta (M2b)

### DIFF
--- a/crates/tzlint_pdk/src/lib.rs
+++ b/crates/tzlint_pdk/src/lib.rs
@@ -20,7 +20,7 @@ mod node;
 mod rule;
 
 pub use diagnostic::{Diagnostic, Fix, RuleId, Severity};
-pub use meta::RuleMeta;
+pub use meta::{Requirements, RuleMeta};
 pub use morphology::{MorphologyError, MorphologyProvider, WhitespaceProvider};
 pub use node::{Children, NodeRef};
 pub use rule::{Context, Rule};

--- a/crates/tzlint_pdk/src/meta.rs
+++ b/crates/tzlint_pdk/src/meta.rs
@@ -3,11 +3,50 @@
 use alloc::vec::Vec;
 
 use tzlint_ast::NodeKind;
+use tzlint_ast::morphology::Lang;
 
 use crate::{RuleId, Severity};
 
-/// Static metadata describing a rule: its id, the [`NodeKind`]s it wants to visit, and its
-/// default severity.
+/// What a rule needs from the engine before it can run, beyond visiting its [`NodeKind`]s.
+///
+/// This is **additive and defaults to "nothing"** ([`Requirements::default`]): an existing rule
+/// declares no requirements and is scheduled exactly as before. A rule that reads morphological
+/// tokens opts in via [`RuleMeta::with_morphology`], which lets the engine provision the right
+/// dictionary and skip the rule (rather than feed it an empty table) when morphology is
+/// unavailable for the document.
+///
+/// The fields are **private and only ever set together**, so an inconsistent state — a pinned
+/// language without a morphology requirement — is unrepresentable: the engine can trust that
+/// [`lang`](Self::lang) is `Some` exactly when [`needs_morphology`](Self::needs_morphology) is
+/// `true`. The shape is kept open for a future language-agnostic morphology rule
+/// (morphology required, no pinned language); that would be added through a new builder, never by
+/// constructing this struct directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Requirements {
+    /// Whether the rule reads the morphology table for the nodes it visits.
+    morphology: bool,
+    /// The dictionary language the morphology backend must provision for this rule, if pinned.
+    /// Set together with `morphology`, so it is `Some` only when `morphology` is `true`.
+    lang: Option<Lang>,
+}
+
+impl Requirements {
+    /// Whether the rule reads the morphology table for the nodes it visits.
+    #[must_use]
+    pub fn needs_morphology(&self) -> bool {
+        self.morphology
+    }
+
+    /// The dictionary language the morphology backend must provision for this rule. `Some` only
+    /// when [`needs_morphology`](Self::needs_morphology) is `true`; the two are set together.
+    #[must_use]
+    pub fn lang(&self) -> Option<Lang> {
+        self.lang
+    }
+}
+
+/// Static metadata describing a rule: its id, the [`NodeKind`]s it wants to visit, its default
+/// severity, and what it [`requires`](RuleMeta::requires) to run.
 ///
 /// The engine applies the `node_kinds` filter itself (a rule is invoked only at matching
 /// nodes), so a rule cannot silently observe nothing because it forgot to filter. A
@@ -20,10 +59,15 @@ pub struct RuleMeta {
     pub id: RuleId,
     pub node_kinds: Vec<NodeKind>,
     pub default_severity: Severity,
+    /// Capabilities the rule needs before it runs. Defaults to [`Requirements::default`]
+    /// (nothing) — see [`with_morphology`](RuleMeta::with_morphology) to opt in. Private so the
+    /// pair stays consistent; read it via [`requires`](RuleMeta::requires).
+    requires: Requirements,
 }
 
 impl RuleMeta {
-    /// Build metadata for a rule.
+    /// Build metadata for a rule. It requires nothing beyond visiting its `node_kinds`; opt into
+    /// extra capabilities with the builder methods (e.g. [`with_morphology`](Self::with_morphology)).
     pub fn new(
         id: impl Into<RuleId>,
         default_severity: Severity,
@@ -33,12 +77,44 @@ impl RuleMeta {
             id: id.into(),
             default_severity,
             node_kinds: node_kinds.into(),
+            requires: Requirements::default(),
         }
+    }
+
+    /// Declare that this rule reads the morphology table, pinned to dictionary language `lang`.
+    ///
+    /// The engine uses this to provision `lang`'s dictionary and to skip the rule when
+    /// morphology is unavailable, instead of running it against an empty table.
+    #[must_use]
+    pub fn with_morphology(mut self, lang: Lang) -> Self {
+        self.requires = Requirements {
+            morphology: true,
+            lang: Some(lang),
+        };
+        self
     }
 
     /// Whether this rule wants to visit `kind`.
     pub fn visits(&self, kind: NodeKind) -> bool {
         self.node_kinds.contains(&kind)
+    }
+
+    /// The capabilities this rule needs before it runs (see [`with_morphology`](Self::with_morphology)).
+    #[must_use]
+    pub fn requires(&self) -> Requirements {
+        self.requires
+    }
+
+    /// Whether this rule reads the morphology table (see [`with_morphology`](Self::with_morphology)).
+    #[must_use]
+    pub fn needs_morphology(&self) -> bool {
+        self.requires.needs_morphology()
+    }
+
+    /// The dictionary language this rule's morphology requirement is pinned to, if any.
+    #[must_use]
+    pub fn required_lang(&self) -> Option<Lang> {
+        self.requires.lang()
     }
 }
 
@@ -46,6 +122,7 @@ impl RuleMeta {
 mod tests {
     use super::*;
     use alloc::vec;
+    use tzlint_ast::morphology::Lang;
 
     #[test]
     fn visits_only_registered_kinds() {
@@ -59,5 +136,44 @@ mod tests {
         assert!(!meta.visits(NodeKind::TEXT));
         assert_eq!(meta.default_severity, Severity::Warning);
         assert_eq!(meta.id.as_str(), "sentence-length");
+    }
+
+    #[test]
+    fn new_meta_requires_no_morphology_by_default() {
+        let meta = RuleMeta::new("plain", Severity::Warning, vec![NodeKind::TEXT]);
+        assert!(!meta.needs_morphology());
+        assert_eq!(meta.required_lang(), None);
+        assert_eq!(meta.requires(), Requirements::default());
+    }
+
+    #[test]
+    fn requires_exposes_the_capability_bundle_through_accessors() {
+        let plain = RuleMeta::new("plain", Severity::Warning, vec![NodeKind::TEXT]);
+        let bundle = plain.requires();
+        assert!(!bundle.needs_morphology());
+        assert_eq!(bundle.lang(), None);
+
+        let morph = RuleMeta::new("no-doubled-joshi", Severity::Warning, vec![NodeKind::TEXT])
+            .with_morphology(Lang::JA);
+        let bundle = morph.requires();
+        assert!(bundle.needs_morphology());
+        assert_eq!(bundle.lang(), Some(Lang::JA));
+    }
+
+    #[test]
+    fn with_morphology_records_the_requirement_and_language() {
+        let meta = RuleMeta::new("no-doubled-joshi", Severity::Warning, vec![NodeKind::TEXT])
+            .with_morphology(Lang::JA);
+        assert!(meta.needs_morphology());
+        assert_eq!(meta.required_lang(), Some(Lang::JA));
+    }
+
+    #[test]
+    fn with_morphology_leaves_the_other_metadata_intact() {
+        let meta = RuleMeta::new("no-doubled-joshi", Severity::Error, vec![NodeKind::TEXT])
+            .with_morphology(Lang::JA);
+        assert_eq!(meta.id.as_str(), "no-doubled-joshi");
+        assert_eq!(meta.default_severity, Severity::Error);
+        assert!(meta.visits(NodeKind::TEXT));
     }
 }


### PR DESCRIPTION
## What

M2b of the Morphology milestone (M2). Adds a capability declaration to `RuleMeta` so a rule can
say it needs the morphology table, and which dictionary language it is pinned to.

- New public `Requirements { morphology: bool, lang: Option<Lang> }` (`Lang` from
  `tzlint_ast::morphology`, landed in M2a / #32).
- `RuleMeta.requires` field, plus a `with_morphology(lang)` builder and
  `needs_morphology()` / `required_lang()` accessors. Exported from `tzlint_pdk`.

## Why additive

`RuleMeta::new` fills in `Requirements::default()` (all construction goes through `new` — there
are no struct-literal constructions of `RuleMeta` elsewhere), so **every existing `RuleMeta::new`
caller and all 10 built-in rules are untouched** and keep behaving identically. `SeverityOverride`
clones `RuleMeta` and only swaps `default_severity`, so the requirement carries through unchanged
(`Requirements` derives `Copy`).

## How it will be consumed (later sub-steps)

- M2d: `Engine::lint(ast, morphology, rules)` threads the table only to rules that ask for it and
  skips them when morphology is unavailable (rather than running against an empty table).
- M2h: a per-run provider registry provisions only the dictionary languages the enabled rules pin
  via `required_lang()`.
- M2l: the `no-doubled-joshi` rule declares `with_morphology(Lang::JA)`.

`lang` is meaningful only when `morphology` is set; the pair is left open
(`morphology: true, lang: None`) so a future language-agnostic morphology rule needs no shape
change.

## Tests / checks

- TDD: 3 new tests (default requires nothing; `with_morphology` records requirement + language;
  builder leaves other metadata intact). `meta.rs` is at 100% line/function/region coverage
  workspace-wide.
- `just check` (rustfmt + clippy `-D warnings` + 309 nextest + doctests), `wasm32-unknown-unknown`
  build of `tzlint_core` + `tzlint_pdk`, and the I/O-boundary guard all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ルールが形態素参照の要件を指定できるようになりました。必要な場合、特定の辞書言語に固定することもできます。
  * ルールのメタデータに形態素要件フィールドが追加され、要件の有無確認と必要言語の取得が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->