### PR TITLE
⚡ Bolt: O(1) rule dispatch per node kind

### DIFF
--- a/crates/tzlint_core/src/engine.rs
+++ b/crates/tzlint_core/src/engine.rs
@@ -25,6 +25,20 @@ impl Engine {
             .map(|meta| Context::new(ast, meta.id.clone(), meta.default_severity))
             .collect();
 
+        // Pre-compute rule dispatch mapping by node kind
+        // ⚡ Bolt Optimization: This avoids an O(rules * nodes) loop during the hot-path traversal,
+        // replacing it with an O(1) array lookup.
+        let mut dispatch: Vec<Vec<usize>> = Vec::new();
+        for (index, meta) in metas.iter().enumerate() {
+            for kind in &meta.node_kinds {
+                let k = kind.as_u32() as usize;
+                if k >= dispatch.len() {
+                    dispatch.resize(k + 1, Vec::new());
+                }
+                dispatch[k].push(index);
+            }
+        }
+
         // Single pre-order walk. A `visited` bitmap makes it cycle-safe and bounds total
         // work to the node count, so a malformed archive — whose links `access` validates as
         // bytes but not as a graph — can neither loop nor OOM here.
@@ -35,10 +49,10 @@ impl Engine {
             }
             let mut stack = vec![root];
             while let Some(node) = stack.pop() {
-                let kind = node.kind();
-                for (index, cx) in contexts.iter_mut().enumerate() {
-                    if metas[index].visits(kind) {
-                        rules[index].check(node, cx);
+                let kind_idx = node.kind().as_u32() as usize;
+                if let Some(indices) = dispatch.get(kind_idx) {
+                    for &index in indices {
+                        rules[index].check(node, &mut contexts[index]);
                     }
                 }
                 for child in node.children() {

--- a/crates/tzlint_core/src/engine.rs
+++ b/crates/tzlint_core/src/engine.rs
@@ -35,7 +35,9 @@ impl Engine {
                 if k >= dispatch.len() {
                     dispatch.resize(k + 1, Vec::new());
                 }
-                dispatch[k].push(index);
+                if dispatch[k].last().copied() != Some(index) {
+                    dispatch[k].push(index);
+                }
             }
         }
 


### PR DESCRIPTION
💡 What: Pre-computes a dispatch map mapping NodeKind to matching rule indices. Replaces the O(nodes * rules) inner loop with an O(1) array lookup.
🎯 Why: The AST traversal is extremely hot and evaluating visits(kind) for *every* rule at *every* node adds measurable overhead.
📊 Impact: Speeds up AST linting by replacing N linear checks with a direct lookup vector.
🔬 Measurement: Run cargo bench and observe improvements in Engine::lint benchmarks.

---
*PR created automatically by Jules for task [1350903137419672822](https://jules.google.com/task/1350903137419672822) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * リント処理の内部アルゴリズムを最適化し、ルール判定の効率を向上させました。パフォーマンスが改善され、大規模なファイルの解析がより迅速に完了するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->