### PR TITLE
feat: lint specific CSV/TSV columns via a pluggable input-format processor seam

### DIFF
--- a/.agents/skills/tzlint-processors/SKILL.md
+++ b/.agents/skills/tzlint-processors/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: tzlint-processors
+description: How to add an input-format processor (e.g. CSV, Re:VIEW) to TsuzuLint. Read this before adding support for a new file type or changing the processor seam.
+---
+
+# Adding an input-format processor
+
+TsuzuLint lints natural-language text in any format via a **processor seam**. A `Processor`
+turns source into either lintable **regions** (the easy path) or a full **AST** (the escape
+hatch for structure-aware rules). The core handles parsing, span-rebasing, per-region rule
+resolution, caching, and fix. See `docs/design/input-format-processors.md` for the full contract.
+
+## Decide: Regions or Ast?
+
+- **Return `Parsed::Regions`** (preferred) when you only need to lint the format's prose. You
+  return the **byte ranges** of the natural-language text plus a `RegionTag` and a `ParseMode`.
+  The core does the rest. This is the lowest-friction path — no AST construction, no span math.
+- **Return `Parsed::Ast`** only when the format's own structure must be visible to rules
+  (headings, lists, code blocks of the source format). You build the frozen `Ast` yourself
+  (text = whole source, absolute spans). Markdown uses this path.
+
+## Steps
+
+1. **Create the module** `crates/tzlint_core/src/processor/<format>.rs`. Implement
+   `Processor`: `extensions()` (dot-less, lowercase) and `parse(source, cfg) -> Result<Parsed, ParseError>`.
+   - For prose extraction, build `Region { slices, tag, parse_mode }`. Each `slice` must be a
+     **contiguous** byte range of `source`; the core parses it independently and rebases spans.
+   - Use `RegionTag { kind: Some("<your-kind>"), index, name }` so config can target rules at
+     regions. Never invent a CSV-specific concept in shared code — `kind` is your namespace.
+   - Never `unwrap`/`expect`/`panic!`/`unreachable!` (clippy-denied). Slice with
+     `source.get(a..b).unwrap_or("")`.
+2. **Register it** in `Registry::with_builtins` (`processor/mod.rs`) — the single wiring point.
+   Add a guard-test extension entry (Task 4.3) so the registry list and the test stay in sync.
+3. **Config (if needed):** if your format needs options (delimiter, columns, …), add a resolved
+   shape under `crates/tzlint_core/src/config/` and a `RawFormat`-style serde model in
+   `config/model.rs`, then build a `ProcessorConfig` for it in `crates/tzlint_cli/src/rules.rs`
+   (`processor_config_for`). Per-region rules flow through `region_rules_for` automatically when
+   your regions carry a `kind`/`name`/`index` the config can match.
+4. **Tests (TDD):** a unit test for your extraction (assert absolute spans of the regions), and
+   an `app.rs` integration test that lints a fixture through the CLI.
+5. **Docs:** add a short section to `docs/processors.md` describing the format's config and any
+   caveats.
+
+## Invariants you must keep
+
+- Spans are absolute byte offsets into the original source; `Ast.text` (for the Ast path) is the
+  whole source.
+- The frozen `AstCoreV1` is not extended — region identity lives in `RegionTag`, outside the AST.
+- All file I/O stays in the CLI/`Host`; a processor only ever sees an in-memory `&str`.
+- One dispatch path: everything goes through `lint_document`; don't add a parallel lint route.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ one before changing that area.
   redirect-stripping; validate the dialed IP.
 - **`tzlint-contributing`** — TDD; `just check` before pushing; confirm-before-push; PR
   conventions; the migrate-and-refactor + parity-gate workflow.
+- **`tzlint-processors`** — how to add a new input-format processor (implement `Processor`,
+  register one line, add tests/docs); the Regions-vs-Ast decision guide; invariants.
+  See also [`docs/processors.md`](docs/processors.md) for user-facing CSV/TSV config.
 
 **Conventions:** Documentation under `docs/` and Rustdoc are written in **English**.
 Library code must not use `.unwrap()`/`.expect()`/`panic!` (clippy-denied). Run

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ $ printf 'これはﾊﾛｰという文です。\n' | tzlint lint -
 1 file(s) checked, 1 issue(s) found
 ```
 
-See [`docs/config-reference.md`](docs/config-reference.md) for configuration.
+See [`docs/config-reference.md`](docs/config-reference.md) for configuration and
+[`docs/processors.md`](docs/processors.md) for CSV/TSV column linting.
 
 ## Workspace layout
 

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -150,6 +150,7 @@ fn lint(
         }
     }
     for path in &inputs.files {
+        note_unconfigured_format(&config, path, stderr);
         match read_and_lint(&registry, host, cache.as_mut(), path, &config) {
             Ok(report) => reports.push(report),
             Err(message) => {
@@ -553,6 +554,27 @@ fn note_unknown_rules(config: &Config, stderr: &mut dyn Write) {
             stderr,
             "note: config references unknown rule '{id}' (ignored)"
         );
+    }
+}
+
+/// Note (best-effort, on stderr) when `path` is a known delimited format (csv/tsv) but the config
+/// has no columns configured for it — so a `.csv`/`.tsv` that lints nothing is not mistaken for a
+/// clean file. Explicitly-named files reach the linter even without config (opt-in columns), so
+/// this is the most common point of confusion.
+fn note_unconfigured_format(config: &Config, path: &Path, stderr: &mut dyn Write) {
+    let known = ["csv", "tsv"];
+    if let Some(ext) = extension_of(path) {
+        let ext = ext.to_ascii_lowercase();
+        let configured = config
+            .formats
+            .get(&ext)
+            .is_some_and(|f| !f.columns.is_empty());
+        if known.contains(&ext.as_str()) && !configured {
+            let _ = writeln!(
+                stderr,
+                "note: no columns configured for '{ext}'; nothing to lint"
+            );
+        }
     }
 }
 
@@ -1360,6 +1382,14 @@ mod tests {
         let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
         assert_eq!(status, ExitStatus::Findings);
         assert!(out.contains("no-hankaku-kana"), "{out}");
+    }
+
+    #[test]
+    fn notes_when_csv_has_no_columns_configured() {
+        // A .csv argument with no formats config → a note that nothing was linted.
+        let host = MockHost::with("data.csv", "id,body\n1,x\n");
+        let (_status, _out, err) = run_capture(&lint_cli("data.csv", OutputFormat::Text), &host);
+        assert!(err.contains("no columns configured for 'csv'"), "{err}");
     }
 
     #[test]

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -21,15 +21,16 @@ use std::path::{Path, PathBuf};
 
 use tzlint_core::io::{MAX_CONFIG, MAX_FILE};
 use tzlint_core::{
-    Config, ConfigFormat, DocumentCache, Host, ProcessorConfig, RegionRules, Registry, discover,
-    lint_cached, lint_document,
+    Config, ConfigFormat, DocumentCache, Host, Registry, discover, lint_cached, lint_document,
 };
 use tzlint_pdk::{Diagnostic, Rule};
 
 use crate::cli::{Cli, Command, OutputFormat, RuleListFormat, RulesCommand};
 use crate::expand;
 use crate::output::{self, FileReport};
-use crate::rules::{resolve_rules, rule_info, rule_infos, unknown_rule_ids};
+use crate::rules::{
+    processor_config_for, region_rules_for, resolve_rules, rule_info, rule_infos, unknown_rule_ids,
+};
 
 /// The path label used for diagnostics linted from standard input.
 const STDIN_LABEL: &str = "<stdin>";
@@ -115,6 +116,8 @@ fn lint(
     let rules = resolve_rules(&config);
     note_if_no_rules(&rules, stderr);
     note_unknown_rules(&config, stderr);
+    // One processor registry for the whole run, shared by every file and the stdin source.
+    let registry = Registry::with_builtins();
 
     // Resolve the PATH arguments into concrete files (globs / directories expanded, sorted and
     // de-duplicated) plus an optional stdin source; surface any discovery notes on stderr.
@@ -131,7 +134,7 @@ fn lint(
     // stdin is reported first so the work order is fixed and the summary count is stable.
     if inputs.stdin {
         match read_stdin(stdin).and_then(|source| {
-            let diagnostics = lint_direct(None, &source, &config)?;
+            let diagnostics = lint_source(&registry, &config, None, &source)?;
             Ok(FileReport {
                 path: PathBuf::from(STDIN_LABEL),
                 source,
@@ -146,7 +149,7 @@ fn lint(
         }
     }
     for path in &inputs.files {
-        match read_and_lint(host, cache.as_mut(), path, &config) {
+        match read_and_lint(&registry, host, cache.as_mut(), path, &config) {
             Ok(report) => reports.push(report),
             Err(message) => {
                 let _ = writeln!(stderr, "error: {}: {message}", path.display());
@@ -191,8 +194,11 @@ fn lint_exit_status(had_error: bool, has_findings: bool) -> ExitStatus {
 }
 
 /// Read `path` through the host and lint it, via the cache when enabled or the processor seam
-/// ([`lint_document`]) otherwise.
+/// ([`lint_document`]) otherwise. Both paths build the file's [`ProcessorConfig`] and
+/// [`RegionRules`] from its extension (so CSV/TSV columns are extracted and per-column rules
+/// applied; Markdown gets the base set and the Markdown processor).
 fn read_and_lint(
+    registry: &Registry,
     host: &dyn Host,
     cache: Option<&mut DocumentCache>,
     path: &Path,
@@ -204,20 +210,12 @@ fn read_and_lint(
     let ext = extension_of(path);
     let diagnostics = match cache {
         Some(cache) => {
-            let registry = Registry::with_builtins();
-            let rr = RegionRules::base_only(resolve_rules(config));
-            lint_cached(
-                cache,
-                ext,
-                &source,
-                config,
-                &registry,
-                &ProcessorConfig::default(),
-                &rr,
-            )
-            .map_err(|e| e.to_string())?
+            let pcfg = processor_config_for(config, ext);
+            let rr = region_rules_for(config, ext);
+            lint_cached(cache, ext, &source, config, registry, &pcfg, &rr)
+                .map_err(|e| e.to_string())?
         }
-        None => lint_direct(ext, &source, config)?,
+        None => lint_source(registry, config, ext, &source)?,
     };
     Ok(FileReport {
         path: path.to_path_buf(),
@@ -232,12 +230,16 @@ fn extension_of(path: &Path) -> Option<&str> {
     path.extension().and_then(|e| e.to_str())
 }
 
-/// The no-cache path: select a processor by extension and lint via the processor seam, surfacing
-/// parse/archive failures as a message (mirrors what [`lint_cached`] reports on the cached path).
-fn lint_direct(ext: Option<&str>, source: &str, config: &Config) -> Result<Vec<Diagnostic>, String> {
-    let registry = Registry::with_builtins();
-    let rr = RegionRules::base_only(resolve_rules(config));
-    lint_document(ext, source, &registry, &ProcessorConfig::default(), &rr).map_err(|e| e.to_string())
+/// Lint one already-read source with the processor seam, given the file's extension.
+fn lint_source(
+    registry: &Registry,
+    config: &Config,
+    ext: Option<&str>,
+    source: &str,
+) -> Result<Vec<Diagnostic>, String> {
+    let pcfg = processor_config_for(config, ext);
+    let rr = region_rules_for(config, ext);
+    lint_document(ext, source, registry, &pcfg, &rr).map_err(|e| e.to_string())
 }
 
 /// `fix`: lint-and-fix each file to a fixpoint; write changed files in place (or just report
@@ -275,14 +277,9 @@ fn fix(
     if inputs.stdin {
         match read_stdin(stdin) {
             Ok(source) => {
-                let rr = RegionRules::base_only(resolve_rules(&config));
-                let fixed = tzlint_core::fix(
-                    None,
-                    &source,
-                    &registry,
-                    &ProcessorConfig::default(),
-                    &rr,
-                );
+                let pcfg = processor_config_for(&config, None);
+                let rr = region_rules_for(&config, None);
+                let fixed = tzlint_core::fix(None, &source, &registry, &pcfg, &rr);
                 let did_change = fixed != source;
                 if dry_run {
                     if did_change {
@@ -323,9 +320,9 @@ fn fix(
         // `fix` parses internally and returns the source unchanged on a parse failure, so the
         // only failure to handle here is the write below.
         let ext = extension_of(path);
-        let rr = RegionRules::base_only(resolve_rules(&config));
-        let fixed =
-            tzlint_core::fix(ext, &source, &registry, &ProcessorConfig::default(), &rr);
+        let pcfg = processor_config_for(&config, ext);
+        let rr = region_rules_for(&config, ext);
+        let fixed = tzlint_core::fix(ext, &source, &registry, &pcfg, &rr);
         if fixed == source {
             continue;
         }
@@ -1351,6 +1348,30 @@ mod tests {
         let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
         assert_eq!(status, ExitStatus::Findings);
         assert!(out.contains("no-hankaku-kana"), "{out}");
+    }
+
+    #[test]
+    fn lint_csv_with_per_column_rule_reports_in_the_right_cell() {
+        // Config lints only the `body` column; `no-todo` is on. The TODO in the `body` cell is
+        // flagged; the TODO in the un-linted `note` column is not.
+        let host = MockHost::new();
+        host.put("data.csv", "id,body,note\n1,TODO fix,TODO ignore\n");
+        host.put(
+            "c.json",
+            r#"{ "rules": { "no-hankaku-kana": false }, "formats": { "csv": { "header": true, "columns": { "body": { "parse-mode": "plain", "rules": { "no-todo": true } } } } } }"#,
+        );
+        let mut c = lint_cli("data.csv", OutputFormat::Json);
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, out, _err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Findings);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let diags = &v[0]["diagnostics"];
+        assert_eq!(
+            diags.as_array().unwrap().len(),
+            1,
+            "only the body TODO: {out}"
+        );
+        assert!(out.contains("no-todo"), "{out}");
     }
 
     #[test]

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -115,7 +115,6 @@ fn lint(
     let rules = resolve_rules(&config);
     note_if_no_rules(&rules, stderr);
     note_unknown_rules(&config, stderr);
-    let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
 
     // Resolve the PATH arguments into concrete files (globs / directories expanded, sorted and
     // de-duplicated) plus an optional stdin source; surface any discovery notes on stderr.
@@ -147,7 +146,7 @@ fn lint(
         }
     }
     for path in &inputs.files {
-        match read_and_lint(host, cache.as_mut(), path, &config, &rule_refs) {
+        match read_and_lint(host, cache.as_mut(), path, &config) {
             Ok(report) => reports.push(report),
             Err(message) => {
                 let _ = writeln!(stderr, "error: {}: {message}", path.display());
@@ -198,14 +197,27 @@ fn read_and_lint(
     cache: Option<&mut DocumentCache>,
     path: &Path,
     config: &Config,
-    rules: &[&dyn Rule],
 ) -> Result<FileReport, String> {
     let source = host
         .read_to_string(path, MAX_FILE)
         .map_err(|e| e.to_string())?;
+    let ext = extension_of(path);
     let diagnostics = match cache {
-        Some(cache) => lint_cached(cache, &source, config, rules).map_err(|e| e.to_string())?,
-        None => lint_direct(extension_of(path), &source, config)?,
+        Some(cache) => {
+            let registry = Registry::with_builtins();
+            let rr = RegionRules::base_only(resolve_rules(config));
+            lint_cached(
+                cache,
+                ext,
+                &source,
+                config,
+                &registry,
+                &ProcessorConfig::default(),
+                &rr,
+            )
+            .map_err(|e| e.to_string())?
+        }
+        None => lint_direct(ext, &source, config)?,
     };
     Ok(FileReport {
         path: path.to_path_buf(),
@@ -246,7 +258,7 @@ fn fix(
     let rules = resolve_rules(&config);
     note_if_no_rules(&rules, stderr);
     note_unknown_rules(&config, stderr);
-    let rule_refs: Vec<&dyn Rule> = rules.iter().map(|rule| rule.as_ref()).collect();
+    let registry = Registry::with_builtins();
 
     let inputs = expand::expand(host, cwd, paths);
     note_expansion(&inputs.notes, stderr);
@@ -263,7 +275,14 @@ fn fix(
     if inputs.stdin {
         match read_stdin(stdin) {
             Ok(source) => {
-                let fixed = tzlint_core::fix(&source, &rule_refs);
+                let rr = RegionRules::base_only(resolve_rules(&config));
+                let fixed = tzlint_core::fix(
+                    None,
+                    &source,
+                    &registry,
+                    &ProcessorConfig::default(),
+                    &rr,
+                );
                 let did_change = fixed != source;
                 if dry_run {
                     if did_change {
@@ -303,7 +322,10 @@ fn fix(
         };
         // `fix` parses internally and returns the source unchanged on a parse failure, so the
         // only failure to handle here is the write below.
-        let fixed = tzlint_core::fix(&source, &rule_refs);
+        let ext = extension_of(path);
+        let rr = RegionRules::base_only(resolve_rules(&config));
+        let fixed =
+            tzlint_core::fix(ext, &source, &registry, &ProcessorConfig::default(), &rr);
         if fixed == source {
             continue;
         }

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -190,8 +190,8 @@ fn lint_exit_status(had_error: bool, has_findings: bool) -> ExitStatus {
     }
 }
 
-/// Read `path` through the host and lint it, via the cache when enabled or the direct
-/// parse→archive→lint bridge otherwise.
+/// Read `path` through the host and lint it, via the cache when enabled or the processor seam
+/// ([`lint_document`]) otherwise.
 fn read_and_lint(
     host: &dyn Host,
     cache: Option<&mut DocumentCache>,
@@ -213,7 +213,8 @@ fn read_and_lint(
     })
 }
 
-/// The lowercase extension of `path` (dot-less), or `None`.
+/// The extension of `path` (dot-less, as-is), or `None`. Case is preserved here; [`Registry::for_ext`]
+/// lowercases when matching.
 fn extension_of(path: &Path) -> Option<&str> {
     path.extension().and_then(|e| e.to_str())
 }

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -23,13 +23,14 @@ use tzlint_core::io::{MAX_CONFIG, MAX_FILE};
 use tzlint_core::{
     Config, ConfigFormat, DocumentCache, Host, Registry, discover, lint_cached, lint_document,
 };
-use tzlint_pdk::{Diagnostic, Rule};
+use tzlint_pdk::Diagnostic;
 
 use crate::cli::{Cli, Command, OutputFormat, RuleListFormat, RulesCommand};
 use crate::expand;
 use crate::output::{self, FileReport};
 use crate::rules::{
-    processor_config_for, region_rules_for, resolve_rules, rule_info, rule_infos, unknown_rule_ids,
+    any_effective_rules, processor_config_for, region_rules_for, rule_info, rule_infos,
+    unknown_rule_ids,
 };
 
 /// The path label used for diagnostics linted from standard input.
@@ -113,8 +114,7 @@ fn lint(
     let stdout: &mut dyn Write = &mut *streams.stdout;
     let stderr: &mut dyn Write = &mut *streams.stderr;
     let config = load_config(cli, host, cwd, stderr)?;
-    let rules = resolve_rules(&config);
-    note_if_no_rules(&rules, stderr);
+    note_if_no_rules(&config, stderr);
     note_unknown_rules(&config, stderr);
     // One processor registry for the whole run, shared by every file and the stdin source.
     let registry = Registry::with_builtins();
@@ -269,8 +269,7 @@ fn fix(
     let stdout: &mut dyn Write = &mut *streams.stdout;
     let stderr: &mut dyn Write = &mut *streams.stderr;
     let config = load_config(cli, host, cwd, stderr)?;
-    let rules = resolve_rules(&config);
-    note_if_no_rules(&rules, stderr);
+    note_if_no_rules(&config, stderr);
     note_unknown_rules(&config, stderr);
     let registry = Registry::with_builtins();
 
@@ -322,6 +321,9 @@ fn fix(
     }
 
     for path in &inputs.files {
+        // Mirror `lint`: a known delimited file with no columns configured fixes nothing, so note
+        // why up front (otherwise `tzlint fix data.csv` silently makes no changes).
+        note_unconfigured_format(&config, path, stderr);
         let source = match host.read_to_string(path, MAX_FILE) {
             Ok(source) => source,
             Err(e) => {
@@ -537,8 +539,10 @@ fn load_config(
 
 /// Print a one-line note to stderr when the resolved rule set is empty (every built-in rule was
 /// turned off by config), so an empty result is not mistaken for "your text is clean".
-fn note_if_no_rules(rules: &[Box<dyn Rule>], stderr: &mut dyn Write) {
-    if rules.is_empty() {
+fn note_if_no_rules(config: &Config, stderr: &mut dyn Write) {
+    // A column overlay (`formats.*.columns.*.rules`) can re-enable a rule the base disabled, so
+    // check the effective set across base AND overlays — not just the base.
+    if !any_effective_rules(config) {
         let _ = writeln!(
             stderr,
             "note: every built-in rule is disabled by config; the pipeline runs but reports nothing"

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -1481,6 +1481,81 @@ mod tests {
     }
 
     #[test]
+    fn lint_csv_column_targeted_by_name_and_index_reports_each_cell_once() {
+        // Regression: when one physical column is targeted by BOTH a header name and a 1-based
+        // index, its cells must be linted exactly once (not twice). Here `body` (column 0 by name)
+        // and `1` (column 0 by index) resolve to the same column; the single TODO must yield ONE
+        // diagnostic, not two.
+        let host = MockHost::new();
+        host.put("data.csv", "body,x\nTODO fix,9\n");
+        host.put(
+            "c.json",
+            r#"{ "rules": { "no-hankaku-kana": false }, "formats": { "csv": { "header": true, "columns": { "body": { "parse-mode": "plain", "rules": { "no-todo": true } }, "1": { "parse-mode": "plain", "rules": { "no-todo": true } } } } } }"#,
+        );
+        let mut c = lint_cli("data.csv", OutputFormat::Json);
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, out, _err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Findings);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let diags = v[0]["diagnostics"].as_array().unwrap();
+        assert_eq!(
+            diags.len(),
+            1,
+            "the cell must be linted once, not doubled: {out}"
+        );
+        assert_eq!(diags[0]["rule_id"], "no-todo", "{out}");
+    }
+
+    #[test]
+    fn lint_csv_index_selected_column_reports_in_the_right_cell() {
+        // A column selected by 1-based INDEX (not name) is linted, and the diagnostic lands inside
+        // that cell. Column "2" → 0-based 1 → the `body` cell "TODO fix" (bytes 10..18 of the
+        // source); the `id` column is untouched.
+        let source = "id,body\n1,TODO fix\n";
+        let host = MockHost::new();
+        host.put("data.csv", source);
+        host.put(
+            "c.json",
+            r#"{ "rules": { "no-hankaku-kana": false }, "formats": { "csv": { "header": true, "columns": { "2": { "parse-mode": "plain", "rules": { "no-todo": true } } } } } }"#,
+        );
+        let mut c = lint_cli("data.csv", OutputFormat::Json);
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, out, _err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Findings);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let diags = v[0]["diagnostics"].as_array().unwrap();
+        assert_eq!(diags.len(), 1, "{out}");
+        assert_eq!(diags[0]["rule_id"], "no-todo", "{out}");
+        // The diagnostic must fall inside the body cell ("TODO fix" begins at byte 10).
+        let start = diags[0]["span"]["start"].as_u64().unwrap();
+        let end = diags[0]["span"]["end"].as_u64().unwrap();
+        let cell_start = source.find("TODO fix").unwrap() as u64;
+        assert!(
+            start >= cell_start && end <= (cell_start + "TODO fix".len() as u64),
+            "diagnostic span {start}..{end} should be inside the body cell at {cell_start}: {out}"
+        );
+    }
+
+    #[test]
+    fn lint_tsv_column_is_linted_end_to_end() {
+        // A `.tsv` file with a `formats.tsv` config: the tab-delimited `body` column is linted.
+        let host = MockHost::new();
+        host.put("data.tsv", "id\tbody\n1\tTODO fix\n");
+        host.put(
+            "c.json",
+            r#"{ "rules": { "no-hankaku-kana": false }, "formats": { "tsv": { "header": true, "columns": { "body": { "parse-mode": "plain", "rules": { "no-todo": true } } } } } }"#,
+        );
+        let mut c = lint_cli("data.tsv", OutputFormat::Json);
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, out, _err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Findings, "{out}");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let diags = v[0]["diagnostics"].as_array().unwrap();
+        assert_eq!(diags.len(), 1, "the tsv body TODO: {out}");
+        assert_eq!(diags[0]["rule_id"], "no-todo", "{out}");
+    }
+
+    #[test]
     fn fix_stdin_read_error_exits_error() {
         // The same failed-read handling for `fix -`: error on stderr, `Error` exit, no document on
         // stdout.

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -220,7 +220,11 @@ fn extension_of(path: &Path) -> Option<&str> {
 
 /// The no-cache path: select a processor by extension and lint via the processor seam, surfacing
 /// parse/archive failures as a message (mirrors what [`lint_cached`] reports on the cached path).
-fn lint_direct(ext: Option<&str>, source: &str, rules: &[&dyn Rule]) -> Result<Vec<Diagnostic>, String> {
+fn lint_direct(
+    ext: Option<&str>,
+    source: &str,
+    rules: &[&dyn Rule],
+) -> Result<Vec<Diagnostic>, String> {
     let registry = Registry::with_builtins();
     lint_document(ext, source, &registry, rules).map_err(|e| e.to_string())
 }

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -19,10 +19,9 @@
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
-use tzlint_ast::{access, to_archive};
 use tzlint_core::io::{MAX_CONFIG, MAX_FILE};
 use tzlint_core::{
-    Config, ConfigFormat, DocumentCache, Engine, Host, discover, lint_cached, parse,
+    Config, ConfigFormat, DocumentCache, Host, Registry, discover, lint_cached, lint_document,
 };
 use tzlint_pdk::{Diagnostic, Rule};
 
@@ -132,7 +131,7 @@ fn lint(
     // stdin is reported first so the work order is fixed and the summary count is stable.
     if inputs.stdin {
         match read_stdin(stdin).and_then(|source| {
-            let diagnostics = lint_direct(&source, &rule_refs)?;
+            let diagnostics = lint_direct(None, &source, &rule_refs)?;
             Ok(FileReport {
                 path: PathBuf::from(STDIN_LABEL),
                 source,
@@ -205,7 +204,7 @@ fn read_and_lint(
         .map_err(|e| e.to_string())?;
     let diagnostics = match cache {
         Some(cache) => lint_cached(cache, &source, config, rules).map_err(|e| e.to_string())?,
-        None => lint_direct(&source, rules)?,
+        None => lint_direct(extension_of(path), &source, rules)?,
     };
     Ok(FileReport {
         path: path.to_path_buf(),
@@ -214,13 +213,16 @@ fn read_and_lint(
     })
 }
 
-/// The no-cache path: parse → archive → access → [`Engine::lint`], surfacing parse/archive
-/// failures as a message (mirrors what [`lint_cached`] reports on the cached path).
-fn lint_direct(source: &str, rules: &[&dyn Rule]) -> Result<Vec<Diagnostic>, String> {
-    let ast = parse(source).map_err(|e| e.to_string())?;
-    let bytes = to_archive(&ast).map_err(|e| format!("archive failed: {e}"))?;
-    let archived = access(&bytes).map_err(|e| format!("archive failed: {e}"))?;
-    Ok(Engine::lint(archived, rules))
+/// The lowercase extension of `path` (dot-less), or `None`.
+fn extension_of(path: &Path) -> Option<&str> {
+    path.extension().and_then(|e| e.to_str())
+}
+
+/// The no-cache path: select a processor by extension and lint via the processor seam, surfacing
+/// parse/archive failures as a message (mirrors what [`lint_cached`] reports on the cached path).
+fn lint_direct(ext: Option<&str>, source: &str, rules: &[&dyn Rule]) -> Result<Vec<Diagnostic>, String> {
+    let registry = Registry::with_builtins();
+    lint_document(ext, source, &registry, rules).map_err(|e| e.to_string())
 }
 
 /// `fix`: lint-and-fix each file to a fixpoint; write changed files in place (or just report
@@ -1314,6 +1316,16 @@ mod tests {
         assert_eq!(status, ExitStatus::Clean);
         assert!(out.contains("\"max\":0"), "{out}");
         assert!(out.contains("from config"), "{out}");
+    }
+
+    #[test]
+    fn lint_routes_through_processor_seam_unchanged_for_markdown() {
+        // Same half-width-kana input as `lint_reports_a_violation_*`: routing through the
+        // processor seam must still produce the `no-hankaku-kana` diagnostic identically.
+        let host = MockHost::with("a.md", "ﾊﾛｰ\n");
+        let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
+        assert_eq!(status, ExitStatus::Findings);
+        assert!(out.contains("no-hankaku-kana"), "{out}");
     }
 
     #[test]

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -121,7 +121,8 @@ fn lint(
 
     // Resolve the PATH arguments into concrete files (globs / directories expanded, sorted and
     // de-duplicated) plus an optional stdin source; surface any discovery notes on stderr.
-    let inputs = expand::expand(host, cwd, paths);
+    let dir_exts = discovery_extensions(&config);
+    let inputs = expand::expand(host, cwd, paths, &dir_exts);
     note_expansion(&inputs.notes, stderr);
 
     // Persistent cache: load the on-disk file (best-effort) so a repeat run on unchanged content
@@ -230,6 +231,16 @@ fn extension_of(path: &Path) -> Option<&str> {
     path.extension().and_then(|e| e.to_str())
 }
 
+/// Extensions discovered when walking a directory: Markdown always, plus any configured
+/// delimited formats (so data CSVs are not linted unless the user opted in).
+fn discovery_extensions(config: &Config) -> Vec<String> {
+    let mut exts = vec!["md".to_string(), "markdown".to_string()];
+    for fmt in config.formats.keys() {
+        exts.push(fmt.clone()); // "csv" / "tsv"
+    }
+    exts
+}
+
 /// Lint one already-read source with the processor seam, given the file's extension.
 fn lint_source(
     registry: &Registry,
@@ -262,7 +273,8 @@ fn fix(
     note_unknown_rules(&config, stderr);
     let registry = Registry::with_builtins();
 
-    let inputs = expand::expand(host, cwd, paths);
+    let dir_exts = discovery_extensions(&config);
+    let inputs = expand::expand(host, cwd, paths, &dir_exts);
     note_expansion(&inputs.notes, stderr);
 
     // When stdin is a target, stdout carries the fixed stdin document (a pass-through filter), so
@@ -1348,6 +1360,39 @@ mod tests {
         let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
         assert_eq!(status, ExitStatus::Findings);
         assert!(out.contains("no-hankaku-kana"), "{out}");
+    }
+
+    #[test]
+    fn directory_walk_includes_csv_only_when_configured() {
+        // Without csv config, a directory walk skips .csv; with it, the .csv is linted.
+        let host = MockHost::new();
+        host.put("docs/a.md", "本文。\n");
+        host.put("docs/data.csv", "id,body\n1,x\n");
+        // No config → csv skipped, only the .md is checked.
+        let (s1, out1, _e1) = run_capture(&lint_cli("docs", OutputFormat::Text), &host);
+        assert_eq!(s1, ExitStatus::Clean);
+        assert!(out1.contains("1 file(s) checked"), "{out1}");
+
+        // With csv config → both files are checked.
+        host.put(
+            "c.json",
+            r#"{ "formats": { "csv": { "header": true, "columns": { "body": {} } } } }"#,
+        );
+        let mut c = lint_cli("docs", OutputFormat::Text);
+        c.config = Some(PathBuf::from("c.json"));
+        let (s2, out2, _e2) = run_capture(&c, &host);
+        assert_eq!(s2, ExitStatus::Clean);
+        assert!(out2.contains("2 file(s) checked"), "{out2}");
+    }
+
+    #[test]
+    fn explicitly_named_csv_is_linted_without_config_gate() {
+        // A literal .csv path is always a target (even with no formats config); it just yields
+        // no diagnostics (opt-in columns).
+        let host = MockHost::with("data.csv", "id,body\n1,x\n");
+        let (status, out, _err) = run_capture(&lint_cli("data.csv", OutputFormat::Text), &host);
+        assert_eq!(status, ExitStatus::Clean);
+        assert!(out.contains("1 file(s) checked"), "{out}");
     }
 
     #[test]

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -21,7 +21,8 @@ use std::path::{Path, PathBuf};
 
 use tzlint_core::io::{MAX_CONFIG, MAX_FILE};
 use tzlint_core::{
-    Config, ConfigFormat, DocumentCache, Host, Registry, discover, lint_cached, lint_document,
+    Config, ConfigFormat, DocumentCache, Host, ProcessorConfig, RegionRules, Registry, discover,
+    lint_cached, lint_document,
 };
 use tzlint_pdk::{Diagnostic, Rule};
 
@@ -131,7 +132,7 @@ fn lint(
     // stdin is reported first so the work order is fixed and the summary count is stable.
     if inputs.stdin {
         match read_stdin(stdin).and_then(|source| {
-            let diagnostics = lint_direct(None, &source, &rule_refs)?;
+            let diagnostics = lint_direct(None, &source, &config)?;
             Ok(FileReport {
                 path: PathBuf::from(STDIN_LABEL),
                 source,
@@ -204,7 +205,7 @@ fn read_and_lint(
         .map_err(|e| e.to_string())?;
     let diagnostics = match cache {
         Some(cache) => lint_cached(cache, &source, config, rules).map_err(|e| e.to_string())?,
-        None => lint_direct(extension_of(path), &source, rules)?,
+        None => lint_direct(extension_of(path), &source, config)?,
     };
     Ok(FileReport {
         path: path.to_path_buf(),
@@ -221,13 +222,10 @@ fn extension_of(path: &Path) -> Option<&str> {
 
 /// The no-cache path: select a processor by extension and lint via the processor seam, surfacing
 /// parse/archive failures as a message (mirrors what [`lint_cached`] reports on the cached path).
-fn lint_direct(
-    ext: Option<&str>,
-    source: &str,
-    rules: &[&dyn Rule],
-) -> Result<Vec<Diagnostic>, String> {
+fn lint_direct(ext: Option<&str>, source: &str, config: &Config) -> Result<Vec<Diagnostic>, String> {
     let registry = Registry::with_builtins();
-    lint_document(ext, source, &registry, rules).map_err(|e| e.to_string())
+    let rr = RegionRules::base_only(resolve_rules(config));
+    lint_document(ext, source, &registry, &ProcessorConfig::default(), &rr).map_err(|e| e.to_string())
 }
 
 /// `fix`: lint-and-fix each file to a fixpoint; write changed files in place (or just report

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -1385,6 +1385,37 @@ mod tests {
     }
 
     #[test]
+    fn changing_column_config_invalidates_cache() {
+        // Run once with body→no-todo on; then a config that turns it off must NOT reuse the
+        // cached (findings) result. The body cell carries a real marker ("TODO " has the trailing
+        // space the default `no-todo` pattern requires).
+        let host = MockHost::new();
+        host.put("data.csv", "id,body\n1,TODO fix\n");
+        host.put(
+            "on.json",
+            r#"{ "rules": { "no-hankaku-kana": false }, "formats": { "csv": { "header": true, "columns": { "body": { "parse-mode": "plain", "rules": { "no-todo": true } } } } } }"#,
+        );
+        host.put(
+            "off.json",
+            r#"{ "rules": { "no-hankaku-kana": false }, "formats": { "csv": { "header": true, "columns": { "body": { "parse-mode": "plain", "rules": { "no-todo": false } } } } } }"#,
+        );
+
+        let mut on = lint_cli("data.csv", OutputFormat::Text);
+        on.config = Some(PathBuf::from("on.json"));
+        let (s_on, out_on, _e) = run_capture(&on, &host);
+        assert_eq!(s_on, ExitStatus::Findings, "{out_on}");
+
+        let mut off = lint_cli("data.csv", OutputFormat::Text);
+        off.config = Some(PathBuf::from("off.json"));
+        let (s_off, out_off, _e) = run_capture(&off, &host);
+        assert_eq!(
+            s_off,
+            ExitStatus::Clean,
+            "cache must invalidate on column-rule change: {out_off}"
+        );
+    }
+
+    #[test]
     fn notes_when_csv_has_no_columns_configured() {
         // A .csv argument with no formats config → a note that nothing was linted.
         let host = MockHost::with("data.csv", "id,body\n1,x\n");

--- a/crates/tzlint_cli/src/expand.rs
+++ b/crates/tzlint_cli/src/expand.rs
@@ -5,7 +5,8 @@
 //! - a glob pattern (contains `*`, `?`, or `[`) — matched with `glob::Pattern` against paths
 //!   discovered by walking [`Host::list_dir`] (never `glob::glob()`, which would touch the
 //!   filesystem directly and bypass the io boundary),
-//! - a directory — recursively yields its Markdown files,
+//! - a directory — recursively yields its files whose extension is in the caller-supplied
+//!   discovery set (Markdown always, plus any configured delimited formats),
 //! - or a literal file path — passed through verbatim (so an existing file behaves exactly as
 //!   before this expansion existed, and a missing one still errors at read time).
 //!
@@ -26,8 +27,6 @@ const MAX_DEPTH: usize = 64;
 /// Soft cap on discovered files; on reaching it, discovery stops and a note is emitted, so a
 /// run over an unexpectedly huge tree fails visibly rather than exhausting memory.
 const MAX_FILES: usize = 100_000;
-/// Extensions a directory / `**`-recursion picks up, matched case-insensitively.
-const MARKDOWN_EXTENSIONS: [&str; 2] = ["md", "markdown"];
 
 /// The expanded work list.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -43,9 +42,10 @@ pub struct Inputs {
 /// Expand `args` (the user's PATH arguments) relative to `cwd`.
 ///
 /// `-` requests stdin (collapsed to a single read). An argument with a glob metacharacter
-/// (`*`, `?`, `[`) is glob-expanded; a listable directory recurses for Markdown files; anything
-/// else is a literal path passed through verbatim (so a missing file still errors at read time).
-pub fn expand(host: &dyn Host, cwd: &Path, args: &[PathBuf]) -> Inputs {
+/// (`*`, `?`, `[`) is glob-expanded; a listable directory recurses for files whose extension is
+/// in `dir_extensions` (Markdown always, plus any configured delimited formats); anything else is
+/// a literal path passed through verbatim (so a missing file still errors at read time).
+pub fn expand(host: &dyn Host, cwd: &Path, args: &[PathBuf], dir_extensions: &[String]) -> Inputs {
     let mut walk = Walk {
         host,
         files: BTreeSet::new(),
@@ -63,7 +63,7 @@ pub fn expand(host: &dyn Host, cwd: &Path, args: &[PathBuf]) -> Inputs {
         if is_glob(&as_str) {
             walk.glob(cwd, &as_str);
         } else if host.list_dir(arg).is_ok() {
-            walk.directory(arg);
+            walk.directory(arg, dir_extensions);
         } else {
             // Not a glob and not a listable directory → a literal file. Pass it through verbatim
             // (no `cwd.join`, no canonicalization): the read reproduces today's behavior exactly,
@@ -90,15 +90,11 @@ fn is_hidden(name: &str) -> bool {
     name.starts_with('.')
 }
 
-/// Whether `path`'s extension is a Markdown extension (case-insensitive).
-fn is_markdown(path: &Path) -> bool {
+/// Whether `path`'s extension (case-insensitive) is in `exts`.
+fn has_extension(path: &Path, exts: &[String]) -> bool {
     path.extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| {
-            MARKDOWN_EXTENSIONS
-                .iter()
-                .any(|candidate| ext.eq_ignore_ascii_case(candidate))
-        })
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| exts.iter().any(|x| e.eq_ignore_ascii_case(x)))
 }
 
 /// Split a glob pattern into its longest literal directory prefix (used as the walk root, so
@@ -131,8 +127,8 @@ fn split_literal_prefix(pattern: &str) -> (PathBuf, String) {
 
 /// What a [`Walk`] selects at each file.
 enum Selector<'a> {
-    /// Directory recursion: keep Markdown files.
-    Markdown,
+    /// Directory recursion: match files whose extension (case-insensitive) is in this set.
+    Extensions(&'a [String]),
     /// Glob: keep files whose path matches the pattern.
     Glob(&'a glob::Pattern),
 }
@@ -149,9 +145,9 @@ struct Walk<'a> {
 }
 
 impl Walk<'_> {
-    /// Recurse `dir` for Markdown files.
-    fn directory(&mut self, dir: &Path) {
-        self.descend(dir, dir, 0, MAX_DEPTH, &Selector::Markdown);
+    /// Recurse `dir` for files whose extension is in `exts` (case-insensitive).
+    fn directory(&mut self, dir: &Path, exts: &[String]) {
+        self.descend(dir, dir, 0, MAX_DEPTH, &Selector::Extensions(exts));
     }
 
     /// Expand a glob pattern by walking its literal prefix and matching the rest.
@@ -230,7 +226,7 @@ impl Walk<'_> {
                 EntryKind::File => {
                     let emit_path = emit_dir.join(&entry.name);
                     let selected = match selector {
-                        Selector::Markdown => is_markdown(&emit_path),
+                        Selector::Extensions(exts) => has_extension(&emit_path, exts),
                         Selector::Glob(pattern) => {
                             pattern.matches_path_with(&match_dir.join(&entry.name), match_options())
                         }
@@ -362,7 +358,8 @@ mod tests {
 
     fn run(host: &TreeHost, args: &[&str]) -> Inputs {
         let args: Vec<PathBuf> = args.iter().map(PathBuf::from).collect();
-        expand(host, Path::new(CWD), &args)
+        let exts = [String::from("md"), String::from("markdown")];
+        expand(host, Path::new(CWD), &args, &exts)
     }
 
     fn paths(strs: &[&str]) -> Vec<PathBuf> {

--- a/crates/tzlint_cli/src/rules.rs
+++ b/crates/tzlint_cli/src/rules.rs
@@ -10,26 +10,83 @@
 //! with default options and its default severity. Unknown rule ids in config are surfaced via
 //! [`unknown_rule_ids`] so a typo'd setting is not silently ignored.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::Value;
-use tzlint_core::{Config, RuleSetting};
+use tzlint_core::processor::{ColumnTarget, DelimitedConfig};
+use tzlint_core::{Config, ProcessorConfig, RegionRules, RuleSetting};
 use tzlint_pdk::{Rule, RuleId, Severity};
 use tzlint_rules::{RULE_IDS, build_rule};
+
+/// Build the boxed rule set for an explicit rule-settings map (every built-in on by default,
+/// minus those turned off, each with its configured options/severity).
+#[must_use]
+pub fn resolve_rules_from_map(rules: &BTreeMap<RuleId, RuleSetting>) -> Vec<Box<dyn Rule>> {
+    RULE_IDS
+        .iter()
+        .filter_map(|id| match rules.get(&RuleId::from(*id)) {
+            Some(RuleSetting::Off) => None,
+            Some(RuleSetting::On { severity, options }) => build_rule(id, options, *severity),
+            None => build_rule(id, &Value::Null, None),
+        })
+        .collect()
+}
 
 /// Build the boxed rule set to run for `config`: every built-in rule (in [`RULE_IDS`] order)
 /// except those a `config.rules` entry turns off, each constructed with its configured options
 /// and severity.
 #[must_use]
 pub fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
-    RULE_IDS
-        .iter()
-        .filter_map(|id| match config.rules.get(&RuleId::from(*id)) {
-            Some(RuleSetting::Off) => None,
-            Some(RuleSetting::On { severity, options }) => build_rule(id, options, *severity),
-            None => build_rule(id, &Value::Null, None),
-        })
-        .collect()
+    resolve_rules_from_map(&config.rules)
+}
+
+/// The [`ProcessorConfig`] for a file with extension `ext` under `config`: the matching
+/// `formats.<ext>` section becomes the delimited extraction config, or empty for other formats.
+#[must_use]
+pub fn processor_config_for(config: &Config, ext: Option<&str>) -> ProcessorConfig {
+    let Some(fmt) = ext.and_then(|e| config.formats.get(&e.to_ascii_lowercase())) else {
+        return ProcessorConfig::default();
+    };
+    ProcessorConfig {
+        delimited: Some(DelimitedConfig {
+            delimiter: fmt.delimiter.map(|c| c as u8).unwrap_or(0),
+            has_header: fmt.has_header,
+            columns: fmt
+                .columns
+                .iter()
+                .map(|c| ColumnTarget {
+                    selector: c.selector.clone(),
+                    parse_mode: c.parse_mode,
+                })
+                .collect(),
+        }),
+    }
+}
+
+/// The [`RegionRules`] for a file with extension `ext` under `config`: a base set from
+/// `config.rules`, plus one set per configured column (its overlay layered over the base).
+#[must_use]
+pub fn region_rules_for(config: &Config, ext: Option<&str>) -> RegionRules {
+    let mut rr = RegionRules::base_only(resolve_rules(config));
+    if let Some(fmt) = ext.and_then(|e| config.formats.get(&e.to_ascii_lowercase())) {
+        for col in &fmt.columns {
+            // base ⊕ column overlay (column wins).
+            let mut merged = config.rules.clone();
+            for (id, setting) in &col.rules {
+                merged.insert(id.clone(), setting.clone());
+            }
+            let rules = resolve_rules_from_map(&merged);
+            match &col.selector {
+                tzlint_core::processor::ColumnSelector::Index(one_based) => {
+                    rr.push_column(one_based.checked_sub(1), None, rules);
+                }
+                tzlint_core::processor::ColumnSelector::Name(name) => {
+                    rr.push_column(None, Some(name.clone()), rules);
+                }
+            }
+        }
+    }
+    rr
 }
 
 /// The effective state of one built-in rule under a resolved [`Config`] — what the `rules`
@@ -273,5 +330,98 @@ mod tests {
             assert_eq!(info.severity, built.meta().default_severity, "{id}");
             assert!(!info.severity_overridden, "{id}");
         }
+    }
+}
+
+#[cfg(test)]
+mod processing_builders {
+    use super::*;
+    use std::collections::BTreeMap;
+    use tzlint_core::processor::{ColumnSelector, ParseMode};
+    use tzlint_core::{ColumnConfig, Config, FormatConfig};
+
+    fn csv_config() -> Config {
+        let mut formats = BTreeMap::new();
+        formats.insert(
+            "csv".into(),
+            FormatConfig {
+                has_header: true,
+                delimiter: None,
+                columns: vec![ColumnConfig {
+                    selector: ColumnSelector::Name("body".into()),
+                    parse_mode: ParseMode::PlainText,
+                    rules: BTreeMap::new(),
+                }],
+            },
+        );
+        Config {
+            formats,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn processor_config_for_csv_extension() {
+        let config = csv_config();
+        let pcfg = processor_config_for(&config, Some("csv"));
+        let d = pcfg.delimited.unwrap();
+        assert!(d.has_header);
+        assert_eq!(d.columns.len(), 1);
+        assert_eq!(d.columns[0].selector, ColumnSelector::Name("body".into()));
+        assert_eq!(d.columns[0].parse_mode, ParseMode::PlainText);
+        // A markdown file → no delimited config.
+        assert!(
+            processor_config_for(&config, Some("md"))
+                .delimited
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn region_rules_for_layers_column_overlay_over_base() {
+        use tzlint_core::RegionTag;
+        // Base disables no-todo; the body column re-enables it. The whole region uses the base
+        // (no-todo absent), while the `body` column region runs no-todo.
+        let mut formats = BTreeMap::new();
+        let mut overlay = BTreeMap::new();
+        overlay.insert(
+            RuleId::from("no-todo"),
+            RuleSetting::On {
+                severity: None,
+                options: Value::Null,
+            },
+        );
+        formats.insert(
+            "csv".into(),
+            FormatConfig {
+                has_header: true,
+                delimiter: None,
+                columns: vec![ColumnConfig {
+                    selector: ColumnSelector::Name("body".into()),
+                    parse_mode: ParseMode::PlainText,
+                    rules: overlay,
+                }],
+            },
+        );
+        let mut base_rules = BTreeMap::new();
+        base_rules.insert(RuleId::from("no-todo"), RuleSetting::Off);
+        let config = Config {
+            rules: base_rules,
+            formats,
+            ..Default::default()
+        };
+
+        let rr = region_rules_for(&config, Some("csv"));
+        let has = |rules: &[&dyn Rule], id: &str| rules.iter().any(|r| r.meta().id.as_str() == id);
+        // The whole-region (base) set has no-todo OFF.
+        assert!(!has(&rr.for_tag(&RegionTag::whole()), "no-todo"));
+        // The `body` column set has no-todo back ON (column overlay wins).
+        assert!(has(
+            &rr.for_tag(&RegionTag::column(1, Some("body".into()))),
+            "no-todo"
+        ));
+        // A markdown file (no csv overlay) yields only the base set, never the column overlay.
+        let md = region_rules_for(&config, Some("md"));
+        assert!(!has(&md.for_tag(&RegionTag::whole()), "no-todo"));
     }
 }

--- a/crates/tzlint_cli/src/rules.rs
+++ b/crates/tzlint_cli/src/rules.rs
@@ -49,6 +49,8 @@ pub fn processor_config_for(config: &Config, ext: Option<&str>) -> ProcessorConf
     };
     ProcessorConfig {
         delimited: Some(DelimitedConfig {
+            // `delimiter` is guaranteed ASCII by config parsing (`ConfigError::NonAsciiDelimiter`),
+            // so `c as u8` is lossless here; `0` means "use the processor default".
             delimiter: fmt.delimiter.map(|c| c as u8).unwrap_or(0),
             has_header: fmt.has_header,
             columns: fmt

--- a/crates/tzlint_cli/src/rules.rs
+++ b/crates/tzlint_cli/src/rules.rs
@@ -124,6 +124,7 @@ mod tests {
             language: None,
             message_language: None,
             rules: map,
+            ..Default::default()
         }
     }
 

--- a/crates/tzlint_cli/src/rules.rs
+++ b/crates/tzlint_cli/src/rules.rs
@@ -40,6 +40,27 @@ pub fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
     resolve_rules_from_map(&config.rules)
 }
 
+/// Whether **any** rule runs anywhere under `config`: the base set, or any column overlay
+/// (`formats.*.columns.*.rules`). A column overlay can re-enable a rule the base turned off, so a
+/// check against the base alone (`resolve_rules`) is not enough to decide whether the run will
+/// report nothing — the CLI uses this for that note.
+#[must_use]
+pub fn any_effective_rules(config: &Config) -> bool {
+    if !resolve_rules(config).is_empty() {
+        return true;
+    }
+    config.formats.values().any(|fmt| {
+        fmt.columns.iter().any(|col| {
+            // base ⊕ column overlay (column wins) — same layering as `region_rules_for`.
+            let mut merged = config.rules.clone();
+            for (id, setting) in &col.rules {
+                merged.insert(id.clone(), setting.clone());
+            }
+            !resolve_rules_from_map(&merged).is_empty()
+        })
+    })
+}
+
 /// The [`ProcessorConfig`] for a file with extension `ext` under `config`: the matching
 /// `formats.<ext>` section becomes the delimited extraction config, or empty for other formats.
 #[must_use]
@@ -425,5 +446,55 @@ mod processing_builders {
         // A markdown file (no csv overlay) yields only the base set, never the column overlay.
         let md = region_rules_for(&config, Some("md"));
         assert!(!has(&md.for_tag(&RegionTag::whole()), "no-todo"));
+    }
+
+    /// A config that disables every built-in rule in the base set.
+    fn all_base_off() -> BTreeMap<RuleId, RuleSetting> {
+        RULE_IDS
+            .iter()
+            .map(|id| (RuleId::from(*id), RuleSetting::Off))
+            .collect()
+    }
+
+    #[test]
+    fn any_effective_rules_false_when_base_off_and_no_overlay() {
+        let config = Config {
+            rules: all_base_off(),
+            ..Default::default()
+        };
+        assert!(!any_effective_rules(&config));
+    }
+
+    #[test]
+    fn any_effective_rules_true_when_a_column_overlay_re_enables_a_rule() {
+        // Base disables everything, but the csv `body` column re-enables no-todo — so the run does
+        // report something, and the "everything disabled" note must be suppressed.
+        let mut overlay = BTreeMap::new();
+        overlay.insert(
+            RuleId::from("no-todo"),
+            RuleSetting::On {
+                severity: None,
+                options: Value::Null,
+            },
+        );
+        let mut formats = BTreeMap::new();
+        formats.insert(
+            "csv".into(),
+            FormatConfig {
+                has_header: true,
+                delimiter: None,
+                columns: vec![ColumnConfig {
+                    selector: ColumnSelector::Name("body".into()),
+                    parse_mode: ParseMode::PlainText,
+                    rules: overlay,
+                }],
+            },
+        );
+        let config = Config {
+            rules: all_base_off(),
+            formats,
+            ..Default::default()
+        };
+        assert!(any_effective_rules(&config));
     }
 }

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -921,8 +921,8 @@ mod tests {
 
         let build_rules = || RegionRules::base_only(vec![Box::new(FlagKind::new(NodeKind::TEXT))]);
 
-        let fresh = crate::lint_document(Some("csv"), source, &registry, &pcfg, &build_rules())
-            .unwrap();
+        let fresh =
+            crate::lint_document(Some("csv"), source, &registry, &pcfg, &build_rules()).unwrap();
         assert_eq!(fresh.len(), 2, "two body cells flagged");
 
         let mut cache = DocumentCache::new();

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -193,6 +193,58 @@ fn fingerprint_config(config: &Config) -> Result<[u8; 32], serde_json::Error> {
             }
         }
     }
+
+    // Format settings: which columns are linted, with what parse mode and rule overlay.
+    hasher.update(&(config.formats.len() as u64).to_le_bytes());
+    for (fmt_id, fmt) in &config.formats {
+        put(&mut hasher, fmt_id.as_bytes());
+        hasher.update(&[u8::from(fmt.has_header)]);
+        match fmt.delimiter {
+            None => {
+                hasher.update(&[0x00]);
+            }
+            Some(c) => {
+                hasher.update(&[0x01]);
+                put(&mut hasher, c.to_string().as_bytes());
+            }
+        }
+        hasher.update(&(fmt.columns.len() as u64).to_le_bytes());
+        for col in &fmt.columns {
+            match &col.selector {
+                crate::processor::ColumnSelector::Name(n) => {
+                    hasher.update(&[0x00]);
+                    put(&mut hasher, n.as_bytes());
+                }
+                crate::processor::ColumnSelector::Index(i) => {
+                    hasher.update(&[0x01]);
+                    hasher.update(&i.to_le_bytes());
+                }
+            }
+            hasher.update(&[parse_mode_byte(col.parse_mode)]);
+            // Column rule overlay (same encoding as the base rules above).
+            hasher.update(&(col.rules.len() as u64).to_le_bytes());
+            for (id, setting) in &col.rules {
+                put(&mut hasher, id.as_str().as_bytes());
+                match setting {
+                    RuleSetting::Off => {
+                        hasher.update(&[0x00]);
+                    }
+                    RuleSetting::On { severity, options } => {
+                        hasher.update(&[0x01]);
+                        match severity {
+                            None => {
+                                hasher.update(&[0x00]);
+                            }
+                            Some(sev) => {
+                                hasher.update(&[0x01, severity_byte(*sev)]);
+                            }
+                        }
+                        put(&mut hasher, &serde_json::to_vec(options)?);
+                    }
+                }
+            }
+        }
+    }
     Ok(*hasher.finalize().as_bytes())
 }
 
@@ -216,6 +268,14 @@ fn severity_byte(severity: Severity) -> u8 {
         Severity::Warning => 1,
         Severity::Info => 2,
         Severity::Hint => 3,
+    }
+}
+
+/// Stable parse-mode discriminant for the format-settings fold in the fingerprint.
+fn parse_mode_byte(mode: crate::processor::ParseMode) -> u8 {
+    match mode {
+        crate::processor::ParseMode::Markdown => 0,
+        crate::processor::ParseMode::PlainText => 1,
     }
 }
 
@@ -610,6 +670,34 @@ mod tests {
             key_of("x", &cfg(r#"{"rules":{"r":{"options":{"max":1}}}}"#)),
             key_of("x", &cfg(r#"{"rules":{"r":{"options":{"max":2}}}}"#))
         );
+    }
+
+    #[test]
+    fn formats_change_the_cache_key() {
+        use crate::processor::{ColumnSelector, ParseMode};
+        use crate::{ColumnConfig, Config, FormatConfig};
+        use std::collections::BTreeMap;
+
+        let base = Config::default();
+        let mut with_cols = Config::default();
+        let mut formats = BTreeMap::new();
+        formats.insert(
+            "csv".to_string(),
+            FormatConfig {
+                has_header: true,
+                delimiter: None,
+                columns: vec![ColumnConfig {
+                    selector: ColumnSelector::Name("body".into()),
+                    parse_mode: ParseMode::Markdown,
+                    rules: BTreeMap::new(),
+                }],
+            },
+        );
+        with_cols.formats = formats;
+
+        let k1 = key_of("x", &base);
+        let k2 = key_of("x", &with_cols);
+        assert_ne!(k1, k2);
     }
 
     #[test]

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -37,7 +37,7 @@ use crate::io::{Host, IoError};
 use crate::parse::ParseError;
 
 /// Cache-key recipe version. Bump to invalidate every key if the key *construction* changes.
-const KEY_SCHEMA_VERSION: u32 = 1;
+const KEY_SCHEMA_VERSION: u32 = 2;
 /// The markdown parser pin. Bump when the `markdown` dependency's major/minor changes.
 const PARSER_VERSION: &str = "markdown@1.0";
 /// The mdast → index-AST transform and enabled constructs. Bump on any change to the transform,
@@ -113,6 +113,11 @@ pub struct CacheKeyInput<'a> {
     /// The exact document source. It MUST be the same `&str` later handed to `parse` (see
     /// [`lint_cached`]), so the key and the parsed spans describe the same bytes.
     pub content: &'a str,
+    /// A stable identity for the processor that parses `content` — its primary extension
+    /// (`"md"`, `"csv"`, `"tsv"`, …). Two processors can yield different diagnostics for
+    /// byte-identical content (e.g. Markdown vs an un-configured CSV that lints nothing), so the
+    /// key must distinguish them even when the resolved rule set coincides (spec §10).
+    pub processor: &'a str,
     /// The resolved configuration.
     pub config: &'a Config,
     /// `(rule-id, rule-version)` for the enabled rules, in any order (sorted internally). Empty
@@ -135,6 +140,9 @@ pub fn document_cache_key(input: &CacheKeyInput) -> Result<CacheKey, serde_json:
         &mut hasher,
         blake3::hash(input.content.as_bytes()).as_bytes(),
     );
+    // 2b. Processor identity — byte-identical content under a different processor must not share
+    // a key (see `CacheKeyInput::processor`).
+    put(&mut hasher, input.processor.as_bytes());
     // 3. Config fingerprint.
     put(&mut hasher, &fingerprint_config(input.config)?);
     // 4. Parser/transform/engine/ABI versions, as one canonical string.
@@ -499,8 +507,18 @@ pub fn lint_cached(
     // rule set.) The `config` fold already covers the `formats` settings (Task 3.3).
     let rule_versions: Vec<(&str, &str)> =
         rules.rule_ids().into_iter().map(|id| (id, "")).collect();
+    // The selected processor's primary extension identifies it in the key, so byte-identical
+    // content linted under two processors (e.g. `.md` vs an un-configured `.csv`) never collides
+    // even when `rule_ids()` coincide.
+    let processor = registry
+        .for_ext(ext)
+        .extensions()
+        .first()
+        .copied()
+        .unwrap_or("");
     let key = document_cache_key(&CacheKeyInput {
         content,
+        processor,
         config,
         rule_versions: &rule_versions,
         morphology_fingerprint: &[],
@@ -597,6 +615,7 @@ mod tests {
     fn key_of(content: &str, config: &Config) -> CacheKey {
         document_cache_key(&CacheKeyInput {
             content,
+            processor: "md",
             config,
             rule_versions: &[],
             morphology_fingerprint: &[],
@@ -700,6 +719,80 @@ mod tests {
     }
 
     #[test]
+    fn processor_identity_is_in_the_cache_key() {
+        // Byte-identical content + config under two processors yields different keys (spec §10).
+        let config = Config::default();
+        let key = |processor| {
+            document_cache_key(&CacheKeyInput {
+                content: "x",
+                processor,
+                config: &config,
+                rule_versions: &[],
+                morphology_fingerprint: &[],
+            })
+            .unwrap()
+        };
+        assert_ne!(key("md"), key("csv"));
+        assert_eq!(key("md"), key("md"));
+    }
+
+    #[test]
+    fn csv_without_columns_does_not_reuse_markdown_cache_entry() {
+        // Regression: the same content + config (no `formats`) linted as `.md` then as `.csv`
+        // must NOT share a cache entry. Markdown flags a TEXT node; an un-configured CSV has no
+        // target columns, so it lints nothing. Their `rule_ids()` coincide (base-only), so before
+        // the processor identity was folded into the key the CSV wrongly reused the Markdown hit.
+        use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+        struct FlagText(RuleMeta);
+        impl Rule for FlagText {
+            fn meta(&self) -> &RuleMeta {
+                &self.0
+            }
+            fn check<'a>(&self, node: NodeRef<'a>, cx: &mut Context<'a>) {
+                cx.report(node.span(), "text");
+            }
+        }
+
+        let rules = crate::RegionRules::base_only(vec![Box::new(FlagText(RuleMeta::new(
+            "flag-text",
+            Severity::Warning,
+            vec![tzlint_ast::NodeKind::TEXT],
+        )))]);
+        let registry = crate::Registry::with_builtins();
+        let pcfg = crate::ProcessorConfig::default();
+        let config = Config::default();
+        let mut cache = DocumentCache::new();
+
+        let md = lint_cached(
+            &mut cache,
+            Some("md"),
+            "abc",
+            &config,
+            &registry,
+            &pcfg,
+            &rules,
+        )
+        .unwrap();
+        assert!(!md.is_empty(), "markdown should flag the text node");
+
+        let csv = lint_cached(
+            &mut cache,
+            Some("csv"),
+            "abc",
+            &config,
+            &registry,
+            &pcfg,
+            &rules,
+        )
+        .unwrap();
+        assert!(
+            csv.is_empty(),
+            "an un-configured csv must lint nothing, not reuse the markdown cache entry"
+        );
+    }
+
+    #[test]
     fn key_is_invariant_to_option_key_order() {
         // The canonical JSON fingerprint must not depend on object-key order.
         let a = cfg(r#"{"rules":{"r":{"options":{"a":1,"b":2}}}}"#);
@@ -723,6 +816,7 @@ mod tests {
         let k = |rv: &[(&str, &str)]| {
             document_cache_key(&CacheKeyInput {
                 content: "x",
+                processor: "md",
                 config: &c,
                 rule_versions: rv,
                 morphology_fingerprint: &[],
@@ -739,6 +833,7 @@ mod tests {
         let c = Config::default();
         let none = document_cache_key(&CacheKeyInput {
             content: "x",
+            processor: "md",
             config: &c,
             rule_versions: &[],
             morphology_fingerprint: &[],
@@ -746,6 +841,7 @@ mod tests {
         .unwrap();
         let present = document_cache_key(&CacheKeyInput {
             content: "x",
+            processor: "md",
             config: &c,
             rule_versions: &[],
             morphology_fingerprint: &[0xAB; 32],

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -30,12 +30,11 @@ use std::path::Path;
 use blake3::Hasher;
 use serde_json::Value;
 use tzlint_ast::Span;
-use tzlint_pdk::{Diagnostic, Fix, Rule, Severity};
+use tzlint_pdk::{Diagnostic, Fix, Severity};
 
 use crate::config::{Config, RuleSetting};
-use crate::engine::Engine;
 use crate::io::{Host, IoError};
-use crate::parse::{ParseError, parse};
+use crate::parse::ParseError;
 
 /// Cache-key recipe version. Bump to invalidate every key if the key *construction* changes.
 const KEY_SCHEMA_VERSION: u32 = 1;
@@ -487,17 +486,19 @@ impl std::error::Error for CacheError {
 /// `(id, version)` pairs derived below.
 pub fn lint_cached(
     cache: &mut DocumentCache,
+    ext: Option<&str>,
     content: &str,
     config: &Config,
-    rules: &[&dyn Rule],
+    registry: &crate::Registry,
+    processor_cfg: &crate::ProcessorConfig,
+    rules: &crate::RegionRules,
 ) -> Result<Vec<Diagnostic>, CacheError> {
-    // Derive rule identity from the rules actually run, so the key reflects the real rule set.
-    // (Keying off a separately-supplied list would let it drift from `rules` — the staleness
-    // this avoids: e.g. an empty-rules result must not be reused for a non-empty rule set.)
-    let rule_versions: Vec<(&str, &str)> = rules
-        .iter()
-        .map(|rule| (rule.meta().id.as_str(), ""))
-        .collect();
+    // Derive rule identity from every rule across the base and column sets, so the key reflects
+    // the real rule set. (Keying off a separately-supplied list would let it drift from `rules`
+    // — the staleness this avoids: e.g. an empty-rules result must not be reused for a non-empty
+    // rule set.) The `config` fold already covers the `formats` settings (Task 3.3).
+    let rule_versions: Vec<(&str, &str)> =
+        rules.rule_ids().into_iter().map(|id| (id, "")).collect();
     let key = document_cache_key(&CacheKeyInput {
         content,
         config,
@@ -510,10 +511,8 @@ pub fn lint_cached(
         return Ok(hit);
     }
 
-    let ast = parse(content).map_err(CacheError::Parse)?;
-    let bytes = tzlint_ast::to_archive(&ast).map_err(|e| CacheError::Archive(e.to_string()))?;
-    let archived = tzlint_ast::access(&bytes).map_err(|e| CacheError::Archive(e.to_string()))?;
-    let diagnostics = Engine::lint(archived, rules);
+    let diagnostics = crate::lint_document(ext, content, registry, processor_cfg, rules)
+        .map_err(CacheError::Parse)?;
     cache.insert(key, diagnostics.clone());
     Ok(diagnostics)
 }
@@ -589,7 +588,7 @@ fn span_from_value(value: &Value) -> Option<Span> {
 mod tests {
     use super::*;
     use tzlint_ast::{NodeKind, Span};
-    use tzlint_pdk::{Context, NodeRef, RuleMeta};
+    use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta};
 
     fn cfg(json: &str) -> Config {
         Config::parse(json, crate::config::ConfigFormat::Json).unwrap()
@@ -847,15 +846,109 @@ mod tests {
     fn lint_cached_miss_then_hit_matches_fresh() {
         let mut cache = DocumentCache::new();
         let c = Config::default();
-        let rule = FlagKind::new(NodeKind::HEADING);
-        let rules: &[&dyn Rule] = &[&rule];
+        let registry = crate::Registry::with_builtins();
+        let pcfg = crate::ProcessorConfig::default();
+        let new_rules =
+            || crate::RegionRules::base_only(vec![Box::new(FlagKind::new(NodeKind::HEADING))]);
 
-        let fresh = lint_cached(&mut cache, "# H\n\nbody", &c, rules).unwrap();
+        let fresh = lint_cached(
+            &mut cache,
+            Some("md"),
+            "# H\n\nbody",
+            &c,
+            &registry,
+            &pcfg,
+            &new_rules(),
+        )
+        .unwrap();
         assert_eq!(fresh.len(), 1, "one heading flagged");
         assert_eq!(cache.len(), 1);
         // Second call is a hit returning identical diagnostics.
-        let hit = lint_cached(&mut cache, "# H\n\nbody", &c, rules).unwrap();
+        let hit = lint_cached(
+            &mut cache,
+            Some("md"),
+            "# H\n\nbody",
+            &c,
+            &registry,
+            &pcfg,
+            &new_rules(),
+        )
+        .unwrap();
         assert_eq!(hit, fresh);
+        assert_eq!(cache.len(), 1, "no new entry on a hit");
+    }
+
+    #[test]
+    fn lint_cached_csv_round_trip_matches_fresh_compute() {
+        use crate::processor::{
+            ColumnSelector, ColumnTarget, DelimitedConfig, ParseMode, ProcessorConfig, RegionRules,
+            Registry,
+        };
+        use crate::{ColumnConfig, FormatConfig};
+        use std::collections::BTreeMap;
+
+        // A FlagText-style rule that flags TEXT nodes, applied only to the "body" column.
+        let source = "id,body\n1,hello\n2,world\n";
+        let registry = Registry::with_builtins();
+        let pcfg = ProcessorConfig {
+            delimited: Some(DelimitedConfig {
+                delimiter: b',',
+                has_header: true,
+                columns: vec![ColumnTarget {
+                    selector: ColumnSelector::Name("body".into()),
+                    parse_mode: ParseMode::PlainText,
+                }],
+            }),
+        };
+        // The config must carry the formats so the cache key reflects them.
+        let mut formats = BTreeMap::new();
+        formats.insert(
+            "csv".to_string(),
+            FormatConfig {
+                has_header: true,
+                delimiter: None,
+                columns: vec![ColumnConfig {
+                    selector: ColumnSelector::Name("body".into()),
+                    parse_mode: ParseMode::PlainText,
+                    rules: BTreeMap::new(),
+                }],
+            },
+        );
+        let config = Config {
+            formats,
+            ..Default::default()
+        };
+
+        let build_rules = || RegionRules::base_only(vec![Box::new(FlagKind::new(NodeKind::TEXT))]);
+
+        let fresh = crate::lint_document(Some("csv"), source, &registry, &pcfg, &build_rules())
+            .unwrap();
+        assert_eq!(fresh.len(), 2, "two body cells flagged");
+
+        let mut cache = DocumentCache::new();
+        let miss = lint_cached(
+            &mut cache,
+            Some("csv"),
+            source,
+            &config,
+            &registry,
+            &pcfg,
+            &build_rules(),
+        )
+        .unwrap();
+        assert_eq!(miss, fresh, "cached miss equals a fresh compute");
+        assert_eq!(cache.len(), 1);
+        let hit = lint_cached(
+            &mut cache,
+            Some("csv"),
+            source,
+            &config,
+            &registry,
+            &pcfg,
+            &build_rules(),
+        )
+        .unwrap();
+        assert_eq!(hit, fresh, "cached hit equals a fresh compute");
         assert_eq!(cache.len(), 1, "no new entry on a hit");
     }
 
@@ -864,12 +957,31 @@ mod tests {
         // Regression: a result computed with one rule set must never be reused for another.
         let mut cache = DocumentCache::new();
         let c = Config::default();
-        let rule = FlagKind::new(NodeKind::HEADING);
+        let registry = crate::Registry::with_builtins();
+        let pcfg = crate::ProcessorConfig::default();
 
-        let empty = lint_cached(&mut cache, "# H\n", &c, &[]).unwrap();
+        let empty = lint_cached(
+            &mut cache,
+            Some("md"),
+            "# H\n",
+            &c,
+            &registry,
+            &pcfg,
+            &crate::RegionRules::base_only(vec![]),
+        )
+        .unwrap();
         assert!(empty.is_empty());
         // A different rule set must miss (not reuse the empty-rules entry) and produce its own.
-        let with_rule = lint_cached(&mut cache, "# H\n", &c, &[&rule]).unwrap();
+        let with_rule = lint_cached(
+            &mut cache,
+            Some("md"),
+            "# H\n",
+            &c,
+            &registry,
+            &pcfg,
+            &crate::RegionRules::base_only(vec![Box::new(FlagKind::new(NodeKind::HEADING))]),
+        )
+        .unwrap();
         assert_eq!(
             with_rule.len(),
             1,
@@ -885,16 +997,36 @@ mod tests {
     #[test]
     fn lint_cached_empty_rules_is_no_diagnostics() {
         let mut cache = DocumentCache::new();
-        let diags = lint_cached(&mut cache, "# H\n", &Config::default(), &[]).unwrap();
+        let registry = crate::Registry::with_builtins();
+        let diags = lint_cached(
+            &mut cache,
+            Some("md"),
+            "# H\n",
+            &Config::default(),
+            &registry,
+            &crate::ProcessorConfig::default(),
+            &crate::RegionRules::base_only(vec![]),
+        )
+        .unwrap();
         assert!(diags.is_empty());
     }
 
     #[test]
     fn lint_cached_surfaces_parse_error_without_caching() {
         let mut cache = DocumentCache::new();
+        let registry = crate::Registry::with_builtins();
         // Deeply nested block containers make `parse` reject the input.
         let pathological = "> ".repeat(5000);
-        let err = lint_cached(&mut cache, &pathological, &Config::default(), &[]).unwrap_err();
+        let err = lint_cached(
+            &mut cache,
+            Some("md"),
+            &pathological,
+            &Config::default(),
+            &registry,
+            &crate::ProcessorConfig::default(),
+            &crate::RegionRules::base_only(vec![]),
+        )
+        .unwrap_err();
         assert!(matches!(err, CacheError::Parse(_)));
         assert!(
             cache.is_empty(),

--- a/crates/tzlint_core/src/config/config.schema.json
+++ b/crates/tzlint_core/src/config/config.schema.json
@@ -24,6 +24,9 @@
         { "$ref": "#/$defs/presetId" },
         { "type": "array", "items": { "$ref": "#/$defs/presetId" } }
       ]
+    },
+    "formats": {
+      "$ref": "#/$defs/formats"
     }
   },
   "$defs": {
@@ -37,6 +40,54 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/ruleSetting"
+      }
+    },
+    "formats": {
+      "description": "Per-input-format settings, keyed by format id. Only `csv` and `tsv` are wired (an unknown id is rejected by the loader at resolve time — not expressible here, so this allows arbitrary keys). Each value describes how to extract and lint that format's columns.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/format"
+      }
+    },
+    "format": {
+      "description": "One delimited format's settings: whether the first row is a header, an optional single-character delimiter override, and the target columns.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "header": {
+          "description": "Whether the first record is a header row (enables selecting columns by name).",
+          "type": "boolean"
+        },
+        "delimiter": {
+          "description": "A single-character delimiter override (else the format default: `,` for csv, tab for tsv). Must be one character and, at resolve time, ASCII (the non-ASCII check is the loader's, not expressible here).",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1
+        },
+        "columns": {
+          "$ref": "#/$defs/columns"
+        }
+      }
+    },
+    "columns": {
+      "description": "Target columns to lint, keyed by selector: a 1-based column number (e.g. \"2\") or a header name (requires `header: true`). Keys are arbitrary strings (the name-vs-number resolution and the header requirement are the loader's, not expressible here).",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/column"
+      }
+    },
+    "column": {
+      "description": "One target column: how to parse its cells and an optional rule overlay layered over the base `rules` (the column wins).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "parse-mode": {
+          "description": "How each cell is parsed before linting. Defaults to markdown.",
+          "enum": ["markdown", "plain"]
+        },
+        "rules": {
+          "$ref": "#/$defs/rules"
+        }
       }
     },
     "ruleSetting": {

--- a/crates/tzlint_core/src/config/config.schema.json
+++ b/crates/tzlint_core/src/config/config.schema.json
@@ -43,10 +43,12 @@
       }
     },
     "formats": {
-      "description": "Per-input-format settings, keyed by format id. Only `csv` and `tsv` are wired (an unknown id is rejected by the loader at resolve time — not expressible here, so this allows arbitrary keys). Each value describes how to extract and lint that format's columns.",
+      "description": "Per-input-format settings for the supported built-in formats. Each value describes how to extract and lint that format's columns. (When a new format is wired into the loader, add its key here.)",
       "type": "object",
-      "additionalProperties": {
-        "$ref": "#/$defs/format"
+      "additionalProperties": false,
+      "properties": {
+        "csv": { "$ref": "#/$defs/format" },
+        "tsv": { "$ref": "#/$defs/format" }
       }
     },
     "format": {

--- a/crates/tzlint_core/src/config/format_config.rs
+++ b/crates/tzlint_core/src/config/format_config.rs
@@ -1,0 +1,30 @@
+//! Resolved per-format configuration (the `formats.<id>` section of a config file).
+
+use std::collections::BTreeMap;
+
+use tzlint_pdk::RuleId;
+
+use crate::RuleSetting;
+use crate::processor::{ColumnSelector, ParseMode};
+
+/// Resolved settings for one delimited format (`formats.csv` / `formats.tsv`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormatConfig {
+    /// Whether the first record is a header row.
+    pub has_header: bool,
+    /// An explicit field delimiter override (else the format default: `,` for csv, tab for tsv).
+    pub delimiter: Option<char>,
+    /// The target columns to lint, in config order.
+    pub columns: Vec<ColumnConfig>,
+}
+
+/// One target column: how to select it, how to parse its cells, and its rule overlay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ColumnConfig {
+    /// By header name or 1-based number.
+    pub selector: ColumnSelector,
+    /// How each cell is parsed before linting (default Markdown).
+    pub parse_mode: ParseMode,
+    /// Rules layered ON TOP of the base `rules` for this column (column wins).
+    pub rules: BTreeMap<RuleId, RuleSetting>,
+}

--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -79,6 +79,15 @@ pub enum ConfigError {
     },
     /// `extends` referenced a preset id that is not a known [`Preset`].
     UnknownPreset(String),
+    /// A `formats` key that is not a known input format (only `csv`/`tsv` support columns).
+    UnknownFormat(String),
+    /// A column was selected by name under a format with `header: false`.
+    ColumnNameWithoutHeader {
+        /// The format id (`csv`/`tsv`) whose column was selected by name.
+        format: String,
+        /// The header name that cannot be resolved without a header row.
+        name: String,
+    },
 }
 
 impl fmt::Display for ConfigError {
@@ -90,6 +99,18 @@ impl fmt::Display for ConfigError {
             }
             ConfigError::UnknownPreset(id) => {
                 write!(f, "`extends` references unknown preset `{id}`")
+            }
+            ConfigError::UnknownFormat(format) => {
+                write!(
+                    f,
+                    "unknown input format '{format}' (only csv/tsv support columns)"
+                )
+            }
+            ConfigError::ColumnNameWithoutHeader { format, name } => {
+                write!(
+                    f,
+                    "column '{name}' in format '{format}' is selected by name but header is false"
+                )
             }
         }
     }

--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -19,6 +19,7 @@
 
 mod discover;
 mod format;
+mod format_config;
 mod model;
 mod preset;
 mod schema;
@@ -30,6 +31,7 @@ use tzlint_pdk::RuleId;
 
 pub use discover::{DiscoveredConfig, ShadowedCandidate, discover};
 pub use format::ConfigFormat;
+pub use format_config::{ColumnConfig, FormatConfig};
 pub use model::RuleSetting;
 pub use preset::{Preset, resolve};
 pub use schema::CONFIG_SCHEMA;
@@ -49,6 +51,8 @@ pub struct Config {
     pub message_language: Option<String>,
     /// Per-rule settings, keyed by [`RuleId`]. Absent ids fall back to a rule's own defaults.
     pub rules: BTreeMap<RuleId, RuleSetting>,
+    /// Per-format settings (e.g. `formats.csv`), keyed by format id. Empty by default.
+    pub formats: BTreeMap<String, FormatConfig>,
 }
 
 impl Config {
@@ -153,5 +157,16 @@ mod tests {
             Config::parse("{ not json", ConfigFormat::Json),
             Err(ConfigError::Parse { .. })
         ));
+    }
+}
+
+#[cfg(test)]
+mod format_config_tests {
+    use super::*;
+
+    #[test]
+    fn config_default_has_no_formats() {
+        let c = Config::default();
+        assert!(c.formats.is_empty());
     }
 }

--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -175,6 +175,18 @@ mod tests {
             .to_string(),
             "delimiter '；' in format 'csv' is not ASCII (only single-byte delimiters are supported)"
         );
+        assert_eq!(
+            ConfigError::UnknownFormat("xml".into()).to_string(),
+            "unknown input format 'xml' (only csv/tsv support columns)"
+        );
+        assert_eq!(
+            ConfigError::ColumnNameWithoutHeader {
+                format: "csv".into(),
+                name: "body".into(),
+            }
+            .to_string(),
+            "column 'body' in format 'csv' is selected by name but header is false"
+        );
     }
 
     #[test]

--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -88,6 +88,14 @@ pub enum ConfigError {
         /// The header name that cannot be resolved without a header row.
         name: String,
     },
+    /// A format's `delimiter` override is not an ASCII character. The delimited scanner is
+    /// byte-oriented, so a multi-byte delimiter cannot be represented; reject it at parse time.
+    NonAsciiDelimiter {
+        /// The format id (`csv`/`tsv`) whose delimiter override is non-ASCII.
+        format: String,
+        /// The offending delimiter character.
+        delimiter: char,
+    },
 }
 
 impl fmt::Display for ConfigError {
@@ -110,6 +118,12 @@ impl fmt::Display for ConfigError {
                 write!(
                     f,
                     "column '{name}' in format '{format}' is selected by name but header is false"
+                )
+            }
+            ConfigError::NonAsciiDelimiter { format, delimiter } => {
+                write!(
+                    f,
+                    "delimiter '{delimiter}' in format '{format}' is not ASCII (only single-byte delimiters are supported)"
                 )
             }
         }
@@ -152,6 +166,14 @@ mod tests {
         assert_eq!(
             ConfigError::UnknownPreset("nope".into()).to_string(),
             "`extends` references unknown preset `nope`"
+        );
+        assert_eq!(
+            ConfigError::NonAsciiDelimiter {
+                format: "csv".into(),
+                delimiter: '；',
+            }
+            .to_string(),
+            "delimiter '；' in format 'csv' is not ASCII (only single-byte delimiters are supported)"
         );
     }
 

--- a/crates/tzlint_core/src/config/model.rs
+++ b/crates/tzlint_core/src/config/model.rs
@@ -33,6 +33,42 @@ pub(super) struct RawConfig {
     /// non-string/array value is a serde type error at parse time.
     #[serde(default)]
     extends: Option<Extends>,
+    /// Per-format sections (`formats.csv` / `formats.tsv`). Resolved into
+    /// [`Config::formats`](super::Config::formats); an unknown format id or a name-keyed column
+    /// under `header: false` is rejected in [`into_config`](RawConfig::into_config).
+    #[serde(default)]
+    formats: std::collections::BTreeMap<String, RawFormat>,
+}
+
+/// The on-disk shape of one `formats.<id>` section.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+struct RawFormat {
+    #[serde(default)]
+    header: bool,
+    #[serde(default)]
+    delimiter: Option<char>,
+    #[serde(default)]
+    columns: BTreeMap<String, RawColumn>,
+}
+
+/// The on-disk shape of one column under `formats.<id>.columns`. The map key is the selector
+/// (a 1-based number, or a header name).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+struct RawColumn {
+    #[serde(default)]
+    parse_mode: Option<RawParseMode>,
+    #[serde(default)]
+    rules: BTreeMap<String, RuleSetting>,
+}
+
+/// The on-disk spelling of a cell parse mode.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum RawParseMode {
+    Markdown,
+    Plain,
 }
 
 /// The shape of the `extends` value: one preset id, or a list of them.
@@ -82,13 +118,62 @@ impl RawConfig {
             ..Default::default()
         };
 
+        // Resolve formats (csv/tsv only; columns become selectors + parse mode + rule overlay).
+        // Formats are not preset-layered, so they are attached to the FINAL folded config below.
+        let mut formats = std::collections::BTreeMap::new();
+        for (fmt_id, raw) in self.formats {
+            if fmt_id != "csv" && fmt_id != "tsv" {
+                return Err(ConfigError::UnknownFormat(fmt_id));
+            }
+            let mut columns = Vec::new();
+            for (key, raw_col) in raw.columns {
+                let selector = match key.parse::<u32>() {
+                    Ok(n) if n >= 1 => crate::processor::ColumnSelector::Index(n),
+                    _ => {
+                        if !raw.header {
+                            return Err(ConfigError::ColumnNameWithoutHeader {
+                                format: fmt_id,
+                                name: key,
+                            });
+                        }
+                        crate::processor::ColumnSelector::Name(key)
+                    }
+                };
+                let parse_mode = match raw_col.parse_mode {
+                    Some(RawParseMode::Plain) => crate::processor::ParseMode::PlainText,
+                    _ => crate::processor::ParseMode::Markdown,
+                };
+                let rules = raw_col
+                    .rules
+                    .into_iter()
+                    .map(|(id, setting)| (RuleId::from(id), setting))
+                    .collect();
+                columns.push(crate::ColumnConfig {
+                    selector,
+                    parse_mode,
+                    rules,
+                });
+            }
+            formats.insert(
+                fmt_id,
+                crate::FormatConfig {
+                    has_header: raw.header,
+                    delimiter: raw.delimiter,
+                    columns,
+                },
+            );
+        }
+
         // Layer presets under the user config. Folding in reverse makes the precedence (low to
         // high) `extends[0] < … < extends[n] < user`: each `resolve` puts its preset *under* the
         // accumulator.
-        Ok(presets
+        let mut result = presets
             .into_iter()
             .rev()
-            .fold(user, |acc, preset| super::resolve(Some(preset), acc)))
+            .fold(user, |acc, preset| super::resolve(Some(preset), acc));
+        // Attach the resolved formats to the FINAL folded config (formats are not preset-layered).
+        result.formats = formats;
+        Ok(result)
     }
 }
 
@@ -415,5 +500,67 @@ mod tests {
     fn into_config_null_extends_is_a_noop() {
         let raw: RawConfig = serde_json::from_str(r#"{ "extends": null }"#).unwrap();
         assert!(raw.into_config().unwrap().rules.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod formats_parsing {
+    use crate::processor::{ColumnSelector, ParseMode};
+    use crate::{Config, ConfigError, ConfigFormat, RuleSetting};
+
+    fn parse(json: &str) -> Result<Config, ConfigError> {
+        Config::parse(json, ConfigFormat::Json)
+    }
+
+    #[test]
+    fn parses_columns_by_name_and_index_with_overlay_rules() {
+        let c = parse(
+            r#"{ "formats": { "csv": { "header": true,
+                "columns": {
+                  "body": { "rules": { "no-todo": true } },
+                  "2": { "parse-mode": "plain", "rules": { "max-ten": { "options": { "max": 0 } } } }
+                } } } }"#,
+        )
+        .unwrap();
+        let csv = c.formats.get("csv").unwrap();
+        assert!(csv.has_header);
+        assert_eq!(csv.columns.len(), 2);
+        // BTreeMap key order: "2" then "body" — assert by finding.
+        let body = csv
+            .columns
+            .iter()
+            .find(|col| col.selector == ColumnSelector::Name("body".into()))
+            .unwrap();
+        assert_eq!(body.parse_mode, ParseMode::Markdown);
+        assert!(matches!(
+            body.rules.get(&"no-todo".into()),
+            Some(RuleSetting::On { .. })
+        ));
+        let col2 = csv
+            .columns
+            .iter()
+            .find(|col| col.selector == ColumnSelector::Index(2))
+            .unwrap();
+        assert_eq!(col2.parse_mode, ParseMode::PlainText);
+    }
+
+    #[test]
+    fn name_key_without_header_is_an_error() {
+        let err =
+            parse(r#"{ "formats": { "tsv": { "header": false, "columns": { "body": {} } } } }"#)
+                .unwrap_err();
+        assert!(
+            matches!(err, ConfigError::ColumnNameWithoutHeader { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_format_id_is_an_error() {
+        let err = parse(r#"{ "formats": { "xml": { "columns": { "1": {} } } } }"#).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::UnknownFormat(ref f) if f == "xml"),
+            "{err:?}"
+        );
     }
 }

--- a/crates/tzlint_core/src/config/model.rs
+++ b/crates/tzlint_core/src/config/model.rs
@@ -79,6 +79,7 @@ impl RawConfig {
             language: self.language,
             message_language: self.message_language,
             rules,
+            ..Default::default()
         };
 
         // Layer presets under the user config. Folding in reverse makes the precedence (low to

--- a/crates/tzlint_core/src/config/model.rs
+++ b/crates/tzlint_core/src/config/model.rs
@@ -125,6 +125,16 @@ impl RawConfig {
             if fmt_id != "csv" && fmt_id != "tsv" {
                 return Err(ConfigError::UnknownFormat(fmt_id));
             }
+            // The delimited scanner is byte-oriented; a non-ASCII delimiter cannot be represented
+            // in one byte and would be silently truncated downstream, so reject it here.
+            if let Some(delimiter) = raw.delimiter
+                && !delimiter.is_ascii()
+            {
+                return Err(ConfigError::NonAsciiDelimiter {
+                    format: fmt_id,
+                    delimiter,
+                });
+            }
             let mut columns = Vec::new();
             for (key, raw_col) in raw.columns {
                 let selector = match key.parse::<u32>() {
@@ -562,5 +572,29 @@ mod formats_parsing {
             matches!(err, ConfigError::UnknownFormat(ref f) if f == "xml"),
             "{err:?}"
         );
+    }
+
+    #[test]
+    fn non_ascii_delimiter_is_an_error() {
+        // The scanner is byte-oriented, so a non-ASCII delimiter would truncate via `char as u8`
+        // and corrupt extraction. Reject it at parse time instead.
+        let err = parse(
+            r#"{ "formats": { "csv": { "header": true, "delimiter": "；", "columns": { "1": {} } } } }"#,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, ConfigError::NonAsciiDelimiter { ref format, delimiter } if format == "csv" && delimiter == '；'),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn ascii_delimiter_override_is_accepted() {
+        // An ASCII override (e.g. a semicolon) is fine — it fits in one byte.
+        let c = parse(
+            r#"{ "formats": { "csv": { "header": true, "delimiter": ";", "columns": { "1": {} } } } }"#,
+        )
+        .unwrap();
+        assert_eq!(c.formats.get("csv").unwrap().delimiter, Some(';'));
     }
 }

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -105,6 +105,8 @@ pub fn resolve(preset: Option<Preset>, user: Config) -> Config {
         language: user.language,
         message_language: user.message_language,
         rules: merge(base, user.rules),
+        // Formats are not preset-layered; layering preserves the user's resolved formats.
+        formats: user.formats,
     }
 }
 
@@ -167,6 +169,7 @@ mod tests {
                 m.insert(RuleId::from("custom-rule"), on()); // user-only
                 m
             },
+            ..Default::default()
         };
         let resolved = resolve(Some(Preset::JaBasic), user.clone());
         // Languages come from the user.

--- a/crates/tzlint_core/src/fix.rs
+++ b/crates/tzlint_core/src/fix.rs
@@ -1,8 +1,6 @@
 //! Applying autofixes with deterministic conflict resolution.
 
-use tzlint_pdk::{Diagnostic, Fix, Rule};
-
-use crate::Engine;
+use tzlint_pdk::{Diagnostic, Fix};
 
 /// Maximum number of lint→fix passes (ESLint semantics), guaranteeing termination.
 pub const MAX_FIX_PASSES: usize = 10;
@@ -72,21 +70,28 @@ pub fn apply_fixes(source: &str, diagnostics: &[Diagnostic]) -> FixPass {
     }
 }
 
-/// Lint-and-fix `source` to a fixpoint: parse → lint → apply, repeating until the text
-/// stops changing or [`MAX_FIX_PASSES`] is reached (which guarantees termination). Returns
-/// the fixed text; a parse failure leaves the current text unchanged.
+/// Lint-and-fix `source` to a fixpoint over the processor seam: select a processor by `ext`,
+/// extract its regions (or whole AST), lint each with the rules its tag resolves to in `rules`,
+/// and apply the collected fixes — repeating until the text stops changing or [`MAX_FIX_PASSES`]
+/// is reached (which guarantees termination). Returns the fixed text; a parse failure leaves the
+/// current text unchanged.
+///
+/// Fixes land in absolute source coordinates, so a CSV/TSV fix changes only its cell while the
+/// structural bytes (delimiters, header, untargeted columns) stay intact.
 #[must_use]
-pub fn fix(source: &str, rules: &[&dyn Rule]) -> String {
+pub fn fix(
+    ext: Option<&str>,
+    source: &str,
+    registry: &crate::Registry,
+    processor_cfg: &crate::ProcessorConfig,
+    rules: &crate::RegionRules,
+) -> String {
     let mut text = source.to_string();
     for _ in 0..MAX_FIX_PASSES {
-        let Ok(ast) = crate::parse(&text) else { break };
-        let Ok(bytes) = tzlint_ast::to_archive(&ast) else {
+        let Ok(diagnostics) = crate::lint_document(ext, &text, registry, processor_cfg, rules)
+        else {
             break;
         };
-        let Ok(archived) = tzlint_ast::access(&bytes) else {
-            break;
-        };
-        let diagnostics = Engine::lint(archived, rules);
         let pass = apply_fixes(&text, &diagnostics);
         if pass.output == text {
             break; // fixpoint: nothing changed
@@ -100,7 +105,7 @@ pub fn fix(source: &str, rules: &[&dyn Rule]) -> String {
 mod tests {
     use super::*;
     use tzlint_ast::{NodeKind, Span};
-    use tzlint_pdk::{Context, NodeRef, RuleMeta, Severity};
+    use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
     fn diag_with_fix(span: Span, replacement: &str) -> Diagnostic {
         Diagnostic::new("t", Severity::Warning, span, "m").with_fix(Fix::replace(span, replacement))
@@ -197,8 +202,64 @@ mod tests {
     #[test]
     fn fix_converges_when_no_more_apply() {
         // Once "BAD" → "ok", re-linting finds nothing, so it stops.
-        let rule = Rewrite::new("BAD", "ok");
-        assert_eq!(fix("BAD\n", &[&rule]), "ok\n");
+        let registry = crate::Registry::with_builtins();
+        let rules = crate::RegionRules::base_only(vec![Box::new(Rewrite::new("BAD", "ok"))]);
+        assert_eq!(
+            fix(
+                Some("md"),
+                "BAD\n",
+                &registry,
+                &crate::ProcessorConfig::default(),
+                &rules
+            ),
+            "ok\n"
+        );
+    }
+
+    /// Replaces a TEXT node whose text is exactly `"x"` with `"y"` via a fix.
+    struct ReplaceXWithY {
+        meta: RuleMeta,
+    }
+    impl ReplaceXWithY {
+        fn new() -> Self {
+            ReplaceXWithY {
+                meta: RuleMeta::new("replace-x", Severity::Warning, vec![NodeKind::TEXT]),
+            }
+        }
+    }
+    impl Rule for ReplaceXWithY {
+        fn meta(&self) -> &RuleMeta {
+            &self.meta
+        }
+        fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+            if node.text() == "x" {
+                cx.report_with_fixes(node.span(), "x→y", [Fix::replace(node.span(), "y")]);
+            }
+        }
+    }
+
+    #[test]
+    fn fix_applies_inside_csv_cells_only() {
+        use crate::processor::{
+            ColumnSelector, ColumnTarget, DelimitedConfig, ParseMode, ProcessorConfig, RegionRules,
+            Registry,
+        };
+        // Only the body cells change; structure (header, ids, commas) is intact.
+        let source = "id,body\n1,x\n2,x\n";
+        let registry = Registry::with_builtins();
+        let pcfg = ProcessorConfig {
+            delimited: Some(DelimitedConfig {
+                delimiter: b',',
+                has_header: true,
+                columns: vec![ColumnTarget {
+                    selector: ColumnSelector::Name("body".into()),
+                    parse_mode: ParseMode::PlainText,
+                }],
+            }),
+        };
+        let rules = RegionRules::base_only(vec![Box::new(ReplaceXWithY::new())]);
+        let out = fix(Some("csv"), source, &registry, &pcfg, &rules);
+        assert_eq!(out, "id,body\n1,y\n2,y\n");
     }
 
     #[test]
@@ -220,7 +281,15 @@ mod tests {
             meta: RuleMeta::new("grow", Severity::Warning, vec![NodeKind::TEXT]),
         };
         // Starts as "a"; each of the 10 passes appends one '!'.
-        let out = fix("a", &[&rule]);
+        let registry = crate::Registry::with_builtins();
+        let rules = crate::RegionRules::base_only(vec![Box::new(rule)]);
+        let out = fix(
+            Some("md"),
+            "a",
+            &registry,
+            &crate::ProcessorConfig::default(),
+            &rules,
+        );
         assert_eq!(out, format!("a{}", "!".repeat(MAX_FIX_PASSES)));
     }
 }

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -39,7 +39,8 @@ pub use io::{DirEntry, EntryKind, Host, IoError};
 pub use parse::{ParseError, parse};
 pub use position::LineIndex;
 pub use processor::{
-    ParseMode, Parsed, Processor, ProcessorConfig, Region, RegionTag, Registry, lint_document,
+    ColumnSelector, ColumnTarget, DelimitedConfig, ParseMode, Parsed, Processor, ProcessorConfig,
+    Region, RegionTag, Registry, lint_document,
 };
 
 #[cfg(test)]

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -39,8 +39,8 @@ pub use io::{DirEntry, EntryKind, Host, IoError};
 pub use parse::{ParseError, parse};
 pub use position::LineIndex;
 pub use processor::{
-    ColumnSelector, ColumnTarget, DelimitedConfig, ParseMode, Parsed, Processor, ProcessorConfig,
-    Region, RegionTag, Registry, lint_document,
+    ColumnSelector, ColumnTarget, DelimitedConfig, DelimitedProcessor, ParseMode, Parsed,
+    Processor, ProcessorConfig, Region, RegionTag, Registry, lint_document,
 };
 
 #[cfg(test)]

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -40,7 +40,7 @@ pub use parse::{ParseError, parse};
 pub use position::LineIndex;
 pub use processor::{
     ColumnSelector, ColumnTarget, DelimitedConfig, DelimitedProcessor, ParseMode, Parsed,
-    Processor, ProcessorConfig, Region, RegionTag, Registry, lint_document,
+    Processor, ProcessorConfig, Region, RegionRules, RegionTag, Registry, lint_document,
 };
 
 #[cfg(test)]

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -45,12 +45,19 @@ pub use processor::{
 
 #[cfg(test)]
 mod tests {
-    use crate::{Registry, lint_document};
+    use crate::{ProcessorConfig, RegionRules, Registry, lint_document};
 
     #[test]
     fn processor_seam_is_reexported_at_crate_root() {
         let reg = Registry::with_builtins();
-        let diags = lint_document(Some("md"), "x\n", &reg, &[]).unwrap();
+        let diags = lint_document(
+            Some("md"),
+            "x\n",
+            &reg,
+            &ProcessorConfig::default(),
+            &RegionRules::base_only(vec![]),
+        )
+        .unwrap();
         assert!(diags.is_empty());
     }
 }

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -3,8 +3,10 @@
 //! Compiles for native and `wasm32`. Houses:
 //! - the markdown-rs parser + mdast → index-AST transform,
 //! - the format-neutral `processor` seam (`Processor`/`Registry`/`lint_document`) that selects a
-//!   parser by file extension, defaulting to Markdown,
-//! - the single-traversal multi-visitor `Engine::lint` (the one dispatch entry point),
+//!   parser by file extension (defaulting to Markdown) — `lint_document` is the single
+//!   document-level dispatch entry point,
+//! - the single-traversal multi-visitor `Engine::lint`, the AST-level executor `lint_document`
+//!   runs over each already-parsed region,
 //! - multi-format config loading (+ presets), the document-level cache,
 //! - the position mapper, and the centralized boundary `io` module (`Host::read_to_string`
 //!   with a size cap, `Host::write_atomic`), behind a `Host` provider abstraction so

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -36,3 +36,18 @@ pub use fix::{FixPass, MAX_FIX_PASSES, apply_fixes, fix};
 pub use io::{DirEntry, EntryKind, Host, IoError};
 pub use parse::{ParseError, parse};
 pub use position::LineIndex;
+pub use processor::{
+    ParseMode, Parsed, Processor, ProcessorConfig, Region, RegionTag, Registry, lint_document,
+};
+
+#[cfg(test)]
+mod processor_exports {
+    use crate::{Registry, lint_document};
+
+    #[test]
+    fn processor_seam_is_reexported_at_crate_root() {
+        let reg = Registry::with_builtins();
+        let diags = lint_document(Some("md"), "x\n", &reg, &[]).unwrap();
+        assert!(diags.is_empty());
+    }
+}

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod fix;
 pub mod io;
 pub mod parse;
 pub mod position;
+pub mod processor;
 
 pub use cache::{
     CacheError, CacheKey, CacheKeyInput, DocumentCache, document_cache_key, lint_cached,

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Compiles for native and `wasm32`. Houses:
 //! - the markdown-rs parser + mdast → index-AST transform,
+//! - the format-neutral `processor` seam (`Processor`/`Registry`/`lint_document`) that selects a
+//!   parser by file extension, defaulting to Markdown,
 //! - the single-traversal multi-visitor `Engine::lint` (the one dispatch entry point),
 //! - multi-format config loading (+ presets), the document-level cache,
 //! - the position mapper, and the centralized boundary `io` module (`Host::read_to_string`
@@ -41,7 +43,7 @@ pub use processor::{
 };
 
 #[cfg(test)]
-mod processor_exports {
+mod tests {
     use crate::{Registry, lint_document};
 
     #[test]

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -30,8 +30,8 @@ pub use cache::{
     CacheError, CacheKey, CacheKeyInput, DocumentCache, document_cache_key, lint_cached,
 };
 pub use config::{
-    CONFIG_SCHEMA, Config, ConfigError, ConfigFormat, DiscoveredConfig, Preset, RuleSetting,
-    ShadowedCandidate, discover, resolve,
+    CONFIG_SCHEMA, ColumnConfig, Config, ConfigError, ConfigFormat, DiscoveredConfig, FormatConfig,
+    Preset, RuleSetting, ShadowedCandidate, discover, resolve,
 };
 pub use engine::Engine;
 pub use fix::{FixPass, MAX_FIX_PASSES, apply_fixes, fix};

--- a/crates/tzlint_core/src/processor/delimited.rs
+++ b/crates/tzlint_core/src/processor/delimited.rs
@@ -18,13 +18,19 @@ impl DelimitedProcessor {
     /// A CSV processor (`.csv`, default delimiter `,`).
     #[must_use]
     pub fn csv() -> Self {
-        DelimitedProcessor { extensions: &["csv"], default_delimiter: b',' }
+        DelimitedProcessor {
+            extensions: &["csv"],
+            default_delimiter: b',',
+        }
     }
 
     /// A TSV processor (`.tsv`, default delimiter tab).
     #[must_use]
     pub fn tsv() -> Self {
-        DelimitedProcessor { extensions: &["tsv"], default_delimiter: b'\t' }
+        DelimitedProcessor {
+            extensions: &["tsv"],
+            default_delimiter: b'\t',
+        }
     }
 }
 
@@ -38,7 +44,11 @@ impl Processor for DelimitedProcessor {
         let Some(d) = cfg.delimited.as_ref() else {
             return Ok(Parsed::Regions(Vec::new()));
         };
-        Ok(Parsed::Regions(build_regions(source, d, self.default_delimiter)))
+        Ok(Parsed::Regions(build_regions(
+            source,
+            d,
+            self.default_delimiter,
+        )))
     }
 }
 
@@ -46,7 +56,11 @@ impl Processor for DelimitedProcessor {
 /// spans across the body rows. Columns that cannot be resolved (a name absent from the header,
 /// or an out-of-range index) are skipped here; Plan 3 surfaces a note for them.
 fn build_regions(source: &str, d: &DelimitedConfig, default_delimiter: u8) -> Vec<Region> {
-    let delimiter = if d.delimiter != 0 { d.delimiter } else { default_delimiter };
+    let delimiter = if d.delimiter != 0 {
+        d.delimiter
+    } else {
+        default_delimiter
+    };
     let records = scan_records(source, delimiter);
 
     let header_names: Vec<String> = if d.has_header {
@@ -72,10 +86,7 @@ fn build_regions(source: &str, d: &DelimitedConfig, default_delimiter: u8) -> Ve
         let (index0, name): (Option<u32>, Option<String>) = match &target.selector {
             ColumnSelector::Index(one_based) => (one_based.checked_sub(1), None),
             ColumnSelector::Name(n) => (
-                header_names
-                    .iter()
-                    .position(|h| h == n)
-                    .map(|i| i as u32),
+                header_names.iter().position(|h| h == n).map(|i| i as u32),
                 Some(n.clone()),
             ),
         };
@@ -112,12 +123,16 @@ mod tests {
 
     fn cfg(columns: Vec<ColumnTarget>, has_header: bool) -> ProcessorConfig {
         ProcessorConfig {
-            delimited: Some(DelimitedConfig { delimiter: b',', has_header, columns }),
+            delimited: Some(DelimitedConfig {
+                delimiter: b',',
+                has_header,
+                columns,
+            }),
         }
     }
 
     /// Project a Parsed::Regions result to (tag-index, parse_mode, cell-texts) for assertions.
-    fn regions_of<'a>(source: &'a str, parsed: Parsed) -> Vec<(Option<u32>, Option<String>, Vec<&'a str>)> {
+    fn regions_of(source: &str, parsed: Parsed) -> Vec<(Option<u32>, Option<String>, Vec<&str>)> {
         match parsed {
             Parsed::Regions(rs) => rs
                 .into_iter()
@@ -135,7 +150,16 @@ mod tests {
         let source = "id,body\n1,hello\n2,world\n";
         let p = DelimitedProcessor::csv();
         let parsed = p
-            .parse(source, &cfg(vec![ColumnTarget { selector: ColumnSelector::Name("body".into()), parse_mode: ParseMode::Markdown }], true))
+            .parse(
+                source,
+                &cfg(
+                    vec![ColumnTarget {
+                        selector: ColumnSelector::Name("body".into()),
+                        parse_mode: ParseMode::Markdown,
+                    }],
+                    true,
+                ),
+            )
             .unwrap();
         assert_eq!(
             regions_of(source, parsed),
@@ -148,10 +172,22 @@ mod tests {
         let source = "a,1\nb,2\n";
         let p = DelimitedProcessor::csv();
         let parsed = p
-            .parse(source, &cfg(vec![ColumnTarget { selector: ColumnSelector::Index(1), parse_mode: ParseMode::PlainText }], false))
+            .parse(
+                source,
+                &cfg(
+                    vec![ColumnTarget {
+                        selector: ColumnSelector::Index(1),
+                        parse_mode: ParseMode::PlainText,
+                    }],
+                    false,
+                ),
+            )
             .unwrap();
         // 1-based index 1 → 0-based 0 → first column "a","b".
-        assert_eq!(regions_of(source, parsed), vec![(Some(0), None, vec!["a", "b"])]);
+        assert_eq!(
+            regions_of(source, parsed),
+            vec![(Some(0), None, vec!["a", "b"])]
+        );
     }
 
     #[test]
@@ -159,7 +195,16 @@ mod tests {
         let source = "id,body\n1,hello\n";
         let p = DelimitedProcessor::csv();
         let parsed = p
-            .parse(source, &cfg(vec![ColumnTarget { selector: ColumnSelector::Name("missing".into()), parse_mode: ParseMode::Markdown }], true))
+            .parse(
+                source,
+                &cfg(
+                    vec![ColumnTarget {
+                        selector: ColumnSelector::Name("missing".into()),
+                        parse_mode: ParseMode::Markdown,
+                    }],
+                    true,
+                ),
+            )
             .unwrap();
         assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
     }
@@ -167,7 +212,9 @@ mod tests {
     #[test]
     fn no_delimited_config_lints_nothing() {
         let p = DelimitedProcessor::csv();
-        let parsed = p.parse("id,body\n1,x\n", &ProcessorConfig::default()).unwrap();
+        let parsed = p
+            .parse("id,body\n1,x\n", &ProcessorConfig::default())
+            .unwrap();
         assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
     }
 }

--- a/crates/tzlint_core/src/processor/delimited.rs
+++ b/crates/tzlint_core/src/processor/delimited.rs
@@ -1,0 +1,173 @@
+//! The built-in delimited (CSV/TSV) processor. It scans the source into cell content spans and
+//! emits one [`Region`] per configured target column. See `docs/design/input-format-processors.md`.
+
+use super::scanner::scan_records;
+use super::{
+    ColumnSelector, DelimitedConfig, Parsed, Processor, ProcessorConfig, Region, RegionTag,
+};
+use crate::ParseError;
+
+/// Lints configured columns of a delimited file. Built as [`DelimitedProcessor::csv`] or
+/// [`DelimitedProcessor::tsv`]; the default delimiter is overridable via the config.
+pub struct DelimitedProcessor {
+    extensions: &'static [&'static str],
+    default_delimiter: u8,
+}
+
+impl DelimitedProcessor {
+    /// A CSV processor (`.csv`, default delimiter `,`).
+    #[must_use]
+    pub fn csv() -> Self {
+        DelimitedProcessor { extensions: &["csv"], default_delimiter: b',' }
+    }
+
+    /// A TSV processor (`.tsv`, default delimiter tab).
+    #[must_use]
+    pub fn tsv() -> Self {
+        DelimitedProcessor { extensions: &["tsv"], default_delimiter: b'\t' }
+    }
+}
+
+impl Processor for DelimitedProcessor {
+    fn extensions(&self) -> &[&str] {
+        self.extensions
+    }
+
+    fn parse(&self, source: &str, cfg: &ProcessorConfig) -> Result<Parsed, ParseError> {
+        // No columns configured for this format → lint nothing (opt-in).
+        let Some(d) = cfg.delimited.as_ref() else {
+            return Ok(Parsed::Regions(Vec::new()));
+        };
+        Ok(Parsed::Regions(build_regions(source, d, self.default_delimiter)))
+    }
+}
+
+/// Build one region per resolvable target column, each carrying that column's non-empty cell
+/// spans across the body rows. Columns that cannot be resolved (a name absent from the header,
+/// or an out-of-range index) are skipped here; Plan 3 surfaces a note for them.
+fn build_regions(source: &str, d: &DelimitedConfig, default_delimiter: u8) -> Vec<Region> {
+    let delimiter = if d.delimiter != 0 { d.delimiter } else { default_delimiter };
+    let records = scan_records(source, delimiter);
+
+    let header_names: Vec<String> = if d.has_header {
+        records
+            .first()
+            .map(|h| {
+                h.iter()
+                    .map(|s| cell_text(source, *s).trim().to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let body: &[Vec<tzlint_ast::Span>] = if d.has_header {
+        records.get(1..).unwrap_or(&[])
+    } else {
+        &records
+    };
+
+    let mut regions = Vec::new();
+    for target in &d.columns {
+        let (index0, name): (Option<u32>, Option<String>) = match &target.selector {
+            ColumnSelector::Index(one_based) => (one_based.checked_sub(1), None),
+            ColumnSelector::Name(n) => (
+                header_names
+                    .iter()
+                    .position(|h| h == n)
+                    .map(|i| i as u32),
+                Some(n.clone()),
+            ),
+        };
+        let Some(idx) = index0 else { continue };
+        let slices: Vec<tzlint_ast::Span> = body
+            .iter()
+            .filter_map(|rec| rec.get(idx as usize).copied())
+            .filter(|s| s.start != s.end) // skip empty cells
+            .collect();
+        if slices.is_empty() {
+            continue;
+        }
+        let resolved_name = name.or_else(|| header_names.get(idx as usize).cloned());
+        regions.push(Region {
+            slices,
+            tag: RegionTag::column(idx, resolved_name),
+            parse_mode: target.parse_mode,
+        });
+    }
+    regions
+}
+
+/// The &str a span covers, or `""` if the span is somehow out of range (never panics).
+fn cell_text(source: &str, span: tzlint_ast::Span) -> &str {
+    source
+        .get(span.start as usize..span.end as usize)
+        .unwrap_or("")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ColumnTarget, ParseMode};
+
+    fn cfg(columns: Vec<ColumnTarget>, has_header: bool) -> ProcessorConfig {
+        ProcessorConfig {
+            delimited: Some(DelimitedConfig { delimiter: b',', has_header, columns }),
+        }
+    }
+
+    /// Project a Parsed::Regions result to (tag-index, parse_mode, cell-texts) for assertions.
+    fn regions_of<'a>(source: &'a str, parsed: Parsed) -> Vec<(Option<u32>, Option<String>, Vec<&'a str>)> {
+        match parsed {
+            Parsed::Regions(rs) => rs
+                .into_iter()
+                .map(|r| {
+                    let texts = r.slices.iter().map(|s| cell_text(source, *s)).collect();
+                    (r.tag.index, r.tag.name, texts)
+                })
+                .collect(),
+            Parsed::Ast(_) => panic!("expected regions"),
+        }
+    }
+
+    #[test]
+    fn selects_column_by_header_name() {
+        let source = "id,body\n1,hello\n2,world\n";
+        let p = DelimitedProcessor::csv();
+        let parsed = p
+            .parse(source, &cfg(vec![ColumnTarget { selector: ColumnSelector::Name("body".into()), parse_mode: ParseMode::Markdown }], true))
+            .unwrap();
+        assert_eq!(
+            regions_of(source, parsed),
+            vec![(Some(1), Some("body".to_string()), vec!["hello", "world"])],
+        );
+    }
+
+    #[test]
+    fn selects_column_by_one_based_index_without_header() {
+        let source = "a,1\nb,2\n";
+        let p = DelimitedProcessor::csv();
+        let parsed = p
+            .parse(source, &cfg(vec![ColumnTarget { selector: ColumnSelector::Index(1), parse_mode: ParseMode::PlainText }], false))
+            .unwrap();
+        // 1-based index 1 → 0-based 0 → first column "a","b".
+        assert_eq!(regions_of(source, parsed), vec![(Some(0), None, vec!["a", "b"])]);
+    }
+
+    #[test]
+    fn unknown_column_name_yields_no_region() {
+        let source = "id,body\n1,hello\n";
+        let p = DelimitedProcessor::csv();
+        let parsed = p
+            .parse(source, &cfg(vec![ColumnTarget { selector: ColumnSelector::Name("missing".into()), parse_mode: ParseMode::Markdown }], true))
+            .unwrap();
+        assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
+    }
+
+    #[test]
+    fn no_delimited_config_lints_nothing() {
+        let p = DelimitedProcessor::csv();
+        let parsed = p.parse("id,body\n1,x\n", &ProcessorConfig::default()).unwrap();
+        assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
+    }
+}

--- a/crates/tzlint_core/src/processor/delimited.rs
+++ b/crates/tzlint_core/src/processor/delimited.rs
@@ -82,6 +82,11 @@ fn build_regions(source: &str, d: &DelimitedConfig, default_delimiter: u8) -> Ve
     };
 
     let mut regions = Vec::new();
+    // Track the 0-based indices already emitted: two config targets (e.g. a header name and a
+    // 1-based index) can resolve to the SAME physical column. Keep the FIRST such target and skip
+    // later duplicates, so a cell is never linted twice. `RegionRules::for_tag` already returns the
+    // first matching rule set, so rule selection is unaffected.
+    let mut seen: Vec<u32> = Vec::new();
     for target in &d.columns {
         let (index0, name): (Option<u32>, Option<String>) = match &target.selector {
             ColumnSelector::Index(one_based) => (one_based.checked_sub(1), None),
@@ -91,6 +96,9 @@ fn build_regions(source: &str, d: &DelimitedConfig, default_delimiter: u8) -> Ve
             ),
         };
         let Some(idx) = index0 else { continue };
+        if seen.contains(&idx) {
+            continue; // this physical column already has a region (first target wins)
+        }
         let slices: Vec<tzlint_ast::Span> = body
             .iter()
             .filter_map(|rec| rec.get(idx as usize).copied())
@@ -100,6 +108,7 @@ fn build_regions(source: &str, d: &DelimitedConfig, default_delimiter: u8) -> Ve
             continue;
         }
         let resolved_name = name.or_else(|| header_names.get(idx as usize).cloned());
+        seen.push(idx);
         regions.push(Region {
             slices,
             tag: RegionTag::column(idx, resolved_name),
@@ -244,6 +253,45 @@ mod tests {
             )
             .unwrap();
         assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
+    }
+
+    #[test]
+    fn column_targeted_by_name_and_index_emits_one_region() {
+        // `body` (column 0 via header) and `1` (column 0 via 1-based index) resolve to the SAME
+        // physical column. Only ONE region may be emitted for it, or its cells would be linted
+        // twice (doubled diagnostics). The FIRST target in iteration order wins.
+        let source = "body,x\nhello,1\nworld,2\n";
+        let p = DelimitedProcessor::csv();
+        let parsed = p
+            .parse(
+                source,
+                &cfg(
+                    vec![
+                        ColumnTarget {
+                            selector: ColumnSelector::Name("body".into()),
+                            parse_mode: ParseMode::Markdown,
+                        },
+                        ColumnTarget {
+                            selector: ColumnSelector::Index(1),
+                            parse_mode: ParseMode::PlainText,
+                        },
+                    ],
+                    true,
+                ),
+            )
+            .unwrap();
+        let Parsed::Regions(rs) = &parsed else {
+            panic!("expected regions");
+        };
+        assert_eq!(rs.len(), 1, "one physical column → exactly one region");
+        // The first target (the name selector, Markdown) is kept; the duplicate index target is
+        // dropped, so the region carries the resolved header name and the FIRST target's parse mode.
+        assert_eq!(rs[0].tag.index, Some(0));
+        assert_eq!(rs[0].parse_mode, ParseMode::Markdown);
+        assert_eq!(
+            regions_of(source, parsed),
+            vec![(Some(0), Some("body".to_string()), vec!["hello", "world"])],
+        );
     }
 
     #[test]

--- a/crates/tzlint_core/src/processor/delimited.rs
+++ b/crates/tzlint_core/src/processor/delimited.rs
@@ -161,6 +161,13 @@ mod tests {
                 ),
             )
             .unwrap();
+        // The region must carry the "column" kind (guards against a regression to
+        // `RegionTag::whole()`).
+        let Parsed::Regions(rs) = &parsed else {
+            panic!("expected regions");
+        };
+        assert_eq!(rs.len(), 1);
+        assert_eq!(rs[0].tag.kind, Some("column"));
         assert_eq!(
             regions_of(source, parsed),
             vec![(Some(1), Some("body".to_string()), vec!["hello", "world"])],
@@ -216,5 +223,52 @@ mod tests {
             .parse("id,body\n1,x\n", &ProcessorConfig::default())
             .unwrap();
         assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
+    }
+
+    #[test]
+    fn index_zero_is_silently_skipped() {
+        // `Index` is 1-based, so `0` is out of range: `checked_sub(1)` → None → no region.
+        // (Plan 3 surfaces a note for such unresolved targets.)
+        let source = "a,1\nb,2\n";
+        let p = DelimitedProcessor::csv();
+        let parsed = p
+            .parse(
+                source,
+                &cfg(
+                    vec![ColumnTarget {
+                        selector: ColumnSelector::Index(0),
+                        parse_mode: ParseMode::PlainText,
+                    }],
+                    false,
+                ),
+            )
+            .unwrap();
+        assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
+    }
+
+    #[test]
+    fn tsv_processor_uses_tab_via_default_delimiter() {
+        // `delimiter: 0` means "use the processor default"; for `tsv()` that is a tab.
+        let source = "id\tbody\n1\thello\n";
+        let p = DelimitedProcessor::tsv();
+        let parsed = p
+            .parse(
+                source,
+                &ProcessorConfig {
+                    delimited: Some(DelimitedConfig {
+                        delimiter: 0, // sentinel → processor default (tab)
+                        has_header: true,
+                        columns: vec![ColumnTarget {
+                            selector: ColumnSelector::Name("body".into()),
+                            parse_mode: ParseMode::Markdown,
+                        }],
+                    }),
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            regions_of(source, parsed),
+            vec![(Some(1), Some("body".to_string()), vec!["hello"])],
+        );
     }
 }

--- a/crates/tzlint_core/src/processor/delimited.rs
+++ b/crates/tzlint_core/src/processor/delimited.rs
@@ -102,7 +102,8 @@ fn build_regions(source: &str, d: &DelimitedConfig, default_delimiter: u8) -> Ve
         let slices: Vec<tzlint_ast::Span> = body
             .iter()
             .filter_map(|rec| rec.get(idx as usize).copied())
-            .filter(|s| s.start != s.end) // skip empty cells
+            // §6: skip empty AND whitespace-only cells (nothing lintable in them).
+            .filter(|s| !cell_text(source, *s).trim().is_empty())
             .collect();
         if slices.is_empty() {
             continue;
@@ -253,6 +254,53 @@ mod tests {
             )
             .unwrap();
         assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
+    }
+
+    #[test]
+    fn whitespace_only_cells_are_not_linted() {
+        // §6: a cell that is empty OR whitespace-only is not linted. Here every `body` body cell
+        // is spaces, so the column yields no region at all.
+        let source = "id,body\n1,   \n2,\t \n";
+        let p = DelimitedProcessor::csv();
+        let parsed = p
+            .parse(
+                source,
+                &cfg(
+                    vec![ColumnTarget {
+                        selector: ColumnSelector::Name("body".into()),
+                        parse_mode: ParseMode::PlainText,
+                    }],
+                    true,
+                ),
+            )
+            .unwrap();
+        assert!(
+            matches!(parsed, Parsed::Regions(rs) if rs.is_empty()),
+            "whitespace-only cells must not produce a region",
+        );
+    }
+
+    #[test]
+    fn whitespace_only_cells_are_skipped_among_real_ones() {
+        // A mix: only the non-blank cells become slices; the whitespace row is dropped.
+        let source = "id,body\n1,hello\n2,   \n3,world\n";
+        let p = DelimitedProcessor::csv();
+        let parsed = p
+            .parse(
+                source,
+                &cfg(
+                    vec![ColumnTarget {
+                        selector: ColumnSelector::Name("body".into()),
+                        parse_mode: ParseMode::PlainText,
+                    }],
+                    true,
+                ),
+            )
+            .unwrap();
+        assert_eq!(
+            regions_of(source, parsed),
+            vec![(Some(1), Some("body".to_string()), vec!["hello", "world"])],
+        );
     }
 
     #[test]

--- a/crates/tzlint_core/src/processor/markdown.rs
+++ b/crates/tzlint_core/src/processor/markdown.rs
@@ -1,0 +1,18 @@
+//! The built-in Markdown processor — the current `parse` behavior, expressed as a
+//! [`Processor`] that returns a full AST.
+
+use super::{Parsed, Processor, ProcessorConfig};
+use crate::ParseError;
+
+/// Parses CommonMark + GFM + frontmatter (the existing [`crate::parse`]) into a full AST.
+pub struct MarkdownProcessor;
+
+impl Processor for MarkdownProcessor {
+    fn extensions(&self) -> &[&str] {
+        &["md", "markdown"]
+    }
+
+    fn parse(&self, source: &str, _cfg: &ProcessorConfig) -> Result<Parsed, ParseError> {
+        Ok(Parsed::Ast(crate::parse(source)?))
+    }
+}

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -183,6 +183,16 @@ impl RegionRules {
         }
         self.base.iter().map(|r| r.as_ref()).collect()
     }
+
+    /// The ids of every rule across the base and all column sets — for the cache key.
+    #[must_use]
+    pub fn rule_ids(&self) -> Vec<&str> {
+        let mut ids: Vec<&str> = self.base.iter().map(|r| r.meta().id.as_str()).collect();
+        for set in &self.columns {
+            ids.extend(set.rules.iter().map(|r| r.meta().id.as_str()));
+        }
+        ids
+    }
 }
 
 mod markdown;

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -240,8 +240,9 @@ impl Registry {
     }
 }
 
-/// The single dispatch entry: select a processor by `ext`, parse `source`, lint every resulting
-/// AST with `rules`, and return the merged diagnostics in the engine's stable order.
+/// The single dispatch entry: select a processor by `ext`, parse `source` with `processor_cfg`,
+/// and lint each resulting region (or the whole AST) with the rules its tag resolves to in
+/// `rules`. Diagnostics carry absolute spans and are returned in the engine's stable order.
 ///
 /// A parse failure is returned as [`ParseError`]; the caller renders it as one diagnostic for the
 /// document (mirroring the existing direct/cached paths).
@@ -249,28 +250,46 @@ pub fn lint_document(
     ext: Option<&str>,
     source: &str,
     registry: &Registry,
-    rules: &[&dyn Rule],
+    processor_cfg: &ProcessorConfig,
+    rules: &RegionRules,
 ) -> Result<Vec<Diagnostic>, ParseError> {
     let processor = registry.for_ext(ext);
-    let parsed = processor.parse(source, &ProcessorConfig::default())?;
-    let asts: Vec<Ast> = match parsed {
-        Parsed::Ast(ast) => vec![ast],
-        Parsed::Regions(regions) => build_region_asts(&regions, source)?,
-    };
+    let parsed = processor.parse(source, processor_cfg)?;
     let mut diagnostics = Vec::new();
-    for ast in &asts {
-        let bytes = tzlint_ast::to_archive(ast).map_err(|e| ParseError {
-            message: format!("archive failed: {e}"),
-        })?;
-        let archived = tzlint_ast::access(&bytes).map_err(|e| ParseError {
-            message: format!("archive failed: {e}"),
-        })?;
-        diagnostics.extend(crate::Engine::lint(archived, rules));
+    match parsed {
+        Parsed::Ast(ast) => {
+            let region_rules = rules.for_tag(&RegionTag::whole());
+            lint_ast_into(&ast, &region_rules, &mut diagnostics)?;
+        }
+        Parsed::Regions(regions) => {
+            for region in &regions {
+                let region_rules = rules.for_tag(&region.tag);
+                for ast in build_region_asts(core::slice::from_ref(region), source)? {
+                    lint_ast_into(&ast, &region_rules, &mut diagnostics)?;
+                }
+            }
+        }
     }
     // Sort unconditionally — even on the single-AST path — so callers never observe an unstable
     // order, and so diagnostics merged across multiple regions come out in one stable sequence.
     diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
     Ok(diagnostics)
+}
+
+/// Archive `ast`, lint it with `rules`, and append the diagnostics into `out`.
+fn lint_ast_into(
+    ast: &Ast,
+    rules: &[&dyn Rule],
+    out: &mut Vec<Diagnostic>,
+) -> Result<(), ParseError> {
+    let bytes = tzlint_ast::to_archive(ast).map_err(|e| ParseError {
+        message: format!("archive failed: {e}"),
+    })?;
+    let archived = tzlint_ast::access(&bytes).map_err(|e| ParseError {
+        message: format!("archive failed: {e}"),
+    })?;
+    out.extend(crate::Engine::lint(archived, rules));
+    Ok(())
 }
 
 /// Build one independent mini-[`Ast`] per slice of every region. Each mini-AST's `text` is the
@@ -364,7 +383,14 @@ mod tests {
         // Through the dispatch entry, a .csv with the default (empty) ProcessorConfig yields no
         // diagnostics — opt-in safety.
         let reg = Registry::with_builtins();
-        let diags = lint_document(Some("csv"), "id,body\n1,ﾊﾛｰ\n", &reg, &[]).unwrap();
+        let diags = lint_document(
+            Some("csv"),
+            "id,body\n1,ﾊﾛｰ\n",
+            &reg,
+            &ProcessorConfig::default(),
+            &RegionRules::base_only(vec![]),
+        )
+        .unwrap();
         assert!(diags.is_empty());
     }
 
@@ -549,8 +575,10 @@ mod tests {
         let reg = Registry::with_builtins();
         let rule = FlagText::new();
         let rules: Vec<&dyn Rule> = vec![&rule];
+        let rr = RegionRules::base_only(vec![Box::new(FlagText::new())]);
 
-        let via_document = lint_document(Some("md"), source, &reg, &rules).unwrap();
+        let via_document =
+            lint_document(Some("md"), source, &reg, &ProcessorConfig::default(), &rr).unwrap();
 
         let ast = crate::parse(source).unwrap();
         let bytes = tzlint_ast::to_archive(&ast).unwrap();
@@ -558,6 +586,57 @@ mod tests {
         let direct = crate::Engine::lint(archived, &rules);
 
         assert_eq!(diag_spans(&via_document), diag_spans(&direct));
+    }
+
+    #[test]
+    fn lint_document_applies_per_region_rules() {
+        // A processor that yields one region tagged column(0,"body") covering bytes 0..3.
+        struct OneCol;
+        impl Processor for OneCol {
+            fn extensions(&self) -> &[&str] {
+                &["onecol"]
+            }
+            fn parse(&self, _s: &str, _c: &ProcessorConfig) -> Result<Parsed, ParseError> {
+                Ok(Parsed::Regions(vec![Region {
+                    slices: vec![Span::new(0, 3)],
+                    tag: RegionTag::column(0, Some("body".into())),
+                    parse_mode: ParseMode::PlainText,
+                }]))
+            }
+        }
+        let mut reg = Registry::with_builtins();
+        reg.push(Box::new(OneCol));
+
+        let flag = FlagText::new(); // base rule, flags TEXT
+        let base: Vec<&dyn Rule> = vec![&flag];
+        // base_only → the region falls back to base and flags its TEXT node at 0..3.
+        let rr = RegionRules::base_only(vec![]); // empty base
+        let mut rr_with_col = RegionRules::base_only(vec![]);
+        // Give the "body" column the flag rule; base stays empty.
+        // (Box a fresh FlagText for the column set.)
+        rr_with_col.push_column(None, Some("body".into()), vec![Box::new(FlagText::new())]);
+
+        let none =
+            lint_document(Some("onecol"), "abc", &reg, &ProcessorConfig::default(), &rr).unwrap();
+        assert!(
+            none.is_empty(),
+            "empty base + no column rules → no diagnostics"
+        );
+        let some = lint_document(
+            Some("onecol"),
+            "abc",
+            &reg,
+            &ProcessorConfig::default(),
+            &rr_with_col,
+        )
+        .unwrap();
+        assert_eq!(
+            some.iter()
+                .map(|d| (d.span.start, d.span.end))
+                .collect::<Vec<_>>(),
+            vec![(0, 3)]
+        );
+        let _ = base; // base slice kept for clarity
     }
 
     #[test]
@@ -610,9 +689,9 @@ mod tests {
             r.push(Box::new(SliceAt)); // see Step 3 for `push`
             r
         };
-        let rule = FlagText::new();
-        let rules: Vec<&dyn Rule> = vec![&rule];
-        let diags = lint_document(Some("slice"), source, &reg, &rules).unwrap();
+        let rr = RegionRules::base_only(vec![Box::new(FlagText::new())]);
+        let diags =
+            lint_document(Some("slice"), source, &reg, &ProcessorConfig::default(), &rr).unwrap();
         // The single TEXT node spans the slice 2..7 absolutely.
         assert_eq!(diag_spans(&diags), vec![(2, 7)]);
     }

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -55,13 +55,21 @@ impl RegionTag {
     /// The tag for a whole single-document format (no kind/index/name).
     #[must_use]
     pub fn whole() -> Self {
-        RegionTag { kind: None, index: None, name: None }
+        RegionTag {
+            kind: None,
+            index: None,
+            name: None,
+        }
     }
 
     /// The tag for a delimited-format column at 0-based `index`, with an optional header `name`.
     #[must_use]
     pub fn column(index: u32, name: Option<String>) -> Self {
-        RegionTag { kind: Some("column"), index: Some(index), name }
+        RegionTag {
+            kind: Some("column"),
+            index: Some(index),
+            name,
+        }
     }
 }
 
@@ -96,7 +104,10 @@ impl Registry {
     /// The registry of built-in processors. Markdown is the default; later plans push CSV/TSV.
     #[must_use]
     pub fn with_builtins() -> Self {
-        Registry { default: Box::new(MarkdownProcessor), others: Vec::new() }
+        Registry {
+            default: Box::new(MarkdownProcessor),
+            others: Vec::new(),
+        }
     }
 
     /// The processor handling `ext` (case-insensitive, dot-less), or the Markdown default when
@@ -139,10 +150,12 @@ pub fn lint_document(
     };
     let mut diagnostics = Vec::new();
     for ast in &asts {
-        let bytes = tzlint_ast::to_archive(ast)
-            .map_err(|e| ParseError { message: format!("archive failed: {e}") })?;
-        let archived = tzlint_ast::access(&bytes)
-            .map_err(|e| ParseError { message: format!("archive failed: {e}") })?;
+        let bytes = tzlint_ast::to_archive(ast).map_err(|e| ParseError {
+            message: format!("archive failed: {e}"),
+        })?;
+        let archived = tzlint_ast::access(&bytes).map_err(|e| ParseError {
+            message: format!("archive failed: {e}"),
+        })?;
         diagnostics.extend(crate::Engine::lint(archived, rules));
     }
     diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
@@ -211,7 +224,11 @@ fn plaintext_slice_ast(start: u32, end: u32, source: &str) -> Ast {
             next_sibling: OptionNodeId::NONE,
         },
     ];
-    Ast { nodes, text: source.to_string(), root: NodeId(0) }
+    Ast {
+        nodes,
+        text: source.to_string(),
+        root: NodeId(0),
+    }
 }
 
 #[cfg(test)]
@@ -244,7 +261,7 @@ mod tests {
     fn fake_processor_reports_extension() {
         let f = Fake;
         assert_eq!(f.extensions(), &["fake"]);
-        let parsed = f.parse("x", &ProcessorConfig::default()).unwrap();
+        let parsed = f.parse("x", &ProcessorConfig).unwrap();
         assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
     }
 
@@ -253,11 +270,18 @@ mod tests {
         let reg = Registry::with_builtins();
         // Markdown is registered for md/markdown…
         assert!(reg.for_ext(Some("md")).extensions().contains(&"md"));
-        assert!(reg.for_ext(Some("markdown")).extensions().contains(&"markdown"));
+        assert!(
+            reg.for_ext(Some("markdown"))
+                .extensions()
+                .contains(&"markdown")
+        );
         // …and is the fallback for unknown / missing extensions.
         let default_exts = reg.for_ext(None).extensions().to_vec();
         assert!(default_exts.contains(&"md"));
-        assert_eq!(reg.for_ext(Some("UNKNOWN")).extensions().to_vec(), default_exts);
+        assert_eq!(
+            reg.for_ext(Some("UNKNOWN")).extensions().to_vec(),
+            default_exts
+        );
         // Case-insensitive match.
         assert!(reg.for_ext(Some("MD")).extensions().contains(&"md"));
     }
@@ -284,7 +308,10 @@ mod tests {
         assert_eq!(ast.nodes[ast.root.0 as usize].kind, NodeKind::ROOT);
         let text_node = ast.nodes.iter().find(|n| n.kind == NodeKind::TEXT).unwrap();
         assert_eq!(text_node.span, Span::new(10, 15));
-        assert_eq!(&ast.text[text_node.span.start as usize..text_node.span.end as usize], "hello");
+        assert_eq!(
+            &ast.text[text_node.span.start as usize..text_node.span.end as usize],
+            "hello"
+        );
     }
 
     #[test]
@@ -295,19 +322,23 @@ mod tests {
         let ast = &asts[0];
         assert_eq!(ast.text, source);
         // The STRONG node's span must be absolute into the whole source.
-        let strong = ast.nodes.iter().find(|n| n.kind == NodeKind::STRONG).unwrap();
-        assert_eq!(&ast.text[strong.span.start as usize..strong.span.end as usize], "**bold**");
+        let strong = ast
+            .nodes
+            .iter()
+            .find(|n| n.kind == NodeKind::STRONG)
+            .unwrap();
+        assert_eq!(
+            &ast.text[strong.span.start as usize..strong.span.end as usize],
+            "**bold**"
+        );
         assert_eq!(strong.span, Span::new(10, 18));
     }
 
     #[test]
     fn one_mini_ast_per_slice() {
         let source = "a\nbb\nccc\n";
-        let asts = build_region_asts(
-            &[region(&[(0, 1), (2, 4)], ParseMode::PlainText)],
-            source,
-        )
-        .unwrap();
+        let asts =
+            build_region_asts(&[region(&[(0, 1), (2, 4)], ParseMode::PlainText)], source).unwrap();
         assert_eq!(asts.len(), 2); // independent mini-document per slice
     }
 
@@ -319,7 +350,9 @@ mod tests {
     }
     impl FlagText {
         fn new() -> Self {
-            FlagText { meta: RuleMeta::new("flag-text", Severity::Warning, vec![NodeKind::TEXT]) }
+            FlagText {
+                meta: RuleMeta::new("flag-text", Severity::Warning, vec![NodeKind::TEXT]),
+            }
         }
     }
     impl Rule for FlagText {

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -167,15 +167,27 @@ impl RegionRules {
         self.columns.push(ColumnRuleSet { index, name, rules });
     }
 
-    /// The rules to run for a region with `tag`: the first matching column set, else the base set.
+    /// The rules to run for a region with `tag`: a matching column set, else the base set.
+    ///
+    /// Resolution is **name first, then index** (independent of column insertion order): a region
+    /// tag carries both a 0-based index and a header name, so a name-selected set and an
+    /// index-selected set can both match the same column. Searching by name first makes the
+    /// documented "name match takes priority" contract hold regardless of how the columns were
+    /// pushed.
     #[must_use]
     pub fn for_tag(&self, tag: &RegionTag) -> Vec<&dyn Rule> {
-        for set in &self.columns {
-            let by_index = set.index.is_some() && set.index == tag.index;
-            let by_name = set.name.is_some() && set.name.as_deref() == tag.name.as_deref();
-            if by_index || by_name {
-                return set.rules.iter().map(|r| r.as_ref()).collect();
-            }
+        if let Some(name) = tag.name.as_deref()
+            && let Some(set) = self
+                .columns
+                .iter()
+                .find(|set| set.name.as_deref() == Some(name))
+        {
+            return set.rules.iter().map(|r| r.as_ref()).collect();
+        }
+        if let Some(index) = tag.index
+            && let Some(set) = self.columns.iter().find(|set| set.index == Some(index))
+        {
+            return set.rules.iter().map(|r| r.as_ref()).collect();
         }
         self.base.iter().map(|r| r.as_ref()).collect()
     }
@@ -738,6 +750,46 @@ mod tests {
             ids(rr.for_tag(&RegionTag::column(9, Some("nope".into())))),
             vec!["base"]
         );
+    }
+
+    #[test]
+    fn for_tag_prefers_name_over_index_regardless_of_push_order() {
+        // A column region tag carries BOTH an index and a header name, so a name-selected set and
+        // an index-selected set can both match it. Name must win either way — independent of which
+        // column was pushed first (config-key order would otherwise decide it).
+        fn rule(id: &'static str) -> Box<dyn Rule> {
+            struct R(RuleMeta);
+            impl Rule for R {
+                fn meta(&self) -> &RuleMeta {
+                    &self.0
+                }
+                fn check<'a>(&self, _n: NodeRef<'a>, _c: &mut Context<'a>) {}
+            }
+            Box::new(R(RuleMeta::new(
+                id,
+                Severity::Warning,
+                vec![NodeKind::TEXT],
+            )))
+        }
+        let ids = |v: Vec<&dyn Rule>| {
+            v.iter()
+                .map(|r| r.meta().id.as_str().to_string())
+                .collect::<Vec<_>>()
+        };
+        // The colliding region: column 0 (1st), header "body" — matched by both sets below.
+        let tag = RegionTag::column(0, Some("body".into()));
+
+        // index pushed first…
+        let mut index_first = RegionRules::base_only(vec![rule("base")]);
+        index_first.push_column(Some(0), None, vec![rule("by-index")]);
+        index_first.push_column(None, Some("body".into()), vec![rule("by-name")]);
+        assert_eq!(ids(index_first.for_tag(&tag)), vec!["by-name"]);
+
+        // …and name pushed first — same result.
+        let mut name_first = RegionRules::base_only(vec![rule("base")]);
+        name_first.push_column(None, Some("body".into()), vec![rule("by-name")]);
+        name_first.push_column(Some(0), None, vec![rule("by-index")]);
+        assert_eq!(ids(name_first.for_tag(&tag)), vec!["by-name"]);
     }
 
     #[test]

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -3,6 +3,7 @@
 //! [`Region`]s. See `docs/design/input-format-processors.md`.
 
 use tzlint_ast::{Ast, Node, NodeId, NodeKind, OptionNodeId, Span};
+use tzlint_pdk::{Diagnostic, Rule};
 
 use crate::ParseError;
 
@@ -112,6 +113,40 @@ impl Registry {
         }
         self.default.as_ref()
     }
+
+    /// Register an additional processor (tried before the Markdown default by extension).
+    pub fn push(&mut self, processor: Box<dyn Processor>) {
+        self.others.push(processor);
+    }
+}
+
+/// The single dispatch entry: select a processor by `ext`, parse `source`, lint every resulting
+/// AST with `rules`, and return the merged diagnostics in the engine's stable order.
+///
+/// A parse failure is returned as [`ParseError`]; the caller renders it as one diagnostic for the
+/// document (mirroring the existing direct/cached paths).
+pub fn lint_document(
+    ext: Option<&str>,
+    source: &str,
+    registry: &Registry,
+    rules: &[&dyn Rule],
+) -> Result<Vec<Diagnostic>, ParseError> {
+    let processor = registry.for_ext(ext);
+    let parsed = processor.parse(source, &ProcessorConfig)?;
+    let asts: Vec<Ast> = match parsed {
+        Parsed::Ast(ast) => vec![ast],
+        Parsed::Regions(regions) => build_region_asts(&regions, source)?,
+    };
+    let mut diagnostics = Vec::new();
+    for ast in &asts {
+        let bytes = tzlint_ast::to_archive(ast)
+            .map_err(|e| ParseError { message: format!("archive failed: {e}") })?;
+        let archived = tzlint_ast::access(&bytes)
+            .map_err(|e| ParseError { message: format!("archive failed: {e}") })?;
+        diagnostics.extend(crate::Engine::lint(archived, rules));
+    }
+    diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
+    Ok(diagnostics)
 }
 
 /// Build one independent mini-[`Ast`] per slice of every region. Each mini-AST's `text` is the
@@ -274,5 +309,78 @@ mod tests {
         )
         .unwrap();
         assert_eq!(asts.len(), 2); // independent mini-document per slice
+    }
+
+    use tzlint_pdk::{Context, Diagnostic, NodeRef, Rule, RuleMeta, Severity};
+
+    /// Flags every TEXT node at its own span (so we can read back absolute offsets).
+    struct FlagText {
+        meta: RuleMeta,
+    }
+    impl FlagText {
+        fn new() -> Self {
+            FlagText { meta: RuleMeta::new("flag-text", Severity::Warning, vec![NodeKind::TEXT]) }
+        }
+    }
+    impl Rule for FlagText {
+        fn meta(&self) -> &RuleMeta {
+            &self.meta
+        }
+        fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+            cx.report(node.span(), "text");
+        }
+    }
+
+    /// A processor that yields one PlainText region covering bytes 2..7 of the source.
+    struct SliceAt;
+    impl Processor for SliceAt {
+        fn extensions(&self) -> &[&str] {
+            &["slice"]
+        }
+        fn parse(&self, _source: &str, _cfg: &ProcessorConfig) -> Result<Parsed, ParseError> {
+            Ok(Parsed::Regions(vec![Region {
+                slices: vec![Span::new(2, 7)],
+                tag: RegionTag::whole(),
+                parse_mode: ParseMode::PlainText,
+            }]))
+        }
+    }
+
+    fn diag_spans(diags: &[Diagnostic]) -> Vec<(u32, u32)> {
+        // `Diagnostic.span` is a public field (not a method); `node.span()` (NodeRef) is a method.
+        diags.iter().map(|d| (d.span.start, d.span.end)).collect()
+    }
+
+    #[test]
+    fn lint_document_markdown_matches_direct_parse() {
+        // The Markdown path must equal parse → archive → access → Engine::lint exactly.
+        let source = "本文。\n";
+        let reg = Registry::with_builtins();
+        let rule = FlagText::new();
+        let rules: Vec<&dyn Rule> = vec![&rule];
+
+        let via_document = lint_document(Some("md"), source, &reg, &rules).unwrap();
+
+        let ast = crate::parse(source).unwrap();
+        let bytes = tzlint_ast::to_archive(&ast).unwrap();
+        let archived = tzlint_ast::access(&bytes).unwrap();
+        let direct = crate::Engine::lint(archived, &rules);
+
+        assert_eq!(diag_spans(&via_document), diag_spans(&direct));
+    }
+
+    #[test]
+    fn lint_document_regions_yields_absolute_spans() {
+        let source = "abXYZok"; // slice 2..7 == "XYZok"
+        let reg = {
+            let mut r = Registry::with_builtins();
+            r.push(Box::new(SliceAt)); // see Step 3 for `push`
+            r
+        };
+        let rule = FlagText::new();
+        let rules: Vec<&dyn Rule> = vec![&rule];
+        let diags = lint_document(Some("slice"), source, &reg, &rules).unwrap();
+        // The single TEXT node spans the slice 2..7 absolutely.
+        assert_eq!(diag_spans(&diags), vec![(2, 7)]);
     }
 }

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -376,6 +376,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn builtin_extensions_are_pinned() {
+        let reg = Registry::with_builtins();
+        // Every built-in extension resolves to a processor that claims it.
+        for ext in ["md", "markdown", "csv", "tsv"] {
+            assert!(
+                reg.for_ext(Some(ext)).extensions().iter().any(|e| *e == ext),
+                "extension {ext} should resolve to a processor claiming it",
+            );
+        }
+        // An unknown extension falls back to Markdown (the default).
+        assert!(reg.for_ext(Some("xyz")).extensions().contains(&"md"));
+    }
+
+    #[test]
     fn registry_includes_csv_and_tsv() {
         let reg = Registry::with_builtins();
         assert!(reg.for_ext(Some("csv")).extensions().contains(&"csv"));

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -139,12 +139,15 @@ pub struct Registry {
 }
 
 impl Registry {
-    /// The registry of built-in processors. Markdown is the default; later plans push CSV/TSV.
+    /// The registry of built-in processors. Markdown is the default; CSV/TSV are registered.
     #[must_use]
     pub fn with_builtins() -> Self {
         Registry {
             default: Box::new(MarkdownProcessor),
-            others: Vec::new(),
+            others: vec![
+                Box::new(DelimitedProcessor::csv()),
+                Box::new(DelimitedProcessor::tsv()),
+            ],
         }
     }
 
@@ -282,6 +285,24 @@ fn plaintext_slice_ast(start: u32, end: u32, source: &str) -> Ast {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn registry_includes_csv_and_tsv() {
+        let reg = Registry::with_builtins();
+        assert!(reg.for_ext(Some("csv")).extensions().contains(&"csv"));
+        assert!(reg.for_ext(Some("tsv")).extensions().contains(&"tsv"));
+        // Unknown still falls back to Markdown.
+        assert!(reg.for_ext(Some("rtf")).extensions().contains(&"md"));
+    }
+
+    #[test]
+    fn csv_with_default_config_lints_nothing_end_to_end() {
+        // Through the dispatch entry, a .csv with the default (empty) ProcessorConfig yields no
+        // diagnostics — opt-in safety.
+        let reg = Registry::with_builtins();
+        let diags = lint_document(Some("csv"), "id,body\n1,ﾊﾛｰ\n", &reg, &[]).unwrap();
+        assert!(diags.is_empty());
+    }
 
     #[test]
     fn delimited_config_constructs() {

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -83,10 +83,43 @@ pub enum ParseMode {
     PlainText,
 }
 
-/// Per-format configuration handed to [`Processor::parse`]. Empty for now; later plans add
-/// delimited-format settings (columns, header, delimiter, parse modes).
+/// Per-format configuration handed to [`Processor::parse`]. Markdown ignores it; delimited
+/// processors read [`delimited`](ProcessorConfig::delimited).
 #[derive(Debug, Clone, Default)]
-pub struct ProcessorConfig;
+pub struct ProcessorConfig {
+    /// Settings for the delimited (CSV/TSV) processor, or `None` when no columns are configured
+    /// (in which case the processor lints nothing).
+    pub delimited: Option<DelimitedConfig>,
+}
+
+/// Resolved settings for one delimited format (the `formats.csv` / `formats.tsv` section).
+#[derive(Debug, Clone)]
+pub struct DelimitedConfig {
+    /// The field delimiter byte (`b','` for CSV, `b'\t'` for TSV; overridable).
+    pub delimiter: u8,
+    /// Whether the first record is a header row (excluded from linting; enables name lookup).
+    pub has_header: bool,
+    /// The columns to lint, in config order.
+    pub columns: Vec<ColumnTarget>,
+}
+
+/// One target column: how to select it and how to interpret its cells.
+#[derive(Debug, Clone)]
+pub struct ColumnTarget {
+    /// How this column is identified.
+    pub selector: ColumnSelector,
+    /// How each cell's text is parsed before linting.
+    pub parse_mode: ParseMode,
+}
+
+/// How a target column is identified.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ColumnSelector {
+    /// Match by header name (requires `has_header`).
+    Name(String),
+    /// Match by 1-based column number (as written in config).
+    Index(u32),
+}
 
 mod markdown;
 pub use markdown::MarkdownProcessor;
@@ -147,7 +180,7 @@ pub fn lint_document(
     rules: &[&dyn Rule],
 ) -> Result<Vec<Diagnostic>, ParseError> {
     let processor = registry.for_ext(ext);
-    let parsed = processor.parse(source, &ProcessorConfig)?;
+    let parsed = processor.parse(source, &ProcessorConfig::default())?;
     let asts: Vec<Ast> = match parsed {
         Parsed::Ast(ast) => vec![ast],
         Parsed::Regions(regions) => build_region_asts(&regions, source)?,
@@ -245,6 +278,25 @@ fn plaintext_slice_ast(start: u32, end: u32, source: &str) -> Ast {
 mod tests {
     use super::*;
 
+    #[test]
+    fn delimited_config_constructs() {
+        let cfg = ProcessorConfig {
+            delimited: Some(DelimitedConfig {
+                delimiter: b',',
+                has_header: true,
+                columns: vec![
+                    ColumnTarget { selector: ColumnSelector::Name("body".into()), parse_mode: ParseMode::Markdown },
+                    ColumnTarget { selector: ColumnSelector::Index(2), parse_mode: ParseMode::PlainText },
+                ],
+            }),
+        };
+        let d = cfg.delimited.as_ref().unwrap();
+        assert_eq!(d.delimiter, b',');
+        assert!(d.has_header);
+        assert_eq!(d.columns.len(), 2);
+        assert_eq!(d.columns[1].selector, ColumnSelector::Index(2));
+    }
+
     /// A test-only processor that reports a fixed extension and returns no regions.
     struct Fake;
     impl Processor for Fake {
@@ -271,7 +323,7 @@ mod tests {
     fn fake_processor_reports_extension() {
         let f = Fake;
         assert_eq!(f.extensions(), &["fake"]);
-        let parsed = f.parse("x", &ProcessorConfig).unwrap();
+        let parsed = f.parse("x", &ProcessorConfig::default()).unwrap();
         assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
     }
 

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -2,7 +2,7 @@
 //! turns source into either a full [`Ast`] (Markdown's path) or a list of lintable
 //! [`Region`]s. See `docs/design/input-format-processors.md`.
 
-use tzlint_ast::Span;
+use tzlint_ast::{Ast, Node, NodeId, NodeKind, OptionNodeId, Span};
 
 use crate::ParseError;
 
@@ -114,6 +114,71 @@ impl Registry {
     }
 }
 
+/// Build one independent mini-[`Ast`] per slice of every region. Each mini-AST's `text` is the
+/// whole `source` and its node spans are **absolute** byte offsets into it, so diagnostics from
+/// linting it are already in the original file's coordinates (no later shifting).
+///
+/// A slice that fails to parse (Markdown only) propagates its [`ParseError`]; the caller turns
+/// it into a single diagnostic for the document.
+pub(crate) fn build_region_asts(regions: &[Region], source: &str) -> Result<Vec<Ast>, ParseError> {
+    let mut asts = Vec::new();
+    for region in regions {
+        for slice in &region.slices {
+            let start = slice.start;
+            let end = slice.end;
+            let text = source.get(start as usize..end as usize).unwrap_or("");
+            let ast = match region.parse_mode {
+                ParseMode::Markdown => markdown_slice_ast(text, start, source)?,
+                ParseMode::PlainText => plaintext_slice_ast(start, end, source),
+            };
+            asts.push(ast);
+        }
+    }
+    Ok(asts)
+}
+
+/// Parse `text` (a slice of `source` starting at byte `start`) as Markdown, then shift every
+/// node span by `start` so they are absolute into `source`, and set the AST's text to the whole
+/// `source`.
+fn markdown_slice_ast(text: &str, start: u32, source: &str) -> Result<Ast, ParseError> {
+    let mut ast = crate::parse(text)?;
+    for node in &mut ast.nodes {
+        node.span = Span::new(node.span.start + start, node.span.end + start);
+    }
+    ast.text = source.to_string();
+    Ok(ast)
+}
+
+/// A fixed Root → Paragraph → Text spine spanning `[start, end)`, with the AST's text set to the
+/// whole `source` (so spans are absolute).
+fn plaintext_slice_ast(start: u32, end: u32, source: &str) -> Ast {
+    let span = Span::new(start, end);
+    let nodes = vec![
+        Node {
+            kind: NodeKind::ROOT,
+            span,
+            parent: NodeId(0),
+            first_child: OptionNodeId::some(NodeId(1)),
+            next_sibling: OptionNodeId::NONE,
+        },
+        Node {
+            kind: NodeKind::PARAGRAPH,
+            span,
+            parent: NodeId(0),
+            first_child: OptionNodeId::some(NodeId(2)),
+            next_sibling: OptionNodeId::NONE,
+        },
+        Node {
+            kind: NodeKind::TEXT,
+            span,
+            parent: NodeId(1),
+            first_child: OptionNodeId::NONE,
+            next_sibling: OptionNodeId::NONE,
+        },
+    ];
+    Ast { nodes, text: source.to_string(), root: NodeId(0) }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,5 +225,54 @@ mod tests {
         assert_eq!(reg.for_ext(Some("UNKNOWN")).extensions().to_vec(), default_exts);
         // Case-insensitive match.
         assert!(reg.for_ext(Some("MD")).extensions().contains(&"md"));
+    }
+
+    use tzlint_ast::{NodeKind, Span};
+
+    fn region(slices: &[(u32, u32)], mode: ParseMode) -> Region {
+        Region {
+            slices: slices.iter().map(|(s, e)| Span::new(*s, *e)).collect(),
+            tag: RegionTag::whole(),
+            parse_mode: mode,
+        }
+    }
+
+    #[test]
+    fn plaintext_slice_builds_absolute_root_paragraph_text() {
+        let source = "id,body\n1,hello\n";
+        // "hello" is at bytes 10..15.
+        let asts = build_region_asts(&[region(&[(10, 15)], ParseMode::PlainText)], source).unwrap();
+        assert_eq!(asts.len(), 1);
+        let ast = &asts[0];
+        // text is the whole source; spans are absolute into it.
+        assert_eq!(ast.text, source);
+        assert_eq!(ast.nodes[ast.root.0 as usize].kind, NodeKind::ROOT);
+        let text_node = ast.nodes.iter().find(|n| n.kind == NodeKind::TEXT).unwrap();
+        assert_eq!(text_node.span, Span::new(10, 15));
+        assert_eq!(&ast.text[text_node.span.start as usize..text_node.span.end as usize], "hello");
+    }
+
+    #[test]
+    fn markdown_slice_shifts_spans_to_absolute() {
+        let source = "id,body\n1,**bold**\n";
+        // "**bold**" is at bytes 10..18.
+        let asts = build_region_asts(&[region(&[(10, 18)], ParseMode::Markdown)], source).unwrap();
+        let ast = &asts[0];
+        assert_eq!(ast.text, source);
+        // The STRONG node's span must be absolute into the whole source.
+        let strong = ast.nodes.iter().find(|n| n.kind == NodeKind::STRONG).unwrap();
+        assert_eq!(&ast.text[strong.span.start as usize..strong.span.end as usize], "**bold**");
+        assert_eq!(strong.span, Span::new(10, 18));
+    }
+
+    #[test]
+    fn one_mini_ast_per_slice() {
+        let source = "a\nbb\nccc\n";
+        let asts = build_region_asts(
+            &[region(&[(0, 1), (2, 4)], ParseMode::PlainText)],
+            source,
+        )
+        .unwrap();
+        assert_eq!(asts.len(), 2); // independent mini-document per slice
     }
 }

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -164,11 +164,7 @@ impl RegionRules {
         name: Option<String>,
         rules: Vec<Box<dyn Rule>>,
     ) {
-        self.columns.push(ColumnRuleSet {
-            index,
-            name,
-            rules,
-        });
+        self.columns.push(ColumnRuleSet { index, name, rules });
     }
 
     /// The rules to run for a region with `tag`: the first matching column set, else the base set.
@@ -626,8 +622,14 @@ mod tests {
         // (Box a fresh FlagText for the column set.)
         rr_with_col.push_column(None, Some("body".into()), vec![Box::new(FlagText::new())]);
 
-        let none =
-            lint_document(Some("onecol"), "abc", &reg, &ProcessorConfig::default(), &rr).unwrap();
+        let none = lint_document(
+            Some("onecol"),
+            "abc",
+            &reg,
+            &ProcessorConfig::default(),
+            &rr,
+        )
+        .unwrap();
         assert!(
             none.is_empty(),
             "empty base + no column rules → no diagnostics"
@@ -700,8 +702,14 @@ mod tests {
             r
         };
         let rr = RegionRules::base_only(vec![Box::new(FlagText::new())]);
-        let diags =
-            lint_document(Some("slice"), source, &reg, &ProcessorConfig::default(), &rr).unwrap();
+        let diags = lint_document(
+            Some("slice"),
+            source,
+            &reg,
+            &ProcessorConfig::default(),
+            &rr,
+        )
+        .unwrap();
         // The single TEXT node spans the slice 2..7 absolutely.
         assert_eq!(diag_spans(&diags), vec![(2, 7)]);
     }

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -333,12 +333,21 @@ pub(crate) fn build_region_asts(regions: &[Region], source: &str) -> Result<Vec<
 }
 
 /// Parse `text` (a slice of `source` starting at byte `start`) as Markdown, then shift every
-/// node span by `start` so they are absolute into `source`, and set the AST's text to the whole
-/// `source`.
+/// node span so they are absolute into `source`, and set the AST's text to the whole `source`.
+///
+/// `crate::parse` strips a single leading BOM (`U+FEFF`) and returns spans relative to the
+/// **stripped** text, so the shift includes that BOM's byte length. Without it, a cell whose
+/// content begins with a BOM would have every span shifted 3 bytes too early — landing inside the
+/// multibyte BOM, which mis-reports `line:column` and makes `apply_fixes`' char-boundary guard
+/// silently drop fixes on that node. (The scanner only strips a BOM at file offset 0, so a BOM in
+/// a quoted or non-first cell reaches here intact.)
 fn markdown_slice_ast(text: &str, start: u32, source: &str) -> Result<Ast, ParseError> {
+    // Bytes `crate::parse` strips from the front before assigning spans (0 or the BOM length).
+    let bom_len = (text.len() - text.strip_prefix('\u{feff}').unwrap_or(text).len()) as u32;
+    let shift = start + bom_len;
     let mut ast = crate::parse(text)?;
     for node in &mut ast.nodes {
-        node.span = Span::new(node.span.start + start, node.span.end + start);
+        node.span = Span::new(node.span.start + shift, node.span.end + shift);
     }
     ast.text = source.to_string();
     Ok(ast)
@@ -543,6 +552,23 @@ mod tests {
             "**bold**"
         );
         assert_eq!(strong.span, Span::new(10, 18));
+    }
+
+    #[test]
+    fn markdown_slice_with_leading_bom_rebases_onto_visible_text() {
+        // A Markdown cell whose content starts with a BOM (U+FEFF, 3 bytes): `crate::parse`
+        // strips it, so the rebase must skip those bytes. The TEXT span must cover the visible
+        // "X" and be a valid char-boundary slice (regression for the 3-byte-too-early shift that
+        // landed inside the BOM and silently dropped autofixes).
+        let source = "id,body\n1,\u{feff}X\n"; // body cell "\u{feff}X" is bytes 10..14
+        let asts = build_region_asts(&[region(&[(10, 14)], ParseMode::Markdown)], source).unwrap();
+        let ast = &asts[0];
+        let text_node = ast.nodes.iter().find(|n| n.kind == NodeKind::TEXT).unwrap();
+        assert_eq!(text_node.span, Span::new(13, 14));
+        assert_eq!(
+            source.get(text_node.span.start as usize..text_node.span.end as usize),
+            Some("X"),
+        );
     }
 
     #[test]

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -79,6 +79,41 @@ pub enum ParseMode {
 #[derive(Debug, Clone, Default)]
 pub struct ProcessorConfig;
 
+mod markdown;
+pub use markdown::MarkdownProcessor;
+
+/// A set of built-in [`Processor`]s, resolved by file extension. The Markdown processor is
+/// always the default/fallback for unknown or missing extensions.
+pub struct Registry {
+    /// The fallback processor (Markdown). Resolved when no extension matches.
+    default: Box<dyn Processor>,
+    /// Additional processors, tried before the default by extension.
+    others: Vec<Box<dyn Processor>>,
+}
+
+impl Registry {
+    /// The registry of built-in processors. Markdown is the default; later plans push CSV/TSV.
+    #[must_use]
+    pub fn with_builtins() -> Self {
+        Registry { default: Box::new(MarkdownProcessor), others: Vec::new() }
+    }
+
+    /// The processor handling `ext` (case-insensitive, dot-less), or the Markdown default when
+    /// `ext` is `None` or unmatched.
+    #[must_use]
+    pub fn for_ext(&self, ext: Option<&str>) -> &dyn Processor {
+        if let Some(ext) = ext {
+            let lower = ext.to_ascii_lowercase();
+            for p in &self.others {
+                if p.extensions().iter().any(|e| *e == lower) {
+                    return p.as_ref();
+                }
+            }
+        }
+        self.default.as_ref()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,5 +146,19 @@ mod tests {
         assert_eq!(f.extensions(), &["fake"]);
         let parsed = f.parse("x", &ProcessorConfig::default()).unwrap();
         assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
+    }
+
+    #[test]
+    fn registry_resolves_known_extension_and_defaults_to_markdown() {
+        let reg = Registry::with_builtins();
+        // Markdown is registered for md/markdown…
+        assert!(reg.for_ext(Some("md")).extensions().contains(&"md"));
+        assert!(reg.for_ext(Some("markdown")).extensions().contains(&"markdown"));
+        // …and is the fallback for unknown / missing extensions.
+        let default_exts = reg.for_ext(None).extensions().to_vec();
+        assert!(default_exts.contains(&"md"));
+        assert_eq!(reg.for_ext(Some("UNKNOWN")).extensions().to_vec(), default_exts);
+        // Case-insensitive match.
+        assert!(reg.for_ext(Some("MD")).extensions().contains(&"md"));
     }
 }

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -1,0 +1,115 @@
+//! The format-neutral processor seam: a file's extension selects a [`Processor`] that
+//! turns source into either a full [`Ast`] (Markdown's path) or a list of lintable
+//! [`Region`]s. See `docs/design/input-format-processors.md`.
+
+use tzlint_ast::Span;
+
+use crate::ParseError;
+
+/// A format-specific parser. Adding a new format = implement this trait and register it in
+/// [`Registry::with_builtins`].
+pub trait Processor {
+    /// Handled file extensions, dot-less and lowercase (e.g. `["csv"]`, `["md", "markdown"]`).
+    fn extensions(&self) -> &[&str];
+
+    /// Parse `source`. Return [`Parsed::Regions`] for the common prose-extraction path, or
+    /// [`Parsed::Ast`] when the format's own structure must be visible to rules.
+    fn parse(&self, source: &str, cfg: &ProcessorConfig) -> Result<Parsed, ParseError>;
+}
+
+/// The result of [`Processor::parse`]. Spans on both arms are absolute byte offsets into the
+/// original `source`.
+pub enum Parsed {
+    /// Lintable regions; the core parses each slice and produces per-slice mini-ASTs.
+    Regions(Vec<Region>),
+    /// A complete AST (text = whole source, spans absolute). Markdown takes this arm.
+    Ast(tzlint_ast::Ast),
+}
+
+/// One lintable region: the unit that shares a rule set and a parse mode.
+pub struct Region {
+    /// Source slices making up this region (e.g. all cells of one column). Each slice is a
+    /// **contiguous** byte range of `source` and is linted as an independent mini-document.
+    pub slices: Vec<Span>,
+    /// What this region is, so config can target rules at it (used by later plans).
+    pub tag: RegionTag,
+    /// How to interpret each slice before linting.
+    pub parse_mode: ParseMode,
+}
+
+/// Format-neutral region identity. `"column"` is just one `kind` used by the delimited
+/// processor; it is **not** a core concept.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegionTag {
+    /// Region kind, a processor-defined static string (`Some("column")` for CSV/TSV);
+    /// `None` for a single-document format (Markdown, plain text).
+    pub kind: Option<&'static str>,
+    /// 0-based ordinal within the kind (e.g. column index), or `None`.
+    pub index: Option<u32>,
+    /// A name (e.g. a column header), or `None`.
+    pub name: Option<String>,
+}
+
+impl RegionTag {
+    /// The tag for a whole single-document format (no kind/index/name).
+    #[must_use]
+    pub fn whole() -> Self {
+        RegionTag { kind: None, index: None, name: None }
+    }
+
+    /// The tag for a delimited-format column at 0-based `index`, with an optional header `name`.
+    #[must_use]
+    pub fn column(index: u32, name: Option<String>) -> Self {
+        RegionTag { kind: Some("column"), index: Some(index), name }
+    }
+}
+
+/// How a region's slices are parsed before linting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ParseMode {
+    /// Parse as Markdown (CommonMark + GFM), reusing the Markdown rules. The default.
+    #[default]
+    Markdown,
+    /// Treat each slice as one plain paragraph (no Markdown constructs).
+    PlainText,
+}
+
+/// Per-format configuration handed to [`Processor::parse`]. Empty for now; later plans add
+/// delimited-format settings (columns, header, delimiter, parse modes).
+#[derive(Debug, Clone, Default)]
+pub struct ProcessorConfig;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A test-only processor that reports a fixed extension and returns no regions.
+    struct Fake;
+    impl Processor for Fake {
+        fn extensions(&self) -> &[&str] {
+            &["fake"]
+        }
+        fn parse(&self, _source: &str, _cfg: &ProcessorConfig) -> Result<Parsed, ParseError> {
+            Ok(Parsed::Regions(Vec::new()))
+        }
+    }
+
+    #[test]
+    fn region_tag_constructors_and_parse_mode() {
+        let whole = RegionTag::whole();
+        assert!(whole.kind.is_none());
+        let col = RegionTag::column(2, Some("body".to_string()));
+        assert_eq!(col.kind, Some("column"));
+        assert_eq!(col.index, Some(2));
+        assert_eq!(col.name.as_deref(), Some("body"));
+        assert_eq!(ParseMode::default(), ParseMode::Markdown);
+    }
+
+    #[test]
+    fn fake_processor_reports_extension() {
+        let f = Fake;
+        assert_eq!(f.extensions(), &["fake"]);
+        let parsed = f.parse("x", &ProcessorConfig::default()).unwrap();
+        assert!(matches!(parsed, Parsed::Regions(rs) if rs.is_empty()));
+    }
+}

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -131,6 +131,60 @@ pub enum ColumnSelector {
     Index(u32),
 }
 
+/// The rule sets to apply per region: a base set plus per-column sets. The CLI builds each set
+/// (base, and `base ⊕ column-overlay` for every column) so this type stays rule-agnostic.
+pub struct RegionRules {
+    base: Vec<Box<dyn Rule>>,
+    columns: Vec<ColumnRuleSet>,
+}
+
+/// One column's rule set plus the index/name it matches against a [`RegionTag`].
+struct ColumnRuleSet {
+    /// 0-based column index to match against `RegionTag.index`, if this column was selected by index.
+    index: Option<u32>,
+    /// Header name to match against `RegionTag.name`, if this column was selected by name.
+    name: Option<String>,
+    rules: Vec<Box<dyn Rule>>,
+}
+
+impl RegionRules {
+    /// A `RegionRules` with only a base set (used for Markdown / un-tagged documents).
+    #[must_use]
+    pub fn base_only(base: Vec<Box<dyn Rule>>) -> Self {
+        RegionRules {
+            base,
+            columns: Vec::new(),
+        }
+    }
+
+    /// Register the rule set for a column selected by 0-based `index` and/or header `name`.
+    pub fn push_column(
+        &mut self,
+        index: Option<u32>,
+        name: Option<String>,
+        rules: Vec<Box<dyn Rule>>,
+    ) {
+        self.columns.push(ColumnRuleSet {
+            index,
+            name,
+            rules,
+        });
+    }
+
+    /// The rules to run for a region with `tag`: the first matching column set, else the base set.
+    #[must_use]
+    pub fn for_tag(&self, tag: &RegionTag) -> Vec<&dyn Rule> {
+        for set in &self.columns {
+            let by_index = set.index.is_some() && set.index == tag.index;
+            let by_name = set.name.is_some() && set.name.as_deref() == tag.name.as_deref();
+            if by_index || by_name {
+                return set.rules.iter().map(|r| r.as_ref()).collect();
+            }
+        }
+        self.base.iter().map(|r| r.as_ref()).collect()
+    }
+}
+
 mod markdown;
 pub use markdown::MarkdownProcessor;
 
@@ -504,6 +558,48 @@ mod tests {
         let direct = crate::Engine::lint(archived, &rules);
 
         assert_eq!(diag_spans(&via_document), diag_spans(&direct));
+    }
+
+    #[test]
+    fn region_rules_resolve_by_name_then_index_then_base() {
+        // Build with a tiny rule so we can identify which set was returned by its meta id.
+        fn rule(id: &'static str) -> Box<dyn Rule> {
+            struct R(RuleMeta);
+            impl Rule for R {
+                fn meta(&self) -> &RuleMeta {
+                    &self.0
+                }
+                fn check<'a>(&self, _n: NodeRef<'a>, _c: &mut Context<'a>) {}
+            }
+            Box::new(R(RuleMeta::new(
+                id,
+                Severity::Warning,
+                vec![NodeKind::TEXT],
+            )))
+        }
+        let mut rr = RegionRules::base_only(vec![rule("base")]);
+        rr.push_column(None, Some("body".into()), vec![rule("body")]);
+        rr.push_column(Some(2), None, vec![rule("col2")]);
+
+        let ids = |v: Vec<&dyn Rule>| {
+            v.iter()
+                .map(|r| r.meta().id.as_str().to_string())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(ids(rr.for_tag(&RegionTag::whole())), vec!["base"]);
+        assert_eq!(
+            ids(rr.for_tag(&RegionTag::column(1, Some("body".into())))),
+            vec!["body"]
+        );
+        assert_eq!(
+            ids(rr.for_tag(&RegionTag::column(2, Some("other".into())))),
+            vec!["col2"]
+        );
+        // No match → base.
+        assert_eq!(
+            ids(rr.for_tag(&RegionTag::column(9, Some("nope".into())))),
+            vec!["base"]
+        );
     }
 
     #[test]

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -96,6 +96,11 @@ pub struct ProcessorConfig {
 #[derive(Debug, Clone)]
 pub struct DelimitedConfig {
     /// The field delimiter byte (`b','` for CSV, `b'\t'` for TSV; overridable).
+    ///
+    /// The sentinel `0` (`b'\0'`) means "use the processor's default delimiter"; the
+    /// [`DelimitedProcessor`] resolves it to `,` (CSV) or tab (TSV). As a consequence `b'\0'`
+    /// cannot be used as a real delimiter. (Plan 3's config builder sets the real byte or leaves
+    /// `0`.)
     pub delimiter: u8,
     /// Whether the first record is a header row (excluded from linting; enables name lookup).
     pub has_header: bool,
@@ -115,9 +120,14 @@ pub struct ColumnTarget {
 /// How a target column is identified.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ColumnSelector {
-    /// Match by header name (requires `has_header`).
+    /// Match by header name (requires `has_header`). Header cells are trimmed before comparison,
+    /// while this selector string is compared as-is, so callers should pass an already-trimmed
+    /// name.
     Name(String),
-    /// Match by 1-based column number (as written in config).
+    /// Match by 1-based column number (as written in config). `1` is the first column; `0` is
+    /// out of range (the number is 1-based) and resolves to no column — the processor converts
+    /// via `checked_sub(1)`, so `Index(0)` yields `None` and the column is skipped. Plan 3 will
+    /// surface a note for such unresolved targets.
     Index(u32),
 }
 
@@ -311,8 +321,14 @@ mod tests {
                 delimiter: b',',
                 has_header: true,
                 columns: vec![
-                    ColumnTarget { selector: ColumnSelector::Name("body".into()), parse_mode: ParseMode::Markdown },
-                    ColumnTarget { selector: ColumnSelector::Index(2), parse_mode: ParseMode::PlainText },
+                    ColumnTarget {
+                        selector: ColumnSelector::Name("body".into()),
+                        parse_mode: ParseMode::Markdown,
+                    },
+                    ColumnTarget {
+                        selector: ColumnSelector::Index(2),
+                        parse_mode: ParseMode::PlainText,
+                    },
                 ],
             }),
         };

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -124,6 +124,8 @@ pub enum ColumnSelector {
 mod markdown;
 pub use markdown::MarkdownProcessor;
 
+mod scanner;
+
 /// A set of built-in [`Processor`]s, resolved by file extension. The Markdown processor is
 /// always the default/fallback for unknown or missing extensions.
 pub struct Registry {

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -381,7 +381,7 @@ mod tests {
         // Every built-in extension resolves to a processor that claims it.
         for ext in ["md", "markdown", "csv", "tsv"] {
             assert!(
-                reg.for_ext(Some(ext)).extensions().iter().any(|e| *e == ext),
+                reg.for_ext(Some(ext)).extensions().contains(&ext),
                 "extension {ext} should resolve to a processor claiming it",
             );
         }

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -112,6 +112,10 @@ impl Registry {
 
     /// The processor handling `ext` (case-insensitive, dot-less), or the Markdown default when
     /// `ext` is `None` or unmatched.
+    ///
+    /// Permanent contract: only the `others` are matched by extension (case-insensitively); the
+    /// `default` (Markdown) processor is returned for any unrecognized or missing extension, so a
+    /// file always has a processor.
     #[must_use]
     pub fn for_ext(&self, ext: Option<&str>) -> &dyn Processor {
         if let Some(ext) = ext {
@@ -158,6 +162,8 @@ pub fn lint_document(
         })?;
         diagnostics.extend(crate::Engine::lint(archived, rules));
     }
+    // Sort unconditionally — even on the single-AST path — so callers never observe an unstable
+    // order, and so diagnostics merged across multiple regions come out in one stable sequence.
     diagnostics.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
     Ok(diagnostics)
 }
@@ -171,9 +177,13 @@ pub fn lint_document(
 pub(crate) fn build_region_asts(regions: &[Region], source: &str) -> Result<Vec<Ast>, ParseError> {
     let mut asts = Vec::new();
     for region in regions {
+        // `region.tag` is intentionally unused at this stage; later plans consume it for
+        // per-region rule selection.
         for slice in &region.slices {
             let start = slice.start;
             let end = slice.end;
+            // An out-of-range slice (a processor-contract violation) degrades to empty text rather
+            // than panicking.
             let text = source.get(start as usize..end as usize).unwrap_or("");
             let ast = match region.parse_mode {
                 ParseMode::Markdown => markdown_slice_ast(text, start, source)?,

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -126,6 +126,9 @@ pub use markdown::MarkdownProcessor;
 
 mod scanner;
 
+mod delimited;
+pub use delimited::DelimitedProcessor;
+
 /// A set of built-in [`Processor`]s, resolved by file extension. The Markdown processor is
 /// always the default/fallback for unknown or missing extensions.
 pub struct Registry {

--- a/crates/tzlint_core/src/processor/scanner.rs
+++ b/crates/tzlint_core/src/processor/scanner.rs
@@ -220,4 +220,13 @@ mod tests {
             vec![vec!["a", "b"], vec!["c", "d"]]
         );
     }
+
+    #[test]
+    fn trailing_bytes_after_closing_quote_are_skipped() {
+        // Junk between a closing quote and the next delimiter/newline is tolerated and dropped:
+        // the cell content is the quoted span only, and the junk is not part of any cell.
+        assert_eq!(cells("\"x\"junk,y\n", b','), vec![vec!["x", "y"]]);
+        // …and at end-of-record too (junk after the closing quote before EOF).
+        assert_eq!(cells("a,\"b\"tail", b','), vec![vec!["a", "b"]]);
+    }
 }

--- a/crates/tzlint_core/src/processor/scanner.rs
+++ b/crates/tzlint_core/src/processor/scanner.rs
@@ -1,0 +1,159 @@
+//! A small RFC 4180-style delimited scanner that yields, per record, the absolute byte
+//! **content** span of each cell. Quoted-cell spans are the bytes inside the outer quotes;
+//! embedded newlines and doubled quotes (`""`) stay in the (contiguous) span as raw bytes.
+//! See `docs/design/input-format-processors.md` §6.
+
+use tzlint_ast::Span;
+
+/// Scan `source` into records of cell **content** spans (absolute byte offsets). Records split
+/// on unquoted CR / LF / CRLF; fields split on the unquoted `delimiter`. A leading UTF-8 BOM is
+/// skipped. Never panics: an unterminated quote takes content to end-of-input.
+pub(crate) fn scan_records(source: &str, delimiter: u8) -> Vec<Vec<Span>> {
+    let b = source.as_bytes();
+    let n = b.len();
+    let mut i = if b.starts_with(&[0xEF, 0xBB, 0xBF]) { 3 } else { 0 };
+
+    let mut records: Vec<Vec<Span>> = Vec::new();
+    if i >= n {
+        return records; // empty (or BOM-only) input → no records
+    }
+    let mut record: Vec<Span> = Vec::new();
+
+    loop {
+        // --- parse one field beginning at `i` ---
+        let (content_start, content_end, after_field);
+        if b.get(i) == Some(&b'"') {
+            // Quoted field: content runs from just after the opening quote to the closing quote.
+            let start = i + 1;
+            let mut j = start;
+            loop {
+                match b.get(j) {
+                    None => break,                       // unterminated → content to EOF
+                    Some(&c) if c == b'"' => {
+                        if b.get(j + 1) == Some(&b'"') {
+                            j += 2; // escaped quote, stays in content
+                            continue;
+                        }
+                        break; // closing quote
+                    }
+                    Some(_) => j += 1,
+                }
+            }
+            content_start = start;
+            content_end = j.min(n);
+            after_field = if j < n { j + 1 } else { n }; // skip the closing quote
+        } else {
+            // Unquoted field: runs to the next delimiter or newline.
+            let mut j = i;
+            while j < n && b[j] != delimiter && b[j] != b'\n' && b[j] != b'\r' {
+                j += 1;
+            }
+            content_start = i;
+            content_end = j;
+            after_field = j;
+        }
+        record.push(Span::new(content_start as u32, content_end as u32));
+
+        // --- advance to the separator (delimiter / newline / EOF) ---
+        let mut k = after_field;
+        while k < n && b[k] != delimiter && b[k] != b'\n' && b[k] != b'\r' {
+            k += 1; // tolerate any trailing bytes after a closing quote
+        }
+        if k >= n {
+            records.push(core::mem::take(&mut record));
+            break;
+        }
+        let sep = b[k];
+        if sep == delimiter {
+            i = k + 1; // another field in the same record
+        } else {
+            // sep is CR or LF — end of record.
+            records.push(core::mem::take(&mut record));
+            i = if sep == b'\r' && b.get(k + 1) == Some(&b'\n') { k + 2 } else { k + 1 };
+            if i >= n {
+                break; // trailing newline does not create a spurious empty record
+            }
+        }
+    }
+    records
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: scan and project each cell span to the &str it covers.
+    fn cells<'a>(source: &'a str, delim: u8) -> Vec<Vec<&'a str>> {
+        scan_records(source, delim)
+            .into_iter()
+            .map(|rec| {
+                rec.into_iter()
+                    .map(|s| source.get(s.start as usize..s.end as usize).unwrap_or("<bad>"))
+                    .collect()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn simple_rows_and_fields() {
+        assert_eq!(
+            cells("a,b,c\n1,2,3\n", b','),
+            vec![vec!["a", "b", "c"], vec!["1", "2", "3"]],
+        );
+    }
+
+    #[test]
+    fn final_line_without_newline() {
+        assert_eq!(cells("a,b\nc,d", b','), vec![vec!["a", "b"], vec!["c", "d"]]);
+    }
+
+    #[test]
+    fn quoted_field_content_excludes_quotes() {
+        // The middle field is quoted and contains the delimiter; its content span is `x,y`.
+        assert_eq!(cells("a,\"x,y\",b\n", b','), vec![vec!["a", "x,y", "b"]]);
+    }
+
+    #[test]
+    fn quoted_field_with_embedded_newline_stays_in_one_cell() {
+        let rows = cells("\"line1\nline2\",b\n", b',');
+        assert_eq!(rows, vec![vec!["line1\nline2", "b"]]);
+    }
+
+    #[test]
+    fn escaped_quotes_remain_raw_in_span() {
+        // `"He said ""hi"""` → content span is `He said ""hi""` (raw doubled quotes; v1).
+        assert_eq!(cells("\"He said \"\"hi\"\"\"\n", b','), vec![vec!["He said \"\"hi\"\""]]);
+    }
+
+    #[test]
+    fn crlf_line_endings() {
+        assert_eq!(cells("a,b\r\nc,d\r\n", b','), vec![vec!["a", "b"], vec!["c", "d"]]);
+    }
+
+    #[test]
+    fn tab_delimiter() {
+        assert_eq!(cells("a\tb\n1\t2\n", b'\t'), vec![vec!["a", "b"], vec!["1", "2"]]);
+    }
+
+    #[test]
+    fn leading_bom_is_skipped() {
+        assert_eq!(cells("\u{feff}a,b\n", b','), vec![vec!["a", "b"]]);
+    }
+
+    #[test]
+    fn ragged_rows_keep_their_field_counts() {
+        assert_eq!(cells("a,b,c\nx,y\n", b','), vec![vec!["a", "b", "c"], vec!["x", "y"]]);
+    }
+
+    #[test]
+    fn empty_input_yields_no_records() {
+        assert!(scan_records("", b',').is_empty());
+        assert!(scan_records("\u{feff}", b',').is_empty());
+    }
+
+    #[test]
+    fn never_panics_on_unterminated_quote() {
+        // Best-effort: an unterminated quote takes content to EOF, no panic.
+        let _ = scan_records("\"unterminated", b',');
+    }
+}

--- a/crates/tzlint_core/src/processor/scanner.rs
+++ b/crates/tzlint_core/src/processor/scanner.rs
@@ -56,6 +56,8 @@ pub(crate) fn scan_records(source: &str, delimiter: u8) -> Vec<Vec<Span>> {
             content_end = j;
             after_field = j;
         }
+        // `as u32` is safe: byte offsets index `source`, and `io::MAX_FILE` (16 MiB) is far below
+        // `u32::MAX`, so an offset always fits.
         record.push(Span::new(content_start as u32, content_end as u32));
 
         // --- advance to the separator (delimiter / newline / EOF) ---
@@ -180,7 +182,42 @@ mod tests {
 
     #[test]
     fn never_panics_on_unterminated_quote() {
-        // Best-effort: an unterminated quote takes content to EOF, no panic.
-        let _ = scan_records("\"unterminated", b',');
+        // Best-effort: an unterminated quote takes content to EOF, no panic — and the recovered
+        // content (inside the opening quote) runs all the way to end-of-input.
+        let records = scan_records("\"abc", b',');
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].len(), 1);
+        let span = records[0][0];
+        assert_eq!(span, Span::new(1, 4)); // content starts just after the opening quote, to EOF
+        assert_eq!(cells("\"abc", b','), vec![vec!["abc"]]);
+    }
+
+    #[test]
+    fn cell_spans_are_exact_byte_offsets() {
+        // The scanner's contract is its spans, so assert raw `Span` values, not just text.
+        // `a,"x,y",b\n` → field 0 = bytes 0..1, field 1 (quoted) = inside the quotes 3..6,
+        // field 2 = bytes 8..9.
+        let records = scan_records("a,\"x,y\",b\n", b',');
+        assert_eq!(records.len(), 1);
+        let row = &records[0];
+        assert_eq!(row[0], Span::new(0, 1));
+        assert_eq!(row[1], Span::new(3, 6));
+        assert_eq!(row[2], Span::new(8, 9));
+    }
+
+    #[test]
+    fn trailing_delimiter_yields_empty_last_field() {
+        // A trailing delimiter produces an empty final field, with or without a final newline.
+        assert_eq!(cells("a,b,\n", b','), vec![vec!["a", "b", ""]]);
+        assert_eq!(cells("a,b,", b','), vec![vec!["a", "b", ""]]);
+    }
+
+    #[test]
+    fn lone_cr_separates_records() {
+        // A bare CR (no following LF) ends a record, like classic Mac line endings.
+        assert_eq!(
+            cells("a,b\rc,d\r", b','),
+            vec![vec!["a", "b"], vec!["c", "d"]]
+        );
     }
 }

--- a/crates/tzlint_core/src/processor/scanner.rs
+++ b/crates/tzlint_core/src/processor/scanner.rs
@@ -11,7 +11,11 @@ use tzlint_ast::Span;
 pub(crate) fn scan_records(source: &str, delimiter: u8) -> Vec<Vec<Span>> {
     let b = source.as_bytes();
     let n = b.len();
-    let mut i = if b.starts_with(&[0xEF, 0xBB, 0xBF]) { 3 } else { 0 };
+    let mut i = if b.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        3
+    } else {
+        0
+    };
 
     let mut records: Vec<Vec<Span>> = Vec::new();
     if i >= n {
@@ -28,8 +32,8 @@ pub(crate) fn scan_records(source: &str, delimiter: u8) -> Vec<Vec<Span>> {
             let mut j = start;
             loop {
                 match b.get(j) {
-                    None => break,                       // unterminated → content to EOF
-                    Some(&c) if c == b'"' => {
+                    None => break, // unterminated → content to EOF
+                    Some(&b'"') => {
                         if b.get(j + 1) == Some(&b'"') {
                             j += 2; // escaped quote, stays in content
                             continue;
@@ -69,7 +73,11 @@ pub(crate) fn scan_records(source: &str, delimiter: u8) -> Vec<Vec<Span>> {
         } else {
             // sep is CR or LF — end of record.
             records.push(core::mem::take(&mut record));
-            i = if sep == b'\r' && b.get(k + 1) == Some(&b'\n') { k + 2 } else { k + 1 };
+            i = if sep == b'\r' && b.get(k + 1) == Some(&b'\n') {
+                k + 2
+            } else {
+                k + 1
+            };
             if i >= n {
                 break; // trailing newline does not create a spurious empty record
             }
@@ -83,12 +91,16 @@ mod tests {
     use super::*;
 
     /// Helper: scan and project each cell span to the &str it covers.
-    fn cells<'a>(source: &'a str, delim: u8) -> Vec<Vec<&'a str>> {
+    fn cells(source: &str, delim: u8) -> Vec<Vec<&str>> {
         scan_records(source, delim)
             .into_iter()
             .map(|rec| {
                 rec.into_iter()
-                    .map(|s| source.get(s.start as usize..s.end as usize).unwrap_or("<bad>"))
+                    .map(|s| {
+                        source
+                            .get(s.start as usize..s.end as usize)
+                            .unwrap_or("<bad>")
+                    })
                     .collect()
             })
             .collect()
@@ -104,7 +116,10 @@ mod tests {
 
     #[test]
     fn final_line_without_newline() {
-        assert_eq!(cells("a,b\nc,d", b','), vec![vec!["a", "b"], vec!["c", "d"]]);
+        assert_eq!(
+            cells("a,b\nc,d", b','),
+            vec![vec!["a", "b"], vec!["c", "d"]]
+        );
     }
 
     #[test]
@@ -122,17 +137,26 @@ mod tests {
     #[test]
     fn escaped_quotes_remain_raw_in_span() {
         // `"He said ""hi"""` → content span is `He said ""hi""` (raw doubled quotes; v1).
-        assert_eq!(cells("\"He said \"\"hi\"\"\"\n", b','), vec![vec!["He said \"\"hi\"\""]]);
+        assert_eq!(
+            cells("\"He said \"\"hi\"\"\"\n", b','),
+            vec![vec!["He said \"\"hi\"\""]]
+        );
     }
 
     #[test]
     fn crlf_line_endings() {
-        assert_eq!(cells("a,b\r\nc,d\r\n", b','), vec![vec!["a", "b"], vec!["c", "d"]]);
+        assert_eq!(
+            cells("a,b\r\nc,d\r\n", b','),
+            vec![vec!["a", "b"], vec!["c", "d"]]
+        );
     }
 
     #[test]
     fn tab_delimiter() {
-        assert_eq!(cells("a\tb\n1\t2\n", b'\t'), vec![vec!["a", "b"], vec!["1", "2"]]);
+        assert_eq!(
+            cells("a\tb\n1\t2\n", b'\t'),
+            vec![vec!["a", "b"], vec!["1", "2"]]
+        );
     }
 
     #[test]
@@ -142,7 +166,10 @@ mod tests {
 
     #[test]
     fn ragged_rows_keep_their_field_counts() {
-        assert_eq!(cells("a,b,c\nx,y\n", b','), vec![vec!["a", "b", "c"], vec!["x", "y"]]);
+        assert_eq!(
+            cells("a,b,c\nx,y\n", b','),
+            vec![vec!["a", "b", "c"], vec!["x", "y"]]
+        );
     }
 
     #[test]

--- a/crates/tzlint_core/tests/config_schema.rs
+++ b/crates/tzlint_core/tests/config_schema.rs
@@ -197,6 +197,68 @@ const CORPUS: &[(&str, &str, Mode)] = &[
         r#"{"rules":{"r":"maybe"}}"#,
         Mode::Reject,
     ),
+    // `formats`: per-format column linting. Only rows where the schema and loader AGREE are in the
+    // corpus — several loader-only validations (unknown format id beyond csv/tsv, name key under
+    // `header:false`, a non-ASCII delimiter) are resolve-time checks that JSON Schema cannot
+    // express, so they are deliberately omitted here (and covered by unit tests in `src/config/`).
+    ("formats empty", r#"{"formats":{}}"#, Mode::Accept),
+    (
+        "format empty object (all defaults)",
+        r#"{"formats":{"csv":{}}}"#,
+        Mode::Accept,
+    ),
+    (
+        "formats valid columns by name with overlay rules",
+        r#"{"formats":{"csv":{"header":true,"columns":{"body":{"rules":{"no-todo":true}}}}}}"#,
+        Mode::Accept,
+    ),
+    (
+        "format parse-mode plain",
+        r#"{"formats":{"csv":{"header":true,"columns":{"body":{"parse-mode":"plain"}}}}}"#,
+        Mode::Accept,
+    ),
+    (
+        "format parse-mode markdown",
+        r#"{"formats":{"csv":{"header":true,"columns":{"2":{"parse-mode":"markdown"}}}}}"#,
+        Mode::Accept,
+    ),
+    (
+        "format single-char delimiter override",
+        r#"{"formats":{"csv":{"header":true,"delimiter":";","columns":{"1":{}}}}}"#,
+        Mode::Accept,
+    ),
+    // Schema-expressible rejections that the loader also rejects (strict parity).
+    (
+        "format parse-mode bogus",
+        r#"{"formats":{"csv":{"header":true,"columns":{"body":{"parse-mode":"bogus"}}}}}"#,
+        Mode::Reject,
+    ),
+    (
+        "format unknown key",
+        r#"{"formats":{"csv":{"header":true,"bogus":1,"columns":{}}}}"#,
+        Mode::Reject,
+    ),
+    (
+        "column unknown key",
+        r#"{"formats":{"csv":{"header":true,"columns":{"body":{"bogus":1}}}}}"#,
+        Mode::Reject,
+    ),
+    (
+        "format header wrong type",
+        r#"{"formats":{"csv":{"header":"yes","columns":{}}}}"#,
+        Mode::Reject,
+    ),
+    (
+        "format multi-char delimiter",
+        r#"{"formats":{"csv":{"header":true,"delimiter":";;","columns":{"1":{}}}}}"#,
+        Mode::Reject,
+    ),
+    ("formats non-object", r#"{"formats":5}"#, Mode::Reject),
+    (
+        "format column rule bad severity (reuses rules sub-schema)",
+        r#"{"formats":{"csv":{"header":true,"columns":{"body":{"rules":{"r":{"severity":"fatal"}}}}}}}"#,
+        Mode::Reject,
+    ),
 ];
 
 fn validator() -> Validator {

--- a/crates/tzlint_core/tests/config_schema.rs
+++ b/crates/tzlint_core/tests/config_schema.rs
@@ -198,10 +198,17 @@ const CORPUS: &[(&str, &str, Mode)] = &[
         Mode::Reject,
     ),
     // `formats`: per-format column linting. Only rows where the schema and loader AGREE are in the
-    // corpus — several loader-only validations (unknown format id beyond csv/tsv, name key under
-    // `header:false`, a non-ASCII delimiter) are resolve-time checks that JSON Schema cannot
-    // express, so they are deliberately omitted here (and covered by unit tests in `src/config/`).
+    // corpus — a couple of loader-only validations (a name key under `header:false`, a non-ASCII
+    // delimiter) are resolve-time checks that JSON Schema cannot express, so they are deliberately
+    // omitted here (and covered by unit tests in `src/config/`). An *unknown* format id, however,
+    // IS schema-expressible (`formats` lists only `csv`/`tsv` with `additionalProperties:false`),
+    // so it is strict parity — see "format unknown id" below.
     ("formats empty", r#"{"formats":{}}"#, Mode::Accept),
+    (
+        "format unknown id",
+        r#"{"formats":{"cvs":{}}}"#,
+        Mode::Reject,
+    ),
     (
         "format empty object (all defaults)",
         r#"{"formats":{"csv":{}}}"#,

--- a/crates/tzlint_lsp/src/lib.rs
+++ b/crates/tzlint_lsp/src/lib.rs
@@ -1,8 +1,9 @@
 //! `tzlint_lsp` — the LSP server.
 //!
-//! Goes through the same `tzlint_core::Engine::lint` as the CLI (parity asserted in
-//! tests). v1 ships a scaffold only; the full server is milestone M5, where a stated
-//! editing-latency strategy (full reparse + debounce; block-level incremental cache,
-//! correctness-gated) and `tree-sitter-md` as an incremental escape hatch are decided.
+//! v1 ships a scaffold only; the full server is milestone M5. When M5 is implemented it
+//! will route through `tzlint_core::lint_document` — the same single dispatch entry used
+//! by the CLI, cache, and fix — achieving CLI/LSP parity. The editing-latency strategy
+//! (full reparse + debounce; block-level incremental cache, correctness-gated) and
+//! `tree-sitter-md` as an incremental escape hatch are decided at M5.
 //!
 //! TODO(M5): implement the server.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -16,10 +16,11 @@
   YAML (`.yaml`/`.yml`). YAML **anchors/aliases are rejected** — they are unnecessary for
   configuration and enable alias-expansion ("billion laughs") memory-exhaustion that the
   config size cap cannot bound.
-- **Validation:** serde `deny_unknown_fields` — an unknown top-level key is an error. Keys in
-  the dynamic `rules` map that are not built-in rule ids are not an error but are **warned** by
-  the CLI (`note: config references unknown rule '…'`), so a typo is surfaced rather than
-  silently ignored.
+- **Validation:** serde `deny_unknown_fields` — an unknown top-level key is an error. Accepted
+  top-level keys are: `language`, `message-language`, `rules`, `extends`, and `formats` (see
+  below). Keys in the dynamic `rules` map that are not built-in rule ids are not an error but
+  are **warned** by the CLI (`note: config references unknown rule '…'`), so a typo is surfaced
+  rather than silently ignored.
 - **Activation model (opt-out):** every built-in rule is **on by default**. A bare
   `tzlint lint` runs the full built-in set; a `rules` entry set to `false` disables that rule.
   So configuration *narrows* the default set rather than opting rules in.
@@ -56,7 +57,73 @@
   dictionary fingerprint (a placeholder until M2), so any change that could alter diagnostics
   invalidates the entry. A cache read/write failure only warns; results are unaffected.
 
+## `formats` — per-format options
+
+The `formats` key is a map from format id (`csv`, `tsv`, …) to format-specific settings. It
+is an accepted top-level key (alongside `language`, `message-language`, `rules`, and
+`extends`). See [`docs/processors.md`](processors.md) for the user-facing guide.
+
+### `formats.<csv|tsv>`
+
+- **`header`** (bool, required): when `true` the first record is read as a header row (not
+  linted; enables column lookup by name). When `false` only integer-key column selectors
+  are valid — a name key is a config error.
+- **`delimiter`** (optional): a single ASCII character that overrides the default delimiter
+  (`,` for CSV, `\t` for TSV). Non-ASCII characters are rejected with a config error; omit
+  the key to use the format default.
+- **`columns`** (map): the columns to lint. **Only listed columns are linted** (opt-in
+  semantics — unlisted columns such as IDs or timestamps are never linted).
+
+  **Key:** a **header name** (string; requires `header: true`) or a **1-based column
+  number** (bare integer string, e.g. `"2"`). With `header: true`, name match takes
+  priority; duplicate header names cause a warning and target all matching columns.
+
+  **Value** (all fields optional):
+  - `parse-mode`: `markdown` (default) | `plain`. `markdown` parses the cell as CommonMark
+    and applies Markdown-aware rules. `plain` treats the cell as a single paragraph with no
+    Markdown constructs (useful when `*`/`_`/`#` are literal).
+  - `rules`: a rule overlay in the same shape as the top-level `rules` map
+    (`false | true | { severity?, options? }`). **Layering**: the effective rule set is
+    `base ⊕ column.rules` — the column overlay wins. To drop a base rule for one column,
+    set it `false` in that column's `rules`.
+
+  A configured column name absent from the actual file header produces a per-file note (not
+  a hard error, because it is data-dependent).
+
+**Example** — header CSV with two prose columns and different rules:
+
+```yaml
+language: ja
+rules:
+  no-hankaku-kana: true      # base: applies to every linted column unless overridden
+formats:
+  csv:
+    header: true             # row 1 is a header → not linted; enables name lookup
+    columns:                 # only these columns are linted (opt-in)
+      title:
+        parse-mode: plain
+        rules:
+          max-ten: { options: { max: 1 } }
+      body:
+        rules:
+          no-todo: true
+          max-ten: { options: { max: 3 } }
+```
+
+**Example** — headerless TSV by 1-based column number:
+
+```yaml
+formats:
+  tsv:
+    header: false
+    columns:
+      "2": { rules: { no-todo: true } }
+      "5": { parse-mode: plain, rules: { max-ten: { options: { max: 0 } } } }
+```
+
 ## Planned
 
 - Per-file **`overrides`** (glob-scoped `language`/rule settings), evolving the schema to a
   `v2` `$id`.
+- General format-neutral `overrides` key (glob + region selector); only
+  `formats.<csv|tsv>.columns` is wired today.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -65,9 +65,9 @@ is an accepted top-level key (alongside `language`, `message-language`, `rules`,
 
 ### `formats.<csv|tsv>`
 
-- **`header`** (bool, required): when `true` the first record is read as a header row (not
-  linted; enables column lookup by name). When `false` only integer-key column selectors
-  are valid — a name key is a config error.
+- **`header`** (bool, optional; defaults to `false`): when `true` the first record is read
+  as a header row (not linted; enables column lookup by name). When `false` (the default)
+  only integer-key column selectors are valid — a name key is a config error.
 - **`delimiter`** (optional): a single ASCII character that overrides the default delimiter
   (`,` for CSV, `\t` for TSV). Non-ASCII characters are rejected with a config error; omit
   the key to use the format default.
@@ -75,8 +75,15 @@ is an accepted top-level key (alongside `language`, `message-language`, `rules`,
   semantics — unlisted columns such as IDs or timestamps are never linted).
 
   **Key:** a **header name** (string; requires `header: true`) or a **1-based column
-  number** (bare integer string, e.g. `"2"`). With `header: true`, name match takes
-  priority; duplicate header names cause a warning and target all matching columns.
+  number** (bare integer string, e.g. `"2"`). When a region matches both a name-keyed and a
+  number-keyed target, the **name** target's rules win (resolution is name-then-index,
+  independent of key order).
+
+  A **bare-integer key is always read as a column number**, even under `header: true` — so a
+  header literally named `"2024"` cannot currently be selected by name (it would resolve to
+  column 2024 and, if out of range, be skipped). Use a non-numeric header name, or select that
+  column by its position. An explicit name/number disambiguation syntax is a possible future
+  addition.
 
   **Value** (all fields optional):
   - `parse-mode`: `markdown` (default) | `plain`. `markdown` parses the cell as CommonMark

--- a/docs/design/input-format-processors.md
+++ b/docs/design/input-format-processors.md
@@ -1,0 +1,427 @@
+# Pluggable Input-Format Processors
+
+> Design spec. Status: approved design, pending implementation plan.
+> Scope: introduce a processor layer so TsuzuLint can lint natural-language text in
+> formats beyond Markdown — starting with CSV/TSV (lint specific columns, with
+> per-column rules), and built so new formats (e.g. Re:VIEW) are easy to add in-tree.
+
+## 1. Summary
+
+Today TsuzuLint parses every input as Markdown (`tzlint_core::parse`) and runs the
+single-traversal engine over the resulting frozen AST. This design inserts a **processor
+layer** in front of that step: a file's extension selects a `Processor`, the processor
+locates the lintable natural-language regions of the source (or returns a full AST), and
+the core parses each region, rebases its spans onto the original file, and lints each
+region with the rule set configured for it.
+
+The first concrete formats are **CSV and TSV**, where the user names the columns to lint
+and may assign different rules per column. The processor abstraction is format-neutral so
+adding a new format (Re:VIEW, AsciiDoc, plain text, …) is a small, well-bounded in-tree
+contribution.
+
+## 2. Goals and non-goals
+
+**Goals**
+
+- Lint specific **columns** of CSV/TSV, selectable by **header name** and by **1-based
+  column number**.
+- Apply **different rules per column** (a column-scoped overlay over the base rules).
+- A format-neutral `Processor` abstraction; "column" is *not* a core concept.
+- Make adding a new format a **low-friction in-tree change** (implement a trait, register
+  one line, add tests/docs). This is the top-priority requirement.
+- Preserve the frozen `AstCoreV1` ABI (no `Node` field changes), the single-traversal
+  engine, `Host`-mediated I/O, and the single dispatch path (CLI/LSP parity).
+
+**Non-goals (this milestone)**
+
+- Runtime/loadable processors (WASM). Extension is by PR into the binary; the trait is
+  designed so a future WASM processor ABI (M3) can layer on, but no WASM work is in scope.
+- A config DSL for describing extraction declaratively.
+- Structure-aware rules across non-Markdown formats beyond what the optional full-AST path
+  already enables (see §5).
+
+## 3. Background (current state)
+
+- `tzlint_core::parse(source) -> Result<Ast, ParseError>` runs markdown-rs and flattens
+  mdast into the frozen index-AST. `Ast.text` is the (BOM-stripped) source; every `Span`
+  is an absolute byte offset into it.
+- `Engine::lint(&ArchivedAst, &[&dyn Rule]) -> Vec<Diagnostic>` walks the tree once and
+  invokes each rule on the node kinds it registered for; diagnostics are sorted into a
+  stable total order.
+- The CLI pipeline (`tzlint_cli::app`) is: `expand` (globs/dirs/stdin, **Markdown
+  extensions only**) → read via `Host` → `lint_cached`/`lint_direct` (`parse` → archive →
+  `access` → `Engine::lint`) → render. `fix` mirrors this. Config is resolved once and
+  `resolve_rules(&config)` builds a flat `Vec<Box<dyn Rule>>` via `tzlint_rules::build_rule`.
+- Config (`RawConfig`): kebab-case, `deny_unknown_fields`; keys `language`,
+  `message-language`, `rules` (`false | true | { severity?, options? }`), `extends`
+  (preset layering, precedence low→high `extends[0] < … < user`).
+
+## 4. Architecture overview
+
+```
+file (path, bytes)
+      │  ext → Registry selects a Processor (Markdown is the default/fallback)
+      ▼
+┌──────────────── Processor (format-specific; the extension point) ───────────────┐
+│  parse(source, cfg) -> Parsed                                                    │
+│    Parsed::Regions(Vec<Region>)  ← easy path: prose ranges + tag + parse_mode    │
+│    Parsed::Ast(Ast)              ← full path: a complete AST (structure-aware)   │
+└──────────────────────────────────────────────────────────────────────────────────┘
+      │
+      ├─ Regions: core parses each slice with its parse_mode, offsets spans by slice.start
+      │           (Ast.text = whole original source; spans stay absolute)
+      └─ Ast:     used as-is (Markdown takes this path; region = Whole)
+      ▼
+per-region rule resolution: base rules ⊕ overrides matching the region's tag
+      ▼
+Engine::lint(region_ast, rules_for_region)   ── once per region (independent)
+      ▼
+merge all diagnostics, sort by the existing stable order
+      ▼
+position mapper → (line, column) → existing renderers (text / JSON)
+```
+
+The frozen AST and the single-traversal engine are **unchanged**. Per-region linting is
+just the existing engine applied independently to each region.
+
+### Crate layout
+
+- `tzlint_core::processor` (new): the `Processor` trait, `Parsed`, `Region`, `RegionTag`,
+  `ParseMode`, and the built-in `Registry`.
+- `tzlint_core::processor::markdown`: the current `parse.rs` logic, re-expressed as
+  `MarkdownProcessor` returning `Parsed::Ast`. The existing `parse()` stays as a thin
+  wrapper for compatibility.
+- `tzlint_core::processor::delimited`: the CSV/TSV processor (parameterized by delimiter).
+- `tzlint_core`: a new single entry point `lint_document(...)` that selects the processor,
+  resolves per-region rules, lints each region, and merges diagnostics. CLI/LSP/cache/fix
+  all go through it (dispatch parity).
+
+## 5. The Processor abstraction
+
+A single-method trait. The return type unifies the easy path (regions) and the optional
+full path (AST). Types below are illustrative, not final signatures.
+
+```rust
+/// A format-specific parser. Adding a new format = implement this + register it.
+pub trait Processor {
+    /// Handled extensions, dot-less and lowercase, e.g. ["csv"], ["md", "markdown"].
+    fn extensions(&self) -> &[&str];
+
+    /// Parse `source`. Return Regions for the common (prose-extraction) path, or a full
+    /// Ast when the format's own structure must be visible to rules.
+    fn parse(&self, source: &str, cfg: &ProcessorConfig) -> Result<Parsed, ParseError>;
+}
+
+/// Parse result. Both paths' spans are ABSOLUTE byte offsets into the original `source`.
+pub enum Parsed {
+    /// Easy path: lintable regions; the core parses each slice and rebases spans.
+    Regions(Vec<Region>),
+    /// Full path: a complete AST (text = whole source, spans absolute). Escape hatch for
+    /// structure-aware linting.
+    Ast(Ast),
+}
+
+/// One lintable region: the unit that shares a rule set and a parse mode.
+pub struct Region {
+    /// Source slices making up this region (e.g. all cells of one column). Each slice is
+    /// a CONTIGUOUS substring of `source` and is parsed independently as a mini-document.
+    pub slices: Vec<Span>,
+    /// What this region is, so config can target rules at it.
+    pub tag: RegionTag,
+    /// How to interpret each slice before linting.
+    pub parse_mode: ParseMode,
+}
+
+/// Format-neutral region identity. "column" is just one `kind`, defined by the delimited
+/// processor — it is NOT a core concept.
+pub struct RegionTag {
+    /// Region kind, a processor-defined &'static str. CSV/TSV use Some("column"); a
+    /// future Re:VIEW processor might use Some("footnote")/Some("caption"); Markdown and
+    /// plain text use None (single document → base rules only).
+    pub kind: Option<&'static str>,
+    /// 0-based ordinal within the kind (e.g. column index). None when not applicable.
+    pub index: Option<u32>,
+    /// A name (e.g. a column header). None when not applicable.
+    pub name: Option<String>,
+}
+
+/// How a region's slices are parsed before linting.
+pub enum ParseMode {
+    /// Parse as Markdown (CommonMark + GFM), reusing all Markdown rules. Default for cells.
+    Markdown,
+    /// Treat each slice as one plain paragraph (no Markdown constructs). For prose in
+    /// formats where `*`/`_`/`#` are literal (LaTeX, HTML text, …).
+    PlainText,
+}
+```
+
+`&'static str` for `kind` is sufficient because extension is compile-time (in-tree PRs),
+not runtime; this matches the "extend by PR" model and avoids allocation.
+
+### Coverage vs textlint
+
+textlint plugins return a full TxtAST per format, so structure-aware rules work across
+formats. The **easy path here covers the majority case** — natural-language linting of
+prose text, which is what most textlint rules (Str-node rules) do — for *any* format. The
+gap is rules that inspect the *source format's own structure*; those formats opt into the
+**full path** (`Parsed::Ast`) on the same trait. We do not force every format to build an
+AST upfront (YAGNI); we keep the door open.
+
+## 6. CSV/TSV processor
+
+### Parsing: a purpose-built scanner that yields content spans
+
+The `csv` crate unescapes quoted fields and does not expose each field's byte range in the
+*original* source, which we need for diagnostics. So we use a **small RFC 4180-style
+scanner** that, for each cell, computes the **contiguous byte span of its content** in the
+original `source`:
+
+- Unquoted cell → the cell's bytes as-is.
+- Quoted cell → the bytes **inside** the outer quotes (quotes are not linted). Embedded
+  newlines and doubled quotes (`""`) remain in the contiguous slice as raw bytes.
+- Records split on unquoted newlines (LF and CRLF); fields split on unquoted delimiters.
+
+Because each `Region.slice` is a contiguous substring of `source`, the core can parse the
+slice and add `slice.start` to every resulting span to get absolute offsets (§7).
+
+### Known v1 simplifications (accepted, documented)
+
+- **Escaped quotes**: a quoted cell containing `""` is linted with the raw `""` present
+  (not the logical single `"`). Minor for prose linting. A future content-normalization +
+  span back-map can fix this if needed (not in scope).
+- **TSV quoting**: TSV is treated as tab-delimited CSV with the same quoting rules (matches
+  real-world "TSV" files), not the strict IANA TSV escaping. A strict mode is future work.
+
+### Column resolution (config → extraction set)
+
+- `header: true`: the first record is read as header names. `columns` string keys resolve
+  by header-name match; bare-integer keys resolve as 1-based positions (→ 0-based index).
+  The header row itself is not linted.
+- `header: false`: only integer keys are valid; a name key is a config error (§11).
+- A configured column name absent from the actual header → a per-file note (§11), not a
+  config error (it is data-dependent).
+
+### Edge cases
+
+- `Ast.text` = the whole original `source` (BOM preserved); the scanner skips a leading
+  BOM. Offsets match the file the user sees.
+- Ragged rows (missing target cell) → that slice is skipped. Extra fields are linted only
+  when targeted by index.
+- Empty / whitespace-only cells → not linted (nothing to parse).
+
+## 7. Span remapping and position correctness
+
+The key invariant that removes the need for a separate offset table: **`Ast.text` is the
+whole original source, and every node span is an absolute offset into it.**
+
+```
+slice  = &source[start..end]                  // a cell's contiguous content
+mini   = parse_mode.parse(slice)              // Markdown (existing parser) or PlainText
+for n in mini.nodes: n.span += start          // shift every span by the slice start
+→ collect these nodes into an Ast whose text = the whole original source
+```
+
+- Diagnostics' spans are therefore already absolute file offsets; `position.rs`'s
+  `LineIndex`, built over the whole source, yields correct `(line, column)`.
+- The Markdown full-AST path is byte-for-byte the current behavior (no shift; region =
+  Whole).
+- Region tags live in **side metadata** (outside the AST, keyed by region/node range),
+  used only for rule selection — so there is **no `AstCoreV1` / ABI change**.
+
+### Region granularity
+
+Decision (locked): **lint each region independently — and within a region, each slice
+(cell) is an independent mini-document.** A rule's `finish` (cross-node state) does not
+carry across cells. This matches the "each cell is a small document" intuition and is the
+natural fit since per-column rule sets already require splitting linting by region. A
+future "one AST per column" optimization is possible but would change document-level rule
+scope, so it is gated separately.
+
+## 8. Region linting and per-region rule resolution
+
+### Single dispatch entry
+
+```
+lint_document(ext, source, config, registry, rule_factory) -> Vec<Diagnostic>
+  1. processor = registry.for_ext(ext)            // Markdown is the default/fallback
+  2. parsed    = processor.parse(source, cfg_for(format))
+  3. regions   = match parsed { Ast(a) => [(Whole, a)], Regions(rs) => build_region_asts(rs, source) }
+  4. for each region: lint with the rule set resolved for its tag (Engine::lint)
+  5. merge diagnostics; sort by the existing stable key
+```
+
+This is the **one dispatch function**; CLI, LSP, cache, and fix all call it
+(`tzlint-dispatch-parity`).
+
+### Resolving rules per region (a factory keeps core rule-agnostic)
+
+`tzlint_core` must not depend on `tzlint_rules` (that would be a dependency cycle). So the
+driver takes a **rule factory**:
+
+```rust
+rule_factory: &dyn Fn(&EffectiveRuleSettings) -> Vec<Box<dyn Rule>>
+```
+
+- Precompute the **distinct** effective settings once: the base (`config.rules`) and, per
+  targeted column, `base ⊕ column.rules`. Build each rule set once via the factory and map
+  `RegionTag → prebuilt rule set`. Every cell of a column reuses its column's set (no
+  per-row rebuild).
+- The CLI passes a closure wrapping the existing `build_rule`/`resolve_rules`. Core stays
+  rule-agnostic; per-column rules are supported.
+
+### Layering and opt-in semantics
+
+- **Opt-in**: only columns listed in `columns` are linted. Unlisted columns (IDs, dates, …)
+  are never linted — directly expressing "lint specific columns".
+- **Layering**: a column's effective rules are `base ⊕ column.rules` (column wins),
+  mirroring the existing preset/`extends` precedence. To drop a base rule for a column,
+  set it `false` in that column.
+
+## 9. Configuration model
+
+New top-level keys (kebab-case, `deny_unknown_fields` extended to the new shapes):
+
+- `formats`: a map keyed by format id (`csv`, `tsv`, …). Each value carries
+  format-specific options. For delimited formats: `header` (bool), `delimiter` (optional
+  override; csv=`,`, tsv=`\t`), and `columns`.
+- `columns`: a map whose key is a header name (string) or a 1-based column number (bare
+  integer string). Each value: optional `parse-mode` (`markdown` default | `plain`) and a
+  `rules` overlay (same shape as top-level `rules`).
+- `overrides` (general, format-neutral): a list of `{ files?: glob[], region: { kind?,
+  index?, name? }, rules }`. `formats.<fmt>.columns` desugars to entries of this form; the
+  general form is the extension point for other formats.
+
+### Examples
+
+Header CSV, two prose columns with different rules:
+
+```yaml
+language: ja
+rules:
+  no-hankaku-kana: true      # base: applies to every linted region unless overridden
+formats:
+  csv:
+    header: true             # row 1 is a header → not linted
+    columns:                 # only these columns are linted (opt-in)
+      title:
+        parse-mode: plain
+        rules:
+          max-ten: { options: { max: 1 } }
+      body:
+        rules:
+          no-todo: true
+          max-ten: { options: { max: 3 } }
+```
+
+Headerless TSV, by 1-based column number:
+
+```yaml
+formats:
+  tsv:
+    header: false
+    columns:
+      "2": { rules: { no-todo: true } }
+      "5": { parse-mode: plain, rules: { max-ten: { options: { max: 0 } } } }
+```
+
+General override (the desugared / cross-format form):
+
+```yaml
+overrides:
+  - files: ["**/*.csv"]
+    region: { kind: column, name: body }
+    rules: { max-ten: false }
+```
+
+### Key disambiguation
+
+String key → header name; bare-integer key → 1-based position. With `header: true`, name
+match takes priority. Duplicate header names: warn, and target all columns with that name.
+
+## 10. CLI / discovery / cache / fix integration
+
+- **Discovery (`expand.rs`)**: replace `is_markdown_extension` with a registry-driven
+  `is_supported_extension`. **Safety default**: directory/glob walks pick up a non-Markdown
+  extension only when the config has that format's section (`formats.csv`/`formats.tsv`);
+  Markdown is always discovered. **Explicitly named files always lint.** This avoids
+  accidentally linting data CSVs.
+- **stdin**: no extension → defaults to Markdown. An optional `--stdin-filename` (or
+  `--format`) flag selects a processor for stdin input (optional in v1).
+- **Cache (`cache.rs`)**: the cache key must incorporate the processor id and the
+  parse/rule-affecting config (columns, header, delimiter, parse-mode, and the effective
+  rule config), so changing column targeting or per-column rules invalidates correctly.
+- **fix (`fix.rs`)**: goes through the same driver. CSV fixes land only inside disjoint
+  cell spans (never delimiters/structure), so fixes across regions compose without
+  overlap; iterate to a fixpoint as today.
+- **dispatch parity**: a parity test asserts the same content through `lint_document`
+  yields identical diagnostics regardless of caller (file vs stdin `--format csv`).
+
+## 11. Error handling
+
+Library crates forbid `unwrap`/`expect`/`panic!`; everything is `Result` or a diagnostic.
+
+- **Parse errors**: a structural CSV error (e.g. an unterminated quote) → `ParseError`,
+  handled like a Markdown `ParseError` (one diagnostic for the file, nothing else linted).
+  Ragged rows / extra fields / empty cells are not errors (§6). The scanner must never
+  panic on arbitrary bytes and must respect `MAX_FILE` / `MAX_SOURCE_LEN`.
+- **Static config errors → `ConfigError`**: an unknown `formats` key (no registered
+  processor); a name key under `columns` with `header: false`; an invalid `parse-mode`.
+- **Runtime, data-dependent → stderr notes** (like the existing unknown-rule note): a
+  configured column name absent from the file header (`note: column 'body' not found in
+  header of data.csv`); a `.csv` argument with no `formats.csv` config (`note: no columns
+  configured for 'csv'; nothing to lint`); unknown rule ids inside a column's `rules`.
+
+## 12. Testing strategy (TDD; `just check` before pushing)
+
+- **Scanner unit tests** (table-driven): quoting/escapes, embedded newline and delimiter,
+  CRLF, BOM, ragged rows; assert each field's absolute span.
+- **Rebasing unit tests**: slice parse + offset → diagnostics land at correct absolute
+  offsets and `line:column`.
+- **Config unit tests**: `formats`/`columns` parsing, `base ⊕ column` layering, name vs
+  index resolution, validation errors.
+- **Rule-resolution unit tests**: distinct rule sets; opt-in (unlisted columns not linted);
+  parse-mode effect.
+- **Integration tests** (`app.rs` `MockHost`): a per-column-rules CSV produces the right
+  diagnostics with correct path/line/column; JSON output; cache invalidation on column
+  config change; fix lands only inside cells; discovery opt-in (csv not auto-walked without
+  config).
+- **Parity test**: `lint_document` single path; file vs stdin `--format csv` match.
+
+## 13. Extensibility deliverable (the top-priority requirement)
+
+Adding a format must be a small, well-bounded change. Deliverables:
+
+1. A skill `.agents/skills/tzlint-processors/`: the step-by-step recipe — implement
+   `Processor` (with a "Regions vs Ast" decision guide), register one line in the built-in
+   registry, define a `ProcessorConfig` slice if needed, add tests (scanner unit + a
+   fixture integration test), add a `docs/` page.
+2. **Wiring confined to one place**: built-in registration is a single registry list plus
+   the new module — the only spot a contributor must touch besides their module.
+3. `docs/design/input-format-processors.md` (this doc) as the contract reference: trait
+   contract, span/offset rules, `parse_mode`, region tags, the Regions-vs-Ast guide, and
+   the textlint-plugin correspondence.
+
+## 14. ABI / frozen-AST impact
+
+None. No `Node` field is added; region tags live outside the AST. The Markdown path is
+byte-for-byte unchanged. The `golden_archived_layout_is_frozen` test is unaffected.
+
+## 15. Decisions locked
+
+1. **Approach A** (processor returns prose regions; core parses & lints per region), with
+   an optional full-AST path on the same trait.
+2. **`RegionTag` is format-neutral** (`kind`/`index`/`name`); "column" is the delimited
+   processor's `kind`, not a core concept.
+3. **Column targeting** by header name and by **1-based** column number.
+4. **Per-region linting**, and **each cell is an independent mini-document** (rule `finish`
+   does not cross cells).
+5. **`parse_mode` default = Markdown** per region, overridable to `PlainText`.
+6. **Opt-in columns** (only listed columns are linted) and **`base ⊕ column` layering**.
+
+## 16. Open questions / future work
+
+- Escaped-quote content fidelity (`""` vs `"`) via content normalization + span back-map.
+- Strict IANA TSV escaping mode.
+- "One AST per column" performance optimization (gated on document-level rule scope).
+- Runtime/WASM processors aligned with the M3 plugin ABI (extend the same trait boundary).
+- `--stdin-filename` / `--format` ergonomics and `columns: "*"` (lint-all-except) shorthand.

--- a/docs/design/input-format-processors.md
+++ b/docs/design/input-format-processors.md
@@ -93,8 +93,8 @@ just the existing engine applied independently to each region.
   wrapper for compatibility.
 - `tzlint_core::processor::delimited`: the CSV/TSV processor (parameterized by delimiter).
 - `tzlint_core`: a new single entry point `lint_document(...)` that selects the processor,
-  resolves per-region rules, lints each region, and merges diagnostics. CLI/LSP/cache/fix
-  all go through it (dispatch parity).
+  resolves per-region rules, lints each region, and merges diagnostics. CLI, cache, and fix
+  all go through it today. LSP will route through it at M5 (CLI/LSP parity is future).
 
 ## 5. The Processor abstraction
 
@@ -242,32 +242,38 @@ scope, so it is gated separately.
 ### Single dispatch entry
 
 ```
-lint_document(ext, source, config, registry, rule_factory) -> Vec<Diagnostic>
+lint_document(ext, source, registry, processor_cfg, rules: &RegionRules) -> Result<Vec<Diagnostic>, ParseError>
   1. processor = registry.for_ext(ext)            // Markdown is the default/fallback
-  2. parsed    = processor.parse(source, cfg_for(format))
-  3. regions   = match parsed { Ast(a) => [(Whole, a)], Regions(rs) => build_region_asts(rs, source) }
-  4. for each region: lint with the rule set resolved for its tag (Engine::lint)
+  2. parsed    = processor.parse(source, processor_cfg)
+  3. regions   = match parsed { Ast(a) => lint whole with base rules, Regions(rs) => per-region }
+  4. for each region: lint with the rule set resolved for its tag (rules.for_tag(&tag))
   5. merge diagnostics; sort by the existing stable key
 ```
 
-This is the **one dispatch function**; CLI, LSP, cache, and fix all call it
-(`tzlint-dispatch-parity`).
+This is the **one dispatch function**; CLI, cache, and fix call it today. LSP will call it
+at M5, achieving CLI/LSP parity (not yet asserted in tests — the LSP crate is an 8-line
+scaffold).
 
-### Resolving rules per region (a factory keeps core rule-agnostic)
+### Resolving rules per region (prebuilt `RegionRules` keeps core rule-agnostic)
 
 `tzlint_core` must not depend on `tzlint_rules` (that would be a dependency cycle). So the
-driver takes a **rule factory**:
+CLI builds a **prebuilt `RegionRules`** and passes it into `lint_document`:
 
 ```rust
-rule_factory: &dyn Fn(&EffectiveRuleSettings) -> Vec<Box<dyn Rule>>
+// CLI-side (tzlint_cli::rules):
+let rules: RegionRules = region_rules_for(&config, ext);
+// ↑ builds base_only(resolve_rules(&config)), then push_column for each configured column.
+
+// Core entry point:
+lint_document(ext, source, registry, processor_cfg, &rules)
 ```
 
-- Precompute the **distinct** effective settings once: the base (`config.rules`) and, per
-  targeted column, `base ⊕ column.rules`. Build each rule set once via the factory and map
-  `RegionTag → prebuilt rule set`. Every cell of a column reuses its column's set (no
-  per-row rebuild).
-- The CLI passes a closure wrapping the existing `build_rule`/`resolve_rules`. Core stays
-  rule-agnostic; per-column rules are supported.
+- `region_rules_for(&Config, Option<&str>) -> RegionRules` (in `tzlint_cli::rules`) builds
+  the base rule set from `config.rules`, then for each configured column computes
+  `base ⊕ column.rules` and registers it via `RegionRules::push_column`. Every cell of a
+  column reuses the prebuilt set (no per-row rebuild).
+- `RegionRules::for_tag(&RegionTag)` picks the first matching column set, falling back to
+  the base. Core stays rule-agnostic; per-column rules are fully supported.
 
 ### Layering and opt-in semantics
 
@@ -288,10 +294,9 @@ New top-level keys (kebab-case, `deny_unknown_fields` extended to the new shapes
   integer string). Each value: optional `parse-mode` (`markdown` default | `plain`) and a
   `rules` overlay (same shape as top-level `rules`).
 - `overrides` (general, format-neutral): a list of `{ files?: glob[], region: { kind?,
-  index?, name? }, rules }`. `formats.<fmt>.columns` desugars to entries of this form; the
-  general form is the extension point for other formats. **(Not yet implemented — only
-  `formats.<csv|tsv>.columns` is wired; `deny_unknown_fields` rejects a top-level `overrides`
-  key today. See §16.)**
+  index?, name? }, rules }`. **Deferred / not implemented.** `formats.<csv|tsv>.columns` is
+  resolved **directly** in `RawConfig::into_config` (not via desugaring to `overrides`). A
+  top-level `overrides` key is rejected today by `deny_unknown_fields`. See §16.
 
 ### Examples
 
@@ -356,8 +361,9 @@ match takes priority. Duplicate header names: warn, and target all columns with 
 - **fix (`fix.rs`)**: goes through the same driver. CSV fixes land only inside disjoint
   cell spans (never delimiters/structure), so fixes across regions compose without
   overlap; iterate to a fixpoint as today.
-- **dispatch parity**: a parity test asserts the same content through `lint_document`
-  yields identical diagnostics regardless of caller (file vs stdin `--format csv`).
+- **dispatch parity**: CLI, cache, and fix all call `lint_document`; a parity test asserts
+  identical diagnostics for the same content via file vs stdin `--format csv`. LSP parity
+  (routing through `lint_document`) is planned for M5.
 
 ## 11. Error handling
 
@@ -426,6 +432,12 @@ byte-for-byte unchanged. The `golden_archived_layout_is_frozen` test is unaffect
 - General top-level `overrides` key (§9): deferred / not yet implemented. Only
   `formats.<csv|tsv>.columns` is wired; a top-level `overrides` key currently hard-errors via
   `deny_unknown_fields`. The format-neutral form lands when a non-column format needs it.
+- **Per-cell morphology (M2):** each CSV/TSV cell is an independent mini-document with its own
+  text spine and absolute spans, so a single whole-document morphology table would be wrong.
+  `lint_ast_into` today passes `morphology = None` to `Engine::lint`, meaning rules that
+  require morphology are skipped for every cell. Open question: segment-the-cell (build a
+  per-cell morphology table) vs skip-on-CSV (keep `None` for delimited formats permanently).
+  The integration is owned on the M2 side.
 - Escaped-quote content fidelity (`""` vs `"`) via content normalization + span back-map.
 - Strict IANA TSV escaping mode.
 - "One AST per column" performance optimization (gated on document-level rule scope).

--- a/docs/design/input-format-processors.md
+++ b/docs/design/input-format-processors.md
@@ -1,6 +1,7 @@
 # Pluggable Input-Format Processors
 
-> Design spec. Status: approved design, pending implementation plan.
+> Design spec. Status: implemented — the processor seam (`Processor`/`Registry`/`lint_document`)
+> and the CSV/TSV column processors are in `tzlint_core`; this doc is the contract reference.
 > Scope: introduce a processor layer so TsuzuLint can lint natural-language text in
 > formats beyond Markdown — starting with CSV/TSV (lint specific columns, with
 > per-column rules), and built so new formats (e.g. Re:VIEW) are easy to add in-tree.
@@ -58,7 +59,7 @@ contribution.
 
 ## 4. Architecture overview
 
-```
+```text
 file (path, bytes)
       │  ext → Registry selects a Processor (Markdown is the default/fallback)
       ▼
@@ -214,7 +215,7 @@ slice and add `slice.start` to every resulting span to get absolute offsets (§7
 The key invariant that removes the need for a separate offset table: **`Ast.text` is the
 whole original source, and every node span is an absolute offset into it.**
 
-```
+```text
 slice  = &source[start..end]                  // a cell's contiguous content
 mini   = parse_mode.parse(slice)              // Markdown (existing parser) or PlainText
 for n in mini.nodes: n.span += start          // shift every span by the slice start
@@ -241,7 +242,7 @@ scope, so it is gated separately.
 
 ### Single dispatch entry
 
-```
+```text
 lint_document(ext, source, registry, processor_cfg, rules: &RegionRules) -> Result<Vec<Diagnostic>, ParseError>
   1. processor = registry.for_ext(ext)            // Markdown is the default/fallback
   2. parsed    = processor.parse(source, processor_cfg)

--- a/docs/design/input-format-processors.md
+++ b/docs/design/input-format-processors.md
@@ -289,7 +289,9 @@ New top-level keys (kebab-case, `deny_unknown_fields` extended to the new shapes
   `rules` overlay (same shape as top-level `rules`).
 - `overrides` (general, format-neutral): a list of `{ files?: glob[], region: { kind?,
   index?, name? }, rules }`. `formats.<fmt>.columns` desugars to entries of this form; the
-  general form is the extension point for other formats.
+  general form is the extension point for other formats. **(Not yet implemented — only
+  `formats.<csv|tsv>.columns` is wired; `deny_unknown_fields` rejects a top-level `overrides`
+  key today. See §16.)**
 
 ### Examples
 
@@ -324,7 +326,8 @@ formats:
       "5": { parse-mode: plain, rules: { max-ten: { options: { max: 0 } } } }
 ```
 
-General override (the desugared / cross-format form):
+General override (the desugared / cross-format form — **not yet implemented; future work.**
+Using a top-level `overrides:` key in a real config hard-errors today via `deny_unknown_fields`):
 
 ```yaml
 overrides:
@@ -420,6 +423,9 @@ byte-for-byte unchanged. The `golden_archived_layout_is_frozen` test is unaffect
 
 ## 16. Open questions / future work
 
+- General top-level `overrides` key (§9): deferred / not yet implemented. Only
+  `formats.<csv|tsv>.columns` is wired; a top-level `overrides` key currently hard-errors via
+  `deny_unknown_fields`. The format-neutral form lands when a non-column format needs it.
 - Escaped-quote content fidelity (`""` vs `"`) via content normalization + span back-map.
 - Strict IANA TSV escaping mode.
 - "One AST per column" performance optimization (gated on document-level rule scope).

--- a/docs/processors.md
+++ b/docs/processors.md
@@ -1,0 +1,45 @@
+# Input formats
+
+TsuzuLint lints Markdown by default. It can also lint **specific columns** of CSV/TSV files,
+and the processor architecture lets new formats be added in-tree (see
+[`design/input-format-processors.md`](design/input-format-processors.md) and the
+`tzlint-processors` skill).
+
+## CSV / TSV
+
+Linting CSV/TSV is **opt-in per column**: only the columns you name are linted. Configure them
+under `formats.csv` / `formats.tsv`:
+
+```yaml
+language: ja
+rules:
+  no-hankaku-kana: true        # base rules apply to every linted column unless overridden
+formats:
+  csv:
+    header: true               # row 1 is a header (not linted); enables name lookup
+    columns:
+      title:                   # by header name
+        parse-mode: plain      # treat the cell as plain text (default: markdown)
+        rules:
+          max-ten: { options: { max: 1 } }
+      body:
+        rules:                 # layered on top of the base rules (column wins)
+          no-todo: true
+  tsv:
+    header: false
+    columns:
+      "2": { rules: { no-todo: true } }   # by 1-based column number
+```
+
+Notes:
+
+- **Opt-in:** unlisted columns (ids, dates, …) are never linted.
+- **Layering:** a column's effective rules are `base ⊕ column.rules`; set a rule to `false` in a
+  column to drop it there.
+- **Keys:** a string key is a header name (requires `header: true`); a bare integer key is a
+  1-based column number.
+- **delimiter:** defaults to `,` (csv) / tab (tsv); override with `delimiter: ";"`.
+- **Discovery:** a directory/glob walk only picks up `.csv`/`.tsv` when the format is configured;
+  an explicitly named file is always linted.
+- **v1 limits:** an escaped quote (`""`) is linted as the raw `""`; TSV is treated as
+  tab-delimited CSV.


### PR DESCRIPTION
## Summary

Adds the ability to lint natural-language text in **CSV/TSV files by specific column**, built on a new **pluggable input-format processor seam** so further formats (e.g. Re:VIEW) can be added in-tree with minimal friction.

- **Processor seam** (`tzlint_core::processor`): a format-neutral `Processor` trait returning either lintable `Region`s (prose slices + tag + parse-mode) or a full `Ast` (Markdown's path). A `Registry` selects a processor by file extension (Markdown is the default/fallback). `lint_document` is the single dispatch entry; the Markdown path stays byte-for-byte identical.
- **CSV/TSV** (`DelimitedProcessor` + a hand-written RFC 4180-style scanner): extracts the absolute byte spans of cells in configured columns. Columns are **opt-in**, selected by **header name** or **1-based number**, each with its own **parse-mode** (`markdown`/`plain`) and **per-column rule overlay** (`base ⊕ column`, column wins).
- **Config** (`formats.<csv|tsv>.columns`): resolved into `Config.formats`; folded into the document cache key (a column-config change invalidates the cache); validated at parse time (unknown format, name-key-without-header, non-ASCII delimiter → `ConfigError`).
- **CLI**: `lint` and `fix` route through the seam; directory discovery picks up `csv`/`tsv` only when the format is configured (explicitly-named files always lint); a note fires when a csv/tsv input has no columns configured.
- **Extensibility**: the `tzlint-processors` skill documents the add-a-format recipe; `docs/processors.md` documents CSV/TSV usage; the config JSON Schema and its loader-parity corpus were updated for `formats`.

No `AstCoreV1`/ABI change — region identity lives outside the frozen AST and spans stay absolute, so diagnostics map to the right line/column with no offset table.

Design spec: `docs/design/input-format-processors.md`. Implemented across 4 TDD plans under `docs/superpowers/plans/`, each reviewed for spec-compliance and code-quality (bugs found in review — doubled diagnostics when a column was targeted by both name and index, a silently-truncated non-ASCII delimiter, and a JSON-schema/loader drift — were fixed).

## Example

```yaml
formats:
  csv:
    header: true
    columns:
      title: { parse-mode: plain, rules: { max-ten: { options: { max: 1 } } } }
      body:  { rules: { no-todo: true } }
```

## Test plan

- [x] `just check` green (rustfmt + clippy `-D warnings` + 365 tests)
- [x] Scanner edge cases (quoting/escapes/CRLF/BOM/ragged rows/trailing bytes) — `scanner.rs` at 100% coverage
- [x] Per-column rules land in the right cell; unlisted columns are not linted
- [x] Cache invalidates on a column-config change
- [x] Discovery is opt-in; explicitly-named files always linted
- [x] `fix` lands inside cells only; Markdown lint/fix parity preserved
- [x] New modules at 98–100% line coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CSV/TSV を入力フォーマットとして正式サポート。列単位の選択、ヘッダ/区切り文字、セルのパースモード（Markdown/プレーン）と列別ルールを設定可能に。CLI で拡張子に応じた処理が行われます。

* **バグ修正 / 安定化**
  * キャッシュ/修正処理がフォーマット・列設定を考慮するようになり、誤った再利用や不正な修正適用を防止。

* **ドキュメント**
  * フォーマット設定リファレンスとプロセッサ設計ドキュメントを大幅追加・整備。

* **テスト**
  * CSV/TSV 周りとプロセッサ経路の包括的な追加テストを導入。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->