### PR TITLE
feat(core): thread morphology into the engine and skip rules that need it (M2d)

### DIFF
--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -220,7 +220,8 @@ fn lint_direct(source: &str, rules: &[&dyn Rule]) -> Result<Vec<Diagnostic>, Str
     let ast = parse(source).map_err(|e| e.to_string())?;
     let bytes = to_archive(&ast).map_err(|e| format!("archive failed: {e}"))?;
     let archived = access(&bytes).map_err(|e| format!("archive failed: {e}"))?;
-    Ok(Engine::lint(archived, rules))
+    // Morphology is not provisioned on the CLI path yet (lands with the provider registry, M2h).
+    Ok(Engine::lint(archived, None, rules))
 }
 
 /// `fix`: lint-and-fix each file to a fixpoint; write changed files in place (or just report

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -453,7 +453,9 @@ pub fn lint_cached(
     let ast = parse(content).map_err(CacheError::Parse)?;
     let bytes = tzlint_ast::to_archive(&ast).map_err(|e| CacheError::Archive(e.to_string()))?;
     let archived = tzlint_ast::access(&bytes).map_err(|e| CacheError::Archive(e.to_string()))?;
-    let diagnostics = Engine::lint(archived, rules);
+    // Morphology is not provisioned on the cached path yet (M2e wires the table and its
+    // fingerprint into the key); rules run without it for now.
+    let diagnostics = Engine::lint(archived, None, rules);
     cache.insert(key, diagnostics.clone());
     Ok(diagnostics)
 }

--- a/crates/tzlint_core/src/engine.rs
+++ b/crates/tzlint_core/src/engine.rs
@@ -1,6 +1,7 @@
 //! The single-traversal, multi-visitor lint engine.
 
 use tzlint_ast::ArchivedAst;
+use tzlint_ast::morphology::ArchivedMorphologyV1;
 use tzlint_pdk::{Context, Diagnostic, NodeRef, Rule};
 
 /// The lint engine. Stateless (config/rule-registry land later); the one dispatch
@@ -16,13 +17,44 @@ impl Engine {
     /// kind are invoked. Each rule keeps its own [`Context`] across the walk; every rule's
     /// `finish` runs once afterwards. The walk is iterative, so even a deeply nested tree
     /// cannot overflow the stack here.
+    ///
+    /// `morphology` is the document's token table, when one is available. A rule that declares
+    /// [`with_morphology`](tzlint_pdk::RuleMeta::with_morphology) reads it through its
+    /// [`Context`]; the table is attached only to those rules' contexts (others never see it).
+    /// When `morphology` is `None`, a rule that requires it is **skipped entirely** — neither its
+    /// `check` nor its `finish` runs — rather than being fed an empty table and reporting nothing
+    /// (or worse, spurious) findings. Rules that need no morphology are unaffected either way.
     #[must_use]
-    pub fn lint(ast: &ArchivedAst, rules: &[&dyn Rule]) -> Vec<Diagnostic> {
+    pub fn lint(
+        ast: &ArchivedAst,
+        morphology: Option<&ArchivedMorphologyV1>,
+        rules: &[&dyn Rule],
+    ) -> Vec<Diagnostic> {
         // Hoist metadata once (not per node × rule); one context per rule.
         let metas: Vec<&tzlint_pdk::RuleMeta> = rules.iter().map(|rule| rule.meta()).collect();
+
+        // A rule that needs morphology runs only when a table is available; otherwise it is
+        // inactive and contributes nothing. `active[i]` gates both `check` and `finish` for
+        // rule `i`, so a skipped rule never observes the document at all. This is a boolean
+        // presence gate: matching a rule's `required_lang()` against the table's languages is
+        // intentionally deferred to the M2h provider registry (which provisions only the
+        // languages enabled rules need), so `required_lang()` is not consulted here yet.
+        let active: Vec<bool> = metas
+            .iter()
+            .map(|meta| morphology.is_some() || !meta.needs_morphology())
+            .collect();
+
+        // One context per rule. Morphology is attached only to the rules that asked for it
+        // (capability-scoped): a rule that did not declare it never sees the table.
         let mut contexts: Vec<Context> = metas
             .iter()
-            .map(|meta| Context::new(ast, meta.id.clone(), meta.default_severity))
+            .map(|meta| {
+                let cx = Context::new(ast, meta.id.clone(), meta.default_severity);
+                match morphology {
+                    Some(table) if meta.needs_morphology() => cx.with_morphology(table),
+                    _ => cx,
+                }
+            })
             .collect();
 
         // Single pre-order walk. A `visited` bitmap makes it cycle-safe and bounds total
@@ -37,7 +69,7 @@ impl Engine {
             while let Some(node) = stack.pop() {
                 let kind = node.kind();
                 for (index, cx) in contexts.iter_mut().enumerate() {
-                    if metas[index].visits(kind) {
+                    if active[index] && metas[index].visits(kind) {
                         rules[index].check(node, cx);
                     }
                 }
@@ -52,9 +84,12 @@ impl Engine {
             }
         }
 
-        // Cross-node finalize, then aggregate and sort into the stable total order.
+        // Cross-node finalize, then aggregate and sort into the stable total order. A skipped
+        // (inactive) rule's `finish` is skipped too, so it stays entirely dormant.
         for (index, cx) in contexts.iter_mut().enumerate() {
-            rules[index].finish(cx);
+            if active[index] {
+                rules[index].finish(cx);
+            }
         }
         let mut diagnostics: Vec<Diagnostic> = Vec::new();
         for cx in contexts {
@@ -69,7 +104,8 @@ impl Engine {
 mod tests {
     use super::*;
     use crate::parse;
-    use tzlint_ast::{Ast, NodeId, NodeKind, Span};
+    use tzlint_ast::morphology::{Lang, access_morphology, to_archive_morphology};
+    use tzlint_ast::{Ast, Node, NodeId, NodeKind, OptionNodeId, Span};
     use tzlint_pdk::{RuleMeta, Severity};
 
     /// Reports `message` at every node of `kind`.
@@ -117,8 +153,105 @@ mod tests {
         }
     }
 
+    /// A morphology-reading rule: declares [`with_morphology`](RuleMeta::with_morphology) and, at
+    /// each visited node, reports how many tokens the table holds for it. The engine skips it
+    /// entirely when no morphology table is available, rather than feeding it an empty one.
+    struct MorphPeek {
+        meta: RuleMeta,
+    }
+    impl MorphPeek {
+        fn new(id: &str) -> Self {
+            MorphPeek {
+                meta: RuleMeta::new(id, Severity::Warning, vec![NodeKind::ROOT])
+                    .with_morphology(Lang::JA),
+            }
+        }
+    }
+    impl Rule for MorphPeek {
+        fn meta(&self) -> &RuleMeta {
+            &self.meta
+        }
+        fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+            let n = cx.tokens_of(node.id()).count();
+            cx.report(node.span(), format!("{n} tokens"));
+        }
+    }
+
+    /// A morphology-requiring rule whose work is in `finish` (so it tests that a skipped rule's
+    /// `finish` is skipped too, not just its `check`).
+    struct MorphFinish {
+        meta: RuleMeta,
+    }
+    impl MorphFinish {
+        fn new(id: &str) -> Self {
+            MorphFinish {
+                meta: RuleMeta::new(id, Severity::Warning, vec![NodeKind::ROOT])
+                    .with_morphology(Lang::JA),
+            }
+        }
+    }
+    impl Rule for MorphFinish {
+        fn meta(&self) -> &RuleMeta {
+            &self.meta
+        }
+        fn check<'ast>(&self, _node: NodeRef<'ast>, _cx: &mut Context<'ast>) {}
+        fn finish<'ast>(&self, cx: &mut Context<'ast>) {
+            cx.report(Span::new(0, 0), "finished");
+        }
+    }
+
+    /// A rule that does NOT declare morphology but still *reads* its context, reporting what it
+    /// observes. It pins the capability-scoping invariant: even when a table is passed to the
+    /// engine, a non-declaring rule must see `morphology() == None` and no tokens.
+    struct PlainObserver {
+        meta: RuleMeta,
+    }
+    impl PlainObserver {
+        fn new(id: &str) -> Self {
+            PlainObserver {
+                meta: RuleMeta::new(id, Severity::Warning, vec![NodeKind::ROOT]),
+            }
+        }
+    }
+    impl Rule for PlainObserver {
+        fn meta(&self) -> &RuleMeta {
+            &self.meta
+        }
+        fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+            cx.report(
+                node.span(),
+                format!(
+                    "observed morph={} tokens={}",
+                    cx.morphology().is_some(),
+                    cx.tokens_of(node.id()).count()
+                ),
+            );
+        }
+    }
+
     fn archive(src: &str) -> tzlint_ast::AlignedVec {
         tzlint_ast::to_archive(&parse(src).unwrap()).unwrap()
+    }
+
+    /// An archived morphology table holding `count` tokens, all keyed to the root (`NodeId(0)`).
+    fn morphology_on_root(count: u32) -> tzlint_ast::AlignedVec {
+        use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+        let mut builder = MorphologyBuilder::new();
+        for i in 0..count {
+            builder.push_token(
+                TokenAttrs {
+                    node: NodeId(0),
+                    surface: Span::new(i, i + 1),
+                    lang: Lang::JA,
+                    tagset: Tagset::NONE,
+                    flags: 0,
+                },
+                None,
+                None,
+                &[],
+            );
+        }
+        to_archive_morphology(&builder.finish()).unwrap()
     }
 
     #[test]
@@ -129,7 +262,7 @@ mod tests {
 
         let text_rule = FlagKind::new("flag-text", NodeKind::TEXT, "text");
         let heading_rule = FlagKind::new("flag-heading", NodeKind::HEADING, "heading");
-        let diags = Engine::lint(ast, &[&text_rule, &heading_rule]);
+        let diags = Engine::lint(ast, None, &[&text_rule, &heading_rule]);
 
         // 2 Text nodes + 1 Heading = 3 diagnostics.
         assert_eq!(diags.len(), 3);
@@ -145,7 +278,7 @@ mod tests {
         // be deterministic by (start, end, rule_id, message).
         let a = FlagKind::new("a-rule", NodeKind::TEXT, "msg");
         let b = FlagKind::new("b-rule", NodeKind::TEXT, "msg");
-        let diags = Engine::lint(ast, &[&b, &a]); // pass b first on purpose
+        let diags = Engine::lint(ast, None, &[&b, &a]); // pass b first on purpose
         let keys: Vec<_> = diags
             .iter()
             .map(|d| (d.span.start, d.rule_id.as_str()))
@@ -162,7 +295,7 @@ mod tests {
         let counter = CountNodes {
             meta: RuleMeta::new("count", Severity::Info, vec![NodeKind::ROOT]),
         };
-        let diags = Engine::lint(ast, &[&counter]);
+        let diags = Engine::lint(ast, None, &[&counter]);
         // check() is a no-op called once at the root; finish() walks the whole tree:
         // Root + Heading + Text + Paragraph + Text = 5.
         assert_eq!(diags.len(), 1);
@@ -173,7 +306,7 @@ mod tests {
     fn no_rules_yields_no_diagnostics() {
         let bytes = archive("text");
         let ast = tzlint_ast::access(&bytes).unwrap();
-        assert!(Engine::lint(ast, &[]).is_empty());
+        assert!(Engine::lint(ast, None, &[]).is_empty());
     }
 
     #[test]
@@ -187,6 +320,146 @@ mod tests {
         .unwrap();
         let ast = tzlint_ast::access(&bytes).unwrap();
         let rule = FlagKind::new("flag-text", NodeKind::TEXT, "text");
-        assert!(Engine::lint(ast, &[&rule]).is_empty());
+        assert!(Engine::lint(ast, None, &[&rule]).is_empty());
+    }
+
+    #[test]
+    fn threads_the_morphology_table_into_a_requesting_rule() {
+        let bytes = archive("word");
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        let mbytes = morphology_on_root(2); // 2 tokens keyed to the root
+        let morph = access_morphology(&mbytes).unwrap();
+
+        let rule = MorphPeek::new("peek");
+        let diags = Engine::lint(ast, Some(morph), &[&rule]);
+        // The rule visited the root, read the table through its context, and saw both tokens.
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].message, "2 tokens");
+    }
+
+    #[test]
+    fn skips_a_morphology_rule_when_no_table_is_available() {
+        let bytes = archive("word");
+        let ast = tzlint_ast::access(&bytes).unwrap();
+
+        let morph_rule = MorphPeek::new("peek"); // needs morphology
+        let plain = FlagKind::new("flag-text", NodeKind::TEXT, "text"); // does not
+        let diags = Engine::lint(ast, None, &[&morph_rule, &plain]);
+
+        // The morphology rule is skipped entirely (no "N tokens" diagnostic, nothing under its id),
+        // while the plain rule runs exactly as before.
+        assert!(diags.iter().all(|d| d.rule_id.as_str() != "peek"));
+        assert!(diags.iter().any(|d| d.rule_id.as_str() == "flag-text"));
+    }
+
+    #[test]
+    fn a_skipped_morphology_rule_does_not_run_its_finish() {
+        let bytes = archive("word");
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        let rule = MorphFinish::new("mf");
+
+        // Absent table → the rule is inactive, so even its `finish` must not emit.
+        assert!(Engine::lint(ast, None, &[&rule]).is_empty());
+
+        // Present table (even an empty one) → the rule is active and `finish` runs.
+        let mbytes = morphology_on_root(0);
+        let morph = access_morphology(&mbytes).unwrap();
+        let diags = Engine::lint(ast, Some(morph), &[&rule]);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].message, "finished");
+    }
+
+    #[test]
+    fn a_non_morphology_rule_runs_whether_or_not_a_table_is_present() {
+        let bytes = archive("# H\n\nbody");
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        let rule = FlagKind::new("flag-text", NodeKind::TEXT, "text");
+
+        let without = Engine::lint(ast, None, &[&rule]);
+        let mbytes = morphology_on_root(3);
+        let morph = access_morphology(&mbytes).unwrap();
+        let with = Engine::lint(ast, Some(morph), &[&rule]);
+
+        // A rule that never declared morphology is unaffected by the table's presence.
+        assert_eq!(without.len(), 2);
+        assert_eq!(with.len(), without.len());
+        assert!(with.iter().all(|d| d.message == "text"));
+    }
+
+    #[test]
+    fn morphology_is_routed_per_rule_across_a_mixed_rule_set_with_a_present_table() {
+        // The realistic shape: several rules in one walk with the table available — two distinct
+        // morphology rules (check-based and finish-based) interleaved with non-declaring rules.
+        // This pins, in a single call: (a) each morphology rule gets its own table-attached
+        // context (index alignment across multiple active rules), and (b) capability-scoping —
+        // a non-declaring rule must NOT see the table even though it was passed to the engine.
+        let bytes = archive("word");
+        let ast = tzlint_ast::access(&bytes).unwrap();
+        let mbytes = morphology_on_root(2);
+        let morph = access_morphology(&mbytes).unwrap();
+
+        let peek = MorphPeek::new("peek"); // declares morphology, check-based
+        let plain = PlainObserver::new("plain"); // declares nothing, but reads its context
+        let finish = MorphFinish::new("mf"); // declares morphology, finish-based
+        let diags = Engine::lint(ast, Some(morph), &[&peek, &plain, &finish]);
+
+        let msg = |id: &str| {
+            diags
+                .iter()
+                .find(|d| d.rule_id.as_str() == id)
+                .map(|d| d.message.as_str())
+        };
+        // Both morphology rules ran and saw the attached table; the finish-based one fired too.
+        assert_eq!(msg("peek"), Some("2 tokens"));
+        assert_eq!(msg("mf"), Some("finished"));
+        // The non-declaring rule ran but observed an empty (None) context — the table was NOT
+        // attached to it. (If the engine's `if meta.needs_morphology()` scope guard were dropped,
+        // this would read `morph=true tokens=2` and the assertion would fail.)
+        assert_eq!(msg("plain"), Some("observed morph=false tokens=0"));
+    }
+
+    #[test]
+    fn the_walk_is_cycle_safe_on_a_malformed_archive() {
+        // A byte-valid but malformed archive whose child links form a cycle: node 2's first_child
+        // points back to node 1, which the walk has already visited. `access` validates byte types
+        // but not the link graph, so this is constructible. The engine's `visited` bitmap must
+        // skip the revisit (engine.rs's already-visited guard) — terminating with no hang and
+        // visiting each node exactly once (so the PARAGRAPH rule fires once, not twice).
+        let ast = Ast {
+            nodes: vec![
+                Node {
+                    kind: NodeKind::ROOT,
+                    span: Span::new(0, 1),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::some(NodeId(1)),
+                    next_sibling: OptionNodeId::NONE,
+                },
+                Node {
+                    kind: NodeKind::PARAGRAPH,
+                    span: Span::new(0, 1),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::some(NodeId(2)),
+                    next_sibling: OptionNodeId::NONE,
+                },
+                Node {
+                    kind: NodeKind::TEXT,
+                    span: Span::new(0, 1),
+                    parent: NodeId(1),
+                    first_child: OptionNodeId::some(NodeId(1)), // cycle back to node 1
+                    next_sibling: OptionNodeId::NONE,
+                },
+            ],
+            text: String::from("x"),
+            root: NodeId(0),
+        };
+        let bytes = tzlint_ast::to_archive(&ast).unwrap();
+        let archived = tzlint_ast::access(&bytes).unwrap();
+
+        let rule = FlagKind::new("flag-para", NodeKind::PARAGRAPH, "para");
+        let diags = Engine::lint(archived, None, &[&rule]);
+        // Node 1 is reachable from both the root and (cyclically) from node 2, but the bitmap
+        // visits it once → exactly one diagnostic, and the call returns (no infinite loop).
+        assert_eq!(diags.len(), 1);
+        assert_eq!(diags[0].message, "para");
     }
 }

--- a/crates/tzlint_core/src/fix.rs
+++ b/crates/tzlint_core/src/fix.rs
@@ -86,7 +86,8 @@ pub fn fix(source: &str, rules: &[&dyn Rule]) -> String {
         let Ok(archived) = tzlint_ast::access(&bytes) else {
             break;
         };
-        let diagnostics = Engine::lint(archived, rules);
+        // No morphology on the fix path yet (wired alongside the cached/CLI paths in M2e/M2h).
+        let diagnostics = Engine::lint(archived, None, rules);
         let pass = apply_fixes(&text, &diagnostics);
         if pass.output == text {
             break; // fixpoint: nothing changed

--- a/crates/tzlint_rules/src/test_support.rs
+++ b/crates/tzlint_rules/src/test_support.rs
@@ -12,5 +12,5 @@ pub(crate) fn diagnose(rule: &dyn Rule, source: &str) -> Vec<Diagnostic> {
     let ast = tzlint_core::parse(source).expect("test source parses");
     let bytes = tzlint_ast::to_archive(&ast).expect("archive");
     let archived = tzlint_ast::access(&bytes).expect("access");
-    tzlint_core::Engine::lint(archived, &[rule])
+    tzlint_core::Engine::lint(archived, None, &[rule])
 }


### PR DESCRIPTION
## What

Thread the document's morphology table into the lint engine and skip rules that require morphology when none is available — building on `RuleMeta::with_morphology`/`needs_morphology` (M2b, #33) and `Context::with_morphology`/`tokens_of` (M2c, #35).

- `Engine::lint` signature changes from `(ast, rules)` to `(ast, morphology: Option<&ArchivedMorphologyV1>, rules)`.
- `active[i] = morphology.is_some() || !meta.needs_morphology()` gates **both** a rule's `check` and its `finish`: a morphology-requiring rule is **skipped entirely** when no table is available, rather than fed an empty one (which would silently report nothing, or worse).
- Morphology is attached **capability-scoped** — only to the `Context` of a rule that declared it (`Some(table) if meta.needs_morphology()`); a rule that didn't ask never sees the table.
- The single pre-order walk is otherwise unchanged.

## Notes

- The gate is a boolean presence check; matching a rule's `required_lang()` against the table's languages is intentionally deferred to the M2h provider registry (documented at the gate).
- All four call sites (cache `lint_cached`, fix loop, CLI `lint_direct`, rules `test_support`) pass `None` for now; real provisioning lands with the fingerprint (M2e) and provider registry (M2h).

## Tests

Morphology threading, skip-on-absent for both `check` and `finish`, capability isolation under a mixed rule set with a present table (a non-declaring rule must observe `morphology() == None`), multiple morphology rules in one walk, and engine-level cycle-safety on a malformed (cyclic) archive. `engine.rs` is 100% line/function coverage; the one uncovered region is the root `visited` bitmap guard, unreachable by construction (`NodeRef::root` only yields an in-range id).

Stacked on #33 + #35 (both merged). Next in the stack: the dictionary I/O primitives (M2f) and provisioning (M2g).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 形態解析情報を必要とするルールが、その情報が利用できない場合には適切にスキップされるようになりました。

* **Refactor**
  * ルールエンジンの内部処理を改善し、より安定した実行フローを実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->