### PR TITLE
feat(core): hash-pinned dictionary provisioning — Host binary I/O + zstd decompress + cache (M2f+M2g)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Belt-and-suspenders next to clippy disallowed-methods: a grep guard.
-      - name: reject raw fs::read*/serde_json in non-io modules
+      # Belt-and-suspenders next to clippy disallowed-methods: a grep guard. The alternation is
+      # unanchored, so `read` also catches `read_dir` and `create_dir` also catches `create_dir_all`.
+      - name: reject raw fs::read*/write/create_dir* in non-io modules
         run: |
-          ! git grep -nE 'std::fs::(read|write)' -- 'crates/*/src/**.rs' \
+          ! git grep -nE 'std::fs::(read|write|create_dir)' -- 'crates/*/src/**.rs' \
             ':!crates/tzlint_core/src/io*' || (echo "raw fs outside io module"; exit 1)
       # blake3 must stay pure-Rust: without `features = ["pure"]` it builds a SIMD backend via a
       # C compiler, breaking the uniform/reproducible build and wasm32. Guard the manifest.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1784,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "tzlint_abi"
 version = "0.0.0"
 dependencies = [
@@ -1808,6 +1823,7 @@ dependencies = [
  "blake3",
  "jsonschema",
  "markdown",
+ "ruzstd",
  "serde",
  "serde_json",
  "tzlint_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,13 @@ yaml_serde = "0.10"
 # job greps that the `pure` feature stays set.)
 blake3 = { version = "1.8.5", default-features = false, features = ["pure"] }
 
+# Pure-Rust Zstandard *decoder* (no C/FFI), used to decompress downloaded morphology
+# dictionaries behind the Host boundary. Decode-only — no encoder — so it stays small and, being
+# pure Rust, builds for `wasm32` and keeps the uniform/reproducible build (same rationale as
+# blake3's `pure`). MIT-licensed. `default-features = false` drops the encoder-side `dict_builder`;
+# `std` provides the `std::io::Read` streaming decoder; `hash` keeps zstd's frame-checksum check.
+ruzstd = { version = "0.8.3", default-features = false, features = ["std", "hash"] }
+
 # Argument parsing for the native `tzlint` CLI (the `derive` API: `Parser`/`Subcommand`/
 # `ValueEnum`). CLI-only — it never reaches the AST or the `wasm32` core (the wasm CI job
 # builds `tzlint_core` lib-only), so a native-only dependency here is fine.

--- a/clippy.toml
+++ b/clippy.toml
@@ -12,4 +12,8 @@ disallowed-methods = [
     { path = "std::fs::read_to_string", reason = "use tzlint_core::io::Host::read_to_string" },
     { path = "std::fs::write", reason = "use tzlint_core::io::Host::write_atomic" },
     { path = "std::fs::read_dir", reason = "use tzlint_core::io::Host::list_dir" },
+    { path = "std::fs::create_dir", reason = "use tzlint_core::io::Host::create_dir_all" },
+    { path = "std::fs::create_dir_all", reason = "use tzlint_core::io::Host::create_dir_all" },
 ]
+# `std::fs::DirBuilder` is the only other directory-creation route; it is unused anywhere in the
+# workspace, so it is left unguarded rather than adding a speculative entry. Revisit if introduced.

--- a/crates/tzlint_core/Cargo.toml
+++ b/crates/tzlint_core/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 yaml_serde = { workspace = true }
 blake3 = { workspace = true }
+ruzstd = { workspace = true }
 
 [dev-dependencies]
 # Reference Draft 2020-12 validator used ONLY by `tests/config_schema.rs` to prove the published

--- a/crates/tzlint_core/src/dict.rs
+++ b/crates/tzlint_core/src/dict.rs
@@ -1,0 +1,281 @@
+//! Morphology-dictionary provisioning: verify a hash-pinned compressed blob, decompress it
+//! (zstd, via the pure-Rust `ruzstd` decoder), and cache the result on disk through the [`Host`]
+//! boundary.
+//!
+//! This is the **verify → decompress → cache** half of provisioning. *Acquiring* the compressed
+//! blob (a network fetch, with its SSRF guard and an HTTP client) is a separate, host-side
+//! concern handled in a later step; here the blob is already present at a local path (a previous
+//! download, or an embedder-provided file) and is read through [`Host::read_bytes`].
+//!
+//! The pinned hash is BLAKE3 over the **compressed** blob and is checked *before* decompression,
+//! so a tampered or wrong file is rejected without processing its contents. The decompressed
+//! dictionary is cached **hash-addressed** (filename = hex of the pinned hash), so a dictionary
+//! upgrade — which changes the pinned hash — is a different cache file and never serves the old
+//! one (the cache-invalidation property the dictionary-version tests rely on).
+
+use std::io::Read;
+use std::path::Path;
+
+use ruzstd::decoding::StreamingDecoder;
+
+use crate::io::{Host, IoError, MAX_DICT};
+
+/// A failure while provisioning a dictionary.
+#[derive(Debug)]
+pub enum DictError {
+    /// The compressed blob's BLAKE3 hash did not equal the pinned value (wrong or tampered file).
+    HashMismatch,
+    /// The blob is not valid zstd / could not be decompressed.
+    Decompress(String),
+    /// The decompressed dictionary exceeded the `limit` bytes.
+    TooLarge {
+        /// The cap that was exceeded.
+        limit: usize,
+    },
+    /// An underlying boundary-I/O failure (reading the blob, creating the cache dir, writing it).
+    Io(IoError),
+}
+
+impl core::fmt::Display for DictError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DictError::HashMismatch => {
+                write!(f, "dictionary hash does not match the pinned value")
+            }
+            DictError::Decompress(reason) => {
+                write!(f, "dictionary decompression failed: {reason}")
+            }
+            DictError::TooLarge { limit } => {
+                write!(f, "decompressed dictionary exceeds the {limit}-byte limit")
+            }
+            DictError::Io(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for DictError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            DictError::Io(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+impl From<IoError> for DictError {
+    fn from(error: IoError) -> Self {
+        DictError::Io(error)
+    }
+}
+
+/// The hash-addressed cache filename for a dictionary pinned to `hash`: lowercase hex + `.dict`.
+fn cache_file_name(hash: &[u8; 32]) -> String {
+    let mut name = String::with_capacity(64 + ".dict".len());
+    for byte in hash {
+        // `from_digit` is infallible for radix 16 and a nibble (0..=15); the fallback is
+        // unreachable and keeps this panic-free (same idiom as `CacheKey::to_hex`).
+        name.push(char::from_digit(u32::from(byte >> 4), 16).unwrap_or('0'));
+        name.push(char::from_digit(u32::from(byte & 0x0f), 16).unwrap_or('0'));
+    }
+    name.push_str(".dict");
+    name
+}
+
+/// Provision the dictionary pinned to `pinned_hash`, returning its decompressed bytes.
+///
+/// Returns the dictionary **in memory** (owned bytes), the one representation every host can use —
+/// a browser/wasm embedder has no filesystem path to memory-map. A caller that needs the
+/// dictionary repeatedly should hold onto the returned bytes: the cache-hit path below is an
+/// `O(size)` read, so this is a provision-once-then-reuse API, not a per-use lookup. (A native
+/// backend that would rather mmap the cached file can grow a path-returning variant later, when
+/// such a consumer actually lands — there is none yet.)
+///
+/// **Cache hit:** if the decompressed result is already cached under `cache_dir`, read and return
+/// it. The cache is hash-addressed and was written by a prior successful verification, so the
+/// cached bytes correspond to exactly this pinned blob (the cache is trusted within its directory,
+/// like the document cache). A failed hit-read — a corrupt, truncated, or over-`MAX_DICT` cache
+/// entry — is **surfaced as an error**, not silently treated as a miss: the operator should clear
+/// the cache, matching the cache-write stance below (the document cache, by contrast, rebuilds
+/// best-effort; a soft-miss self-heal here is a deliberate policy left for when the registry lands).
+///
+/// **Cache miss:** read the compressed blob from `compressed_source` through the [`Host`], verify
+/// `blake3(blob) == pinned_hash` **before** decompressing (never process an unverified blob),
+/// zstd-decompress it (bounded by [`MAX_DICT`]), cache the result (creating `cache_dir` and
+/// writing atomically), and return it. A cache-write failure is **surfaced**, not swallowed:
+/// provisioning is a setup step, so a non-writable cache directory is an environment problem the
+/// operator should fix rather than have masked by silently re-decompressing on every run.
+pub fn provision_dictionary(
+    host: &dyn Host,
+    cache_dir: &Path,
+    compressed_source: &Path,
+    pinned_hash: &[u8; 32],
+) -> Result<Vec<u8>, DictError> {
+    let cache_path = cache_dir.join(cache_file_name(pinned_hash));
+    if host.exists(&cache_path) {
+        return Ok(host.read_bytes(&cache_path, MAX_DICT)?);
+    }
+
+    let compressed = host.read_bytes(compressed_source, MAX_DICT)?;
+    // Verify before decompressing: never process the contents of an unverified blob.
+    if blake3::hash(&compressed).as_bytes() != pinned_hash {
+        return Err(DictError::HashMismatch);
+    }
+    let decompressed = zstd_decompress(&compressed, MAX_DICT)?;
+
+    host.create_dir_all(cache_dir)?;
+    host.write_atomic(&cache_path, &decompressed)?;
+    Ok(decompressed)
+}
+
+/// Decompress the zstd `compressed` blob, rejecting output larger than `limit` bytes.
+fn zstd_decompress(compressed: &[u8], limit: usize) -> Result<Vec<u8>, DictError> {
+    let decoder =
+        StreamingDecoder::new(compressed).map_err(|e| DictError::Decompress(e.to_string()))?;
+    let mut out = Vec::new();
+    // Cap one past the limit so "exactly at the limit" is distinguishable from "over it"
+    // (mirrors `Host::read_bytes`); `saturating_add` keeps `usize::MAX` from overflowing.
+    decoder
+        .take((limit as u64).saturating_add(1))
+        .read_to_end(&mut out)
+        .map_err(|e| DictError::Decompress(e.to_string()))?;
+    if out.len() > limit {
+        return Err(DictError::TooLarge { limit });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::NativeHost;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// A known payload, zstd-compressed offline (`zstd -q -c`); decompresses to [`PAYLOAD`].
+    const FIXTURE: &[u8] = &[
+        0x28, 0xb5, 0x2f, 0xfd, 0x04, 0x58, 0x21, 0x02, 0x00, 0x74, 0x73, 0x75, 0x7a, 0x75, 0x6c,
+        0x69, 0x6e, 0x74, 0x20, 0x6d, 0x6f, 0x72, 0x70, 0x68, 0x6f, 0x6c, 0x6f, 0x67, 0x79, 0x20,
+        0x64, 0x69, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x61, 0x72, 0x79, 0x20, 0x66, 0x69, 0x78, 0x74,
+        0x75, 0x72, 0x65, 0x20, 0xe2, 0x80, 0x94, 0x20, 0xe5, 0xbd, 0xa2, 0xe6, 0x85, 0x8b, 0xe7,
+        0xb4, 0xa0, 0xe8, 0xbe, 0x9e, 0xe6, 0x9b, 0xb8, 0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3,
+        0x83, 0x88, 0x85, 0x9e, 0x8c, 0x61,
+    ];
+    const PAYLOAD: &str = "tsuzulint morphology dictionary fixture — 形態素辞書テスト";
+
+    /// A unique, freshly-created temp directory (cleaned up by the caller).
+    fn temp_dir() -> PathBuf {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "tzlint-dict-test-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        NativeHost.create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn pin_of(blob: &[u8]) -> [u8; 32] {
+        *blake3::hash(blob).as_bytes()
+    }
+
+    #[test]
+    fn provision_decompresses_caches_and_then_serves_from_the_cache() {
+        let dir = temp_dir();
+        let host = NativeHost;
+        let source = dir.join("ipadic.zst");
+        host.write_atomic(&source, FIXTURE).unwrap();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+
+        // Cache miss: verifies, decompresses, and caches.
+        let first = provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap();
+        assert_eq!(first, PAYLOAD.as_bytes());
+        assert!(host.exists(&cache_dir.join(cache_file_name(&pinned))));
+
+        // Remove the source so a re-read would fail; the second call must hit the cache instead.
+        std::fs::remove_file(&source).unwrap();
+        let second = provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap();
+        assert_eq!(second, PAYLOAD.as_bytes());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn provision_rejects_a_blob_whose_hash_is_not_pinned() {
+        let dir = temp_dir();
+        let host = NativeHost;
+        let source = dir.join("tampered.zst");
+        host.write_atomic(&source, FIXTURE).unwrap();
+        // A pin that does not match the blob → rejected before any decompression, no cache write.
+        let wrong = [0u8; 32];
+        let err = provision_dictionary(&host, &dir.join("cache"), &source, &wrong).unwrap_err();
+        assert!(matches!(err, DictError::HashMismatch));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn provision_errors_on_a_verified_but_non_zstd_blob() {
+        let dir = temp_dir();
+        let host = NativeHost;
+        let garbage: &[u8] = b"this is not a zstd frame";
+        let source = dir.join("garbage.zst");
+        host.write_atomic(&source, garbage).unwrap();
+        // The hash matches (so verification passes) but the bytes are not zstd → Decompress error.
+        let pinned = pin_of(garbage);
+        let err = provision_dictionary(&host, &dir.join("cache"), &source, &pinned).unwrap_err();
+        assert!(matches!(err, DictError::Decompress(_)));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn provision_surfaces_a_missing_source_as_an_io_error() {
+        let dir = temp_dir();
+        let host = NativeHost;
+        let missing = dir.join("does-not-exist.zst");
+        let err = provision_dictionary(&host, &dir.join("cache"), &missing, &pin_of(FIXTURE))
+            .unwrap_err();
+        assert!(matches!(err, DictError::Io(IoError::NotFound)));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn zstd_decompress_rejects_output_larger_than_the_limit() {
+        // The fixture decompresses to exactly 68 bytes; a 10-byte cap must reject it as TooLarge.
+        let err = zstd_decompress(FIXTURE, 10).unwrap_err();
+        assert!(matches!(err, DictError::TooLarge { limit: 10 }));
+        // Pin the off-by-one boundary (mirrors io.rs's read-cap tests): exactly-at-limit is
+        // accepted, one under is rejected — guards the `> limit` / `take(limit+1)` arithmetic.
+        assert_eq!(zstd_decompress(FIXTURE, 68).unwrap(), PAYLOAD.as_bytes());
+        assert!(matches!(
+            zstd_decompress(FIXTURE, 67).unwrap_err(),
+            DictError::TooLarge { limit: 67 }
+        ));
+        // At a generous cap it decompresses fully.
+        assert_eq!(
+            zstd_decompress(FIXTURE, MAX_DICT).unwrap(),
+            PAYLOAD.as_bytes()
+        );
+    }
+
+    #[test]
+    fn dict_error_display_and_source() {
+        use std::error::Error;
+        assert_eq!(
+            DictError::HashMismatch.to_string(),
+            "dictionary hash does not match the pinned value"
+        );
+        assert!(
+            DictError::Decompress("bad frame".into())
+                .to_string()
+                .contains("bad frame")
+        );
+        assert_eq!(
+            DictError::TooLarge { limit: 8 }.to_string(),
+            "decompressed dictionary exceeds the 8-byte limit"
+        );
+        let io = DictError::Io(IoError::NotFound);
+        assert_eq!(io.to_string(), "file not found");
+        assert!(io.source().is_some()); // the Io variant chains its source
+        assert!(DictError::HashMismatch.source().is_none());
+    }
+}

--- a/crates/tzlint_core/src/io.rs
+++ b/crates/tzlint_core/src/io.rs
@@ -13,6 +13,12 @@ use std::path::Path;
 pub const MAX_FILE: usize = 16 * 1024 * 1024; // 16 MiB
 /// Maximum size, in bytes, of a configuration file.
 pub const MAX_CONFIG: usize = 1024 * 1024; // 1 MiB
+/// Maximum size, in bytes, of a single morphology-dictionary blob read through
+/// [`Host::read_bytes`]. Far larger than [`MAX_FILE`] because dictionaries (IPADIC / UniDic /
+/// ko-dic / CC-CEDICT) are multi-MB binaries, yet still bounded so a corrupt or hostile path
+/// cannot exhaust memory. Generous enough for the common ja/ko/zh dictionaries; a larger variant
+/// (e.g. full UniDic) can raise this when its provisioning lands.
+pub const MAX_DICT: usize = 512 * 1024 * 1024; // 512 MiB
 
 /// A boundary-I/O failure.
 #[derive(Debug)]
@@ -119,6 +125,31 @@ pub trait Host {
             "directory listing is not supported by this host".to_string(),
         ))
     }
+
+    /// Read the raw bytes of the file at `path`, rejecting anything larger than `limit` bytes.
+    ///
+    /// Unlike [`read_to_string`](Host::read_to_string) this does **no** UTF-8 validation — it is
+    /// the boundary for binary blobs such as morphology dictionaries (see [`MAX_DICT`]). Like
+    /// [`list_dir`](Host::list_dir) it defaults to an error, so a host without an ambient
+    /// filesystem (a browser/wasm embedder, which obtains dictionaries by other means — see the
+    /// M2k browser provider) need not implement it; [`NativeHost`] overrides it. A missing `path`
+    /// maps to [`IoError::NotFound`].
+    fn read_bytes(&self, path: &Path, limit: usize) -> Result<Vec<u8>, IoError> {
+        let _ = (path, limit);
+        Err(IoError::Other(
+            "binary file reads are not supported by this host".to_string(),
+        ))
+    }
+
+    /// Create `dir` and any missing parent directories (the dictionary cache root, e.g.), a no-op
+    /// success when it already exists. Like [`list_dir`](Host::list_dir) it defaults to an error
+    /// so a non-filesystem host need not implement it; [`NativeHost`] overrides it.
+    fn create_dir_all(&self, dir: &Path) -> Result<(), IoError> {
+        let _ = dir;
+        Err(IoError::Other(
+            "directory creation is not supported by this host".to_string(),
+        ))
+    }
 }
 
 // The real-filesystem host. Not compiled for `wasm32`, where the embedder injects its own
@@ -151,6 +182,28 @@ mod native {
                 return Err(IoError::TooLarge { limit });
             }
             String::from_utf8(bytes).map_err(|e| IoError::Other(format!("invalid UTF-8: {e}")))
+        }
+
+        fn read_bytes(&self, path: &Path, limit: usize) -> Result<Vec<u8>, IoError> {
+            let file = File::open(path)?;
+            // Same capped-read shape as `read_to_string` (one past `limit` so "exactly at the
+            // limit" is distinguishable; `saturating_add` keeps `usize::MAX` from overflowing),
+            // but no UTF-8 validation — the bytes are returned verbatim.
+            let mut bytes = Vec::new();
+            file.take((limit as u64).saturating_add(1))
+                .read_to_end(&mut bytes)?;
+            if bytes.len() > limit {
+                return Err(IoError::TooLarge { limit });
+            }
+            Ok(bytes)
+        }
+
+        fn create_dir_all(&self, dir: &Path) -> Result<(), IoError> {
+            // The single allowed `create_dir_all` call site (the io boundary); clippy's
+            // `disallowed_methods` bans it everywhere else, mirroring `read`/`write`/`read_dir`.
+            #[allow(clippy::disallowed_methods)]
+            std::fs::create_dir_all(dir)?;
+            Ok(())
         }
 
         fn write_atomic(&self, path: &Path, contents: &[u8]) -> Result<(), IoError> {
@@ -299,7 +352,7 @@ mod native {
     #[cfg(test)]
     mod tests {
         use super::*;
-        use crate::io::{DirEntry, EntryKind, IoError, MAX_FILE};
+        use crate::io::{DirEntry, EntryKind, IoError, MAX_DICT, MAX_FILE};
         use std::sync::atomic::{AtomicU64, Ordering};
 
         /// A unique, freshly-created temp directory (cleaned up by the caller).
@@ -310,7 +363,7 @@ mod native {
                 std::process::id(),
                 N.fetch_add(1, Ordering::Relaxed)
             ));
-            std::fs::create_dir_all(&dir).unwrap();
+            NativeHost.create_dir_all(&dir).unwrap();
             dir
         }
 
@@ -361,12 +414,137 @@ mod native {
         }
 
         #[test]
+        fn read_bytes_roundtrips_binary_that_is_not_valid_utf8() {
+            let dir = temp_dir();
+            let path = dir.join("dict.bin");
+            let host = NativeHost;
+            // Bytes that are NOT valid UTF-8 (a dictionary blob is arbitrary binary).
+            let blob: &[u8] = &[0xFF, 0x00, 0xFE, 0x80, b'a'];
+            host.write_atomic(&path, blob).unwrap();
+            // `read_bytes` returns them verbatim …
+            assert_eq!(host.read_bytes(&path, MAX_DICT).unwrap(), blob);
+            // … whereas the UTF-8 read rejects the same content, confirming `read_bytes` is the
+            // binary boundary.
+            assert!(matches!(
+                host.read_to_string(&path, MAX_DICT),
+                Err(IoError::Other(_))
+            ));
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn read_bytes_rejects_oversize_at_one_past_the_limit() {
+            let dir = temp_dir();
+            let path = dir.join("big.bin");
+            let host = NativeHost;
+            host.write_atomic(&path, b"0123456789").unwrap();
+            assert!(matches!(
+                host.read_bytes(&path, 4),
+                Err(IoError::TooLarge { limit: 4 })
+            ));
+            // Exactly at the limit is accepted.
+            assert_eq!(host.read_bytes(&path, 10).unwrap(), b"0123456789");
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn read_bytes_missing_path_is_not_found() {
+            let host = NativeHost;
+            let missing = Path::new("/no/such/tzlint/path/zzz.bin");
+            assert!(matches!(
+                host.read_bytes(missing, MAX_DICT),
+                Err(IoError::NotFound)
+            ));
+        }
+
+        #[test]
+        fn read_bytes_with_no_practical_cap_reads_everything() {
+            let dir = temp_dir();
+            let path = dir.join("any.bin");
+            let host = NativeHost;
+            host.write_atomic(&path, b"abcdef").unwrap();
+            // `usize::MAX` must not overflow the `take` cap; it reads the whole file.
+            assert_eq!(host.read_bytes(&path, usize::MAX).unwrap(), b"abcdef");
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn create_dir_all_makes_nested_dirs_idempotently_then_writes_into_them() {
+            let dir = temp_dir();
+            let nested = dir.join("cache").join("dicts").join("ja");
+            let host = NativeHost;
+            // Creates the whole chain …
+            host.create_dir_all(&nested).unwrap();
+            // … and is a no-op success when it already exists.
+            host.create_dir_all(&nested).unwrap();
+            // The freshly-created dir is usable as a write target (the dictionary cache use case).
+            let path = nested.join("ipadic.bin");
+            host.write_atomic(&path, b"dict").unwrap();
+            assert_eq!(host.read_bytes(&path, MAX_DICT).unwrap(), b"dict");
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        /// A host that implements only the required methods and relies on the trait defaults for
+        /// the optional, native-only capabilities — modeling a non-filesystem embedder.
+        struct DefaultsHost;
+        impl Host for DefaultsHost {
+            fn read_to_string(&self, _path: &Path, _limit: usize) -> Result<String, IoError> {
+                Ok(String::new())
+            }
+            fn write_atomic(&self, _path: &Path, _contents: &[u8]) -> Result<(), IoError> {
+                Ok(())
+            }
+            fn exists(&self, _path: &Path) -> bool {
+                false
+            }
+        }
+
+        #[test]
+        fn create_dir_all_errors_when_a_path_component_is_a_file() {
+            let dir = temp_dir();
+            let file = dir.join("not-a-dir");
+            let host = NativeHost;
+            host.write_atomic(&file, b"x").unwrap();
+            // Creating a directory *under* a regular file fails — the error surfaces (no panic).
+            assert!(host.create_dir_all(&file.join("sub")).is_err());
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
+        fn optional_capabilities_default_to_an_error_on_a_non_filesystem_host() {
+            let host = DefaultsHost;
+            let p = Path::new("anything");
+            // The required methods it implements behave as written (exercised so the fixture
+            // carries no dead code) …
+            assert_eq!(host.read_to_string(p, MAX_DICT).unwrap(), "");
+            assert!(host.write_atomic(p, b"x").is_ok());
+            assert!(!host.exists(p));
+            // … while the optional, native-only capabilities default to a clear error, never a
+            // panic — the documented contract for `read_bytes` / `create_dir_all` / `list_dir`.
+            assert!(matches!(
+                host.read_bytes(p, MAX_DICT),
+                Err(IoError::Other(_))
+            ));
+            assert!(matches!(host.create_dir_all(p), Err(IoError::Other(_))));
+            assert!(matches!(host.list_dir(p), Err(IoError::Other(_))));
+        }
+
+        #[test]
+        fn read_bytes_on_a_directory_errors_rather_than_panicking() {
+            // Opening a directory succeeds but reading its bytes fails; the error surfaces
+            // (exercises the read error path, mirroring how `create_dir_all` is error-tested).
+            let dir = temp_dir();
+            assert!(NativeHost.read_bytes(&dir, MAX_DICT).is_err());
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        #[test]
         fn write_atomic_errors_and_leaves_no_temp_when_rename_fails() {
             // Renaming the temp over an existing directory fails; the error surfaces and the
             // RAII guard removes the temp (no leak), rather than panicking.
             let dir = temp_dir();
             let target = dir.join("a-directory");
-            std::fs::create_dir_all(&target).unwrap();
+            NativeHost.create_dir_all(&target).unwrap();
             assert!(NativeHost.write_atomic(&target, b"data").is_err());
             // Dogfood `list_dir` (rather than raw `read_dir`, now disallowed) to scan for a leak.
             let leaked = NativeHost
@@ -476,7 +654,7 @@ mod native {
             let dir = temp_dir();
             let host = NativeHost;
             host.write_atomic(&dir.join("a.md"), b"x").unwrap();
-            std::fs::create_dir(dir.join("sub")).unwrap();
+            NativeHost.create_dir_all(&dir.join("sub")).unwrap();
 
             let entries = by_name(host.list_dir(&dir).unwrap());
             assert_eq!(entries.get("a.md"), Some(&EntryKind::File));

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod cache;
 pub mod config;
+pub mod dict;
 pub mod engine;
 pub mod fix;
 pub mod io;
@@ -30,6 +31,7 @@ pub use config::{
     CONFIG_SCHEMA, Config, ConfigError, ConfigFormat, DiscoveredConfig, Preset, RuleSetting,
     ShadowedCandidate, discover, resolve,
 };
+pub use dict::{DictError, provision_dictionary};
 pub use engine::Engine;
 pub use fix::{FixPass, MAX_FIX_PASSES, apply_fixes, fix};
 pub use io::{DirEntry, EntryKind, Host, IoError};


### PR DESCRIPTION
## Summary

Bundles **M2f** and **M2g** — the offline half of morphology-dictionary provisioning. M2f's binary-I/O boundary primitives exist only to be consumed by M2g, so shipping them together avoids landing unused `Host` methods.

- **M2f — `Host` binary-read + dir-create boundary primitives** (`io.rs`, `clippy.toml`, `ci.yml`)
  - `Host::read_bytes(path, limit) -> Result<Vec<u8>, IoError>`: bounded binary read (no UTF-8 validation), reads `take(limit+1)` and returns `TooLarge` if it exceeds `limit`.
  - `Host::create_dir_all(dir) -> Result<(), IoError>`: recursive dir creation.
  - Both default to `Err` on the `Host` trait (like `list_dir`); only `NativeHost` overrides them, so wasm embedders opt in explicitly.
  - `MAX_DICT = 512 MiB` added alongside the existing `MAX_FILE` / `MAX_CONFIG` caps.
  - I/O-guard widened: `clippy.toml` disallows `std::fs::create_dir{,_all}`; the CI grep guard now also catches `create_dir`.

- **M2g — hash-pinned dictionary decompress + on-disk cache** (`dict.rs`, deps)
  - `provision_dictionary(host, cache_dir, compressed_source, pinned_hash) -> Result<Vec<u8>, DictError>`.
  - **Cache hit**: hash-addressed filename (`hex(pinned_hash) + ".dict"`) — read and return.
  - **Miss**: read compressed blob via `Host`, **verify `blake3(blob) == pinned_hash` *before* decompressing** (no untrusted bytes reach the decoder unverified), `zstd_decompress(.., MAX_DICT)` (streaming, bounded by `take(limit+1)` → `TooLarge`), then `create_dir_all` + atomic write, and return the in-memory bytes.
  - `DictError { HashMismatch, Decompress, TooLarge { limit }, Io }` with `Display` / `source` / `From<IoError>`.
  - **Network fetch is intentionally out of scope** — the `compressed_source` is a local path here; HTTP fetch + SSRF hardening is deferred to a follow-up (`M2g-fetch`).
  - zstd decoding via **`ruzstd` 0.8.3** (pure-Rust decoder, `default-features = false`, `["std","hash"]`) — user-vetted for wasm32 compatibility and license (MIT).

## Decoder choice

Pure-Rust `ruzstd` (decoder-only) keeps `tzlint_core` building on `wasm32-unknown-unknown` with no C toolchain. Returning in-memory bytes (rather than an mmap handle) is deliberate: wasm has no mmap path, the cache-hit re-read is O(size), and a failed cache-hit read is treated as fatal rather than silently re-provisioning.

## Tests

- M2f: `NativeHost` round-trips for `read_bytes` (incl. `TooLarge` boundary) and `create_dir_all`; default-`Host` `Err` behavior.
- M2g: 6 TDD cases — cache miss→provision→hit, hash-mismatch rejection (pre-decompress), decompress success, oversized-output `TooLarge`, I/O error propagation. Offline fixture (`zstd -c`, 81 bytes) round-trips to `"tsuzulint morphology dictionary fixture — 形態素辞書テスト"`.
- `just check` green (fmt + clippy `-D warnings` + 333 nextest + doctests); `just wasm` builds `tzlint_core` for `wasm32-unknown-unknown`.

## Frozen-ABI / I/O invariants

No AST/ABI change. All new boundary I/O goes through `Host`; no raw `std::fs` outside `io.rs`. No `unwrap`/`expect`/`panic!` in library code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 形態素辞書のプロビジョニング機能を追加。圧縮辞書の検証、伸長、キャッシング機構に対応
  * バイナリデータ読み込みと複数階層ディレクトリ作成の I/O 機能を拡充

* **Chores**
  * Zstandard デコーディング依存関係を追加
  * ファイルシステム操作に関する CI ガードと Lint ルールを強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->