### PR TITLE
feat: network dictionary fetch + SSRF guard (M2g-fetch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,13 @@ jobs:
         run: |
           ! git grep -nE 'std::fs::(read|write|create_dir)' -- 'crates/*/src/**.rs' \
             ':!crates/tzlint_core/src/io*' || (echo "raw fs outside io module"; exit 1)
+      # Network egress has a single boundary too: the dictionary fetch goes through
+      # `Host::fetch`, implemented only in the CLI's `host.rs` with `ureq`. Keep the HTTP client
+      # out of every other module (and out of `tzlint_core`, which must stay network-free / wasm).
+      - name: reject network clients outside the CLI host boundary
+        run: |
+          ! git grep -nE '\bureq\b' -- 'crates/*/src/**.rs' \
+            ':!crates/tzlint_cli/src/host.rs' || (echo "network egress (ureq) must go through CliHost::fetch in host.rs"; exit 1)
       # blake3 must stay pure-Rust: without `features = ["pure"]` it builds a SIMD backend via a
       # C compiler, breaking the uniform/reproducible build and wasm32. Guard the manifest.
       - name: blake3 must keep features = ["pure"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1814,6 +1816,7 @@ dependencies = [
  "tzlint_core",
  "tzlint_pdk",
  "tzlint_rules",
+ "ureq",
 ]
 
 [[package]]
@@ -1828,6 +1831,7 @@ dependencies = [
  "serde_json",
  "tzlint_ast",
  "tzlint_pdk",
+ "url",
  "yaml_serde",
 ]
 
@@ -1880,6 +1884,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1922,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -2029,6 +2067,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,10 +65,24 @@ blake3 = { version = "1.8.5", default-features = false, features = ["pure"] }
 # `std` provides the `std::io::Read` streaming decoder; `hash` keeps zstd's frame-checksum check.
 ruzstd = { version = "0.8.3", default-features = false, features = ["std", "hash"] }
 
+# WHATWG-URL parser (servo) for the dictionary-fetch SSRF guard (`tzlint_core::net`). A robust,
+# spec-conformant parser is mandatory here: hand-rolling scheme/authority/host parsing is exactly
+# where parser-differential SSRF bypasses hide. Pure Rust (idna/percent-encoding/form_urlencoded,
+# no C/FFI), so it builds for `wasm32` and keeps the uniform/reproducible build; MIT/Apache-2.0.
+# The guard itself does no I/O, so this never pulls networking into the wasm-clean core.
+url = "2"
+
 # Argument parsing for the native `tzlint` CLI (the `derive` API: `Parser`/`Subcommand`/
 # `ValueEnum`). CLI-only — it never reaches the AST or the `wasm32` core (the wasm CI job
 # builds `tzlint_core` lib-only), so a native-only dependency here is fine.
 clap = { version = "4", features = ["derive"] }
+
+# Blocking HTTPS client for the native CLI's dictionary fetch (`CliHost::fetch`, the single
+# network-egress boundary). `rustls` keeps TLS pure-Rust (no OpenSSL/C toolchain), matching the
+# project's uniform/reproducible build. CLI-only and native by construction — it never reaches
+# `tzlint_core` or the `wasm32` build, so the core stays network-free. A deliberately minimal
+# feature set (no gzip/json/cookies) keeps the dependency/audit surface small.
+ureq = { version = "3", default-features = false, features = ["rustls"] }
 
 # Lints applied workspace-wide. `unwrap`/`expect`/`panic` are denied in library code
 # (per the design's error-handling rules); the io-guard CI job adds the disallowed-methods

--- a/crates/tzlint_cli/Cargo.toml
+++ b/crates/tzlint_cli/Cargo.toml
@@ -28,6 +28,9 @@ tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
 # Argument parsing (derive API).
 clap = { workspace = true }
+# Blocking HTTPS client for `CliHost::fetch` — the CLI's network-egress boundary for dictionary
+# acquisition (rustls TLS, pure Rust). Native/CLI-only, so the wasm-clean core stays network-free.
+ureq = { workspace = true }
 # Glob pattern matching for `lint`/`fix` PATH arguments. Used ONLY for `Pattern::matches_path`
 # (pure string matching); the directory walk itself goes through `Host::list_dir`, never
 # `glob::glob()` (which would touch `std::fs` directly and bypass the io boundary). CLI-only —

--- a/crates/tzlint_cli/src/host.rs
+++ b/crates/tzlint_cli/src/host.rs
@@ -1,0 +1,180 @@
+//! The CLI's network-capable [`Host`]: the real filesystem plus an HTTPS dictionary fetch.
+//!
+//! [`tzlint_core`]'s own [`NativeHost`] is deliberately network-free so the core carries no
+//! networking dependency and keeps building for `wasm32`. The native `tzlint` binary, by contrast,
+//! must be able to *acquire* a morphology dictionary, so it runs on [`CliHost`]: every filesystem
+//! method delegates to [`NativeHost`], and [`fetch`](Host::fetch) is implemented here with `ureq`
+//! (rustls TLS). Keeping the HTTP client in the binary — not the library — is what lets the core
+//! stay wasm-clean.
+
+use std::io::Read;
+use std::path::Path;
+use std::time::Duration;
+
+use tzlint_core::io::{DirEntry, Host, IoError, NativeHost};
+
+/// A [`Host`] for the native CLI: [`NativeHost`]'s filesystem access plus a real HTTPS
+/// [`fetch`](Host::fetch) over `ureq` + rustls.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CliHost {
+    fs: NativeHost,
+}
+
+impl CliHost {
+    /// Create a CLI host (stateless; the underlying [`NativeHost`] is a unit type).
+    pub fn new() -> Self {
+        CliHost { fs: NativeHost }
+    }
+}
+
+impl Host for CliHost {
+    fn read_to_string(&self, path: &Path, limit: usize) -> Result<String, IoError> {
+        self.fs.read_to_string(path, limit)
+    }
+
+    fn write_atomic(&self, path: &Path, contents: &[u8]) -> Result<(), IoError> {
+        self.fs.write_atomic(path, contents)
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        self.fs.exists(path)
+    }
+
+    fn list_dir(&self, dir: &Path) -> Result<Vec<DirEntry>, IoError> {
+        self.fs.list_dir(dir)
+    }
+
+    fn read_bytes(&self, path: &Path, limit: usize) -> Result<Vec<u8>, IoError> {
+        self.fs.read_bytes(path, limit)
+    }
+
+    fn create_dir_all(&self, dir: &Path) -> Result<(), IoError> {
+        self.fs.create_dir_all(dir)
+    }
+
+    /// Fetch `url` over HTTPS, capping the response at `limit` bytes.
+    ///
+    /// `url` is expected to have already passed `tzlint_core::net::validate_dictionary_url`. The
+    /// client adds defense in depth on top of that guard:
+    /// - **`https_only`** — the client itself refuses any non-`https` request.
+    /// - **`max_redirects(0)`** — redirects are *not* followed. A redirect target is not re-checked
+    ///   by the SSRF guard, so following a `3xx` to an internal address would bypass it; operators
+    ///   pin the final URL instead.
+    /// - **per-phase timeouts** — DNS resolve, TCP+TLS connect, response-header receipt, and body
+    ///   receipt are each bounded, so a server that stalls at *any* phase (including one that
+    ///   accepts the connection but never sends headers) cannot hang provisioning.
+    ///
+    /// The body is read through a streaming handle with the same one-past-`limit` cap the rest of
+    /// the [`Host`] boundary uses, so an over-size response is reported as [`IoError::TooLarge`]
+    /// rather than exhausting memory. A fresh agent per call is fine: provisioning is a rare,
+    /// one-shot setup step, not a hot path.
+    ///
+    /// Not yet covered (a documented follow-up): re-validating the *resolved* address to defend
+    /// against DNS rebinding (a hostname that resolves to an internal IP). The pinned-hash check in
+    /// `tzlint_core::dict` is the backstop — a fetch of the wrong endpoint cannot match the pin.
+    fn fetch(&self, url: &str, limit: usize) -> Result<Vec<u8>, IoError> {
+        let agent: ureq::Agent = ureq::Agent::config_builder()
+            .https_only(true)
+            .max_redirects(0)
+            .timeout_resolve(Some(Duration::from_secs(30)))
+            .timeout_connect(Some(Duration::from_secs(30)))
+            // `timeout_recv_body` only bounds the *body* phase; header receipt needs its own bound
+            // (`timeout_recv_response`) or `call()` could wait forever for a connected-but-silent peer.
+            .timeout_recv_response(Some(Duration::from_secs(30)))
+            .timeout_recv_body(Some(Duration::from_secs(300)))
+            .build()
+            .into();
+        let mut response = agent
+            .get(url)
+            .call()
+            .map_err(|e| IoError::Other(format!("dictionary fetch failed: {e}")))?;
+        // `as_reader()` is itself unbounded; the size cap lives in `read_to_limit` so it is
+        // unit-testable without a network.
+        read_to_limit(response.body_mut().as_reader(), limit)
+    }
+}
+
+/// Read `reader` fully into a `Vec`, rejecting more than `limit` bytes.
+///
+/// Uses the same one-past-`limit` cap as the rest of the [`Host`] boundary (`Host::read_bytes`):
+/// reading `limit + 1` lets "exactly at the limit" be distinguished from "over it", which is
+/// reported as [`IoError::TooLarge`] rather than buffering an unbounded response. Factored out of
+/// [`CliHost::fetch`] so the cap logic is testable with an in-memory reader (the `ureq` transport
+/// itself cannot be exercised offline).
+fn read_to_limit(reader: impl Read, limit: usize) -> Result<Vec<u8>, IoError> {
+    let mut bytes = Vec::new();
+    reader
+        .take((limit as u64).saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|e| IoError::Other(format!("reading dictionary response failed: {e}")))?;
+    if bytes.len() > limit {
+        return Err(IoError::TooLarge { limit });
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tzlint_core::io::MAX_DICT;
+
+    #[test]
+    fn delegates_filesystem_operations_to_the_native_host() {
+        // `CliHost` must be a drop-in for `NativeHost` on every filesystem method (the CLI runs
+        // entirely on it), so a write/read round-trip through `CliHost` behaves identically.
+        let dir = std::env::temp_dir().join(format!("tzlint-clihost-{}", std::process::id()));
+        let host = CliHost::new();
+        host.create_dir_all(&dir).unwrap();
+        let path = dir.join("d.bin");
+        let blob: &[u8] = &[0xFF, 0x00, 0xFE, b'x'];
+        host.write_atomic(&path, blob).unwrap();
+        assert!(host.exists(&path));
+        assert_eq!(host.read_bytes(&path, MAX_DICT).unwrap(), blob);
+        assert!(
+            host.list_dir(&dir)
+                .unwrap()
+                .iter()
+                .any(|e| e.name == "d.bin")
+        );
+        // A UTF-8 file also round-trips through the string read (exercises that delegation too).
+        let text_path = dir.join("note.md");
+        host.write_atomic(&text_path, "見出し\n".as_bytes())
+            .unwrap();
+        assert_eq!(
+            host.read_to_string(&text_path, MAX_DICT).unwrap(),
+            "見出し\n"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn read_to_limit_caps_at_one_past_the_limit() {
+        use std::io::Cursor;
+        // Under the limit: returned verbatim.
+        assert_eq!(
+            read_to_limit(Cursor::new(b"abc".to_vec()), 10).unwrap(),
+            b"abc"
+        );
+        // Exactly at the limit: accepted (the off-by-one boundary, mirroring `read_bytes`).
+        assert_eq!(
+            read_to_limit(Cursor::new(b"0123456789".to_vec()), 10).unwrap(),
+            b"0123456789"
+        );
+        // One over the limit: rejected as TooLarge rather than buffered.
+        assert!(matches!(
+            read_to_limit(Cursor::new(b"0123456789".to_vec()), 9),
+            Err(IoError::TooLarge { limit: 9 })
+        ));
+    }
+
+    #[test]
+    fn fetch_refuses_a_non_https_url_without_touching_the_network() {
+        // `https_only` makes the client reject a cleartext URL up front (no connection attempt),
+        // so this is deterministic and offline. It surfaces as an `Other` I/O error, never a panic.
+        let host = CliHost::new();
+        let err = host
+            .fetch("http://dict.example.com/d.zst", MAX_DICT)
+            .unwrap_err();
+        assert!(matches!(err, IoError::Other(_)), "got {err:?}");
+    }
+}

--- a/crates/tzlint_cli/src/main.rs
+++ b/crates/tzlint_cli/src/main.rs
@@ -3,7 +3,8 @@
 //! Wires the `lint` / `fix` / `init` / `rules` subcommands over `tzlint_core`: config discovery,
 //! the parse → archive → `Engine::lint` pipeline (with the in-memory document cache), autofix,
 //! and text / JSON / SARIF output via the position mapper. `rules` reports the resolved rule set.
-//! All file access goes through the `Host` boundary (`NativeHost`), never raw `std::fs`.
+//! All I/O goes through the `Host` boundary — here [`host::CliHost`] (the real filesystem plus an
+//! HTTPS dictionary fetch), never raw `std::fs` or a raw socket.
 //!
 //! The rule set is resolved from config by [`rules::resolve_rules`]: every built-in rule
 //! (`tzlint_rules::builtin_rules`) runs by default, and a `config.rules` entry can disable one.
@@ -12,19 +13,20 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use tzlint_core::io::NativeHost;
 
 use crate::cli::Cli;
+use crate::host::CliHost;
 
 mod app;
 mod cli;
 mod expand;
+mod host;
 mod output;
 mod rules;
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
-    let host = NativeHost;
+    let host = CliHost::new();
     // Resolve the working directory once, here at the edge, and pass it in — the orchestration
     // stays independent of process-global state (and so hermetically testable).
     let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));

--- a/crates/tzlint_core/Cargo.toml
+++ b/crates/tzlint_core/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { workspace = true }
 yaml_serde = { workspace = true }
 blake3 = { workspace = true }
 ruzstd = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 # Reference Draft 2020-12 validator used ONLY by `tests/config_schema.rs` to prove the published

--- a/crates/tzlint_core/src/dict.rs
+++ b/crates/tzlint_core/src/dict.rs
@@ -19,10 +19,13 @@ use std::path::Path;
 use ruzstd::decoding::StreamingDecoder;
 
 use crate::io::{Host, IoError, MAX_DICT};
+use crate::net::{UrlPolicyError, validate_dictionary_url};
 
 /// A failure while provisioning a dictionary.
 #[derive(Debug)]
 pub enum DictError {
+    /// The fetch URL failed the SSRF safety guard (see [`crate::net`]).
+    InvalidUrl(UrlPolicyError),
     /// The compressed blob's BLAKE3 hash did not equal the pinned value (wrong or tampered file).
     HashMismatch,
     /// The blob is not valid zstd / could not be decompressed.
@@ -39,6 +42,7 @@ pub enum DictError {
 impl core::fmt::Display for DictError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            DictError::InvalidUrl(error) => write!(f, "{error}"),
             DictError::HashMismatch => {
                 write!(f, "dictionary hash does not match the pinned value")
             }
@@ -57,6 +61,7 @@ impl std::error::Error for DictError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             DictError::Io(error) => Some(error),
+            DictError::InvalidUrl(error) => Some(error),
             _ => None,
         }
     }
@@ -65,6 +70,12 @@ impl std::error::Error for DictError {
 impl From<IoError> for DictError {
     fn from(error: IoError) -> Self {
         DictError::Io(error)
+    }
+}
+
+impl From<UrlPolicyError> for DictError {
+    fn from(error: UrlPolicyError) -> Self {
+        DictError::InvalidUrl(error)
     }
 }
 
@@ -116,14 +127,55 @@ pub fn provision_dictionary(
     }
 
     let compressed = host.read_bytes(compressed_source, MAX_DICT)?;
+    verify_decompress_and_cache(host, cache_dir, &cache_path, &compressed, pinned_hash)
+}
+
+/// Provision the dictionary pinned to `pinned_hash`, **fetching** the compressed blob from `url`
+/// when it is not already cached.
+///
+/// Identical to [`provision_dictionary`] except the cache-miss source is the network rather than a
+/// local path: `url` is first run through [`validate_dictionary_url`] (the SSRF guard) and only a
+/// URL that passes is handed to [`Host::fetch`]. Everything after acquisition is shared — verify
+/// `blake3 == pin` **before** decompressing, zstd-decompress (bounded by [`MAX_DICT`]), cache the
+/// result, and return it in memory. A cache hit never touches the network at all (so a pinned, already
+/// provisioned dictionary works offline).
+pub fn provision_dictionary_from_url(
+    host: &dyn Host,
+    cache_dir: &Path,
+    url: &str,
+    pinned_hash: &[u8; 32],
+) -> Result<Vec<u8>, DictError> {
+    let cache_path = cache_dir.join(cache_file_name(pinned_hash));
+    if host.exists(&cache_path) {
+        return Ok(host.read_bytes(&cache_path, MAX_DICT)?);
+    }
+
+    // Guard the URL *before* any network access, then fetch through the single egress boundary.
+    let validated = validate_dictionary_url(url)?;
+    let compressed = host.fetch(validated.as_str(), MAX_DICT)?;
+    verify_decompress_and_cache(host, cache_dir, &cache_path, &compressed, pinned_hash)
+}
+
+/// Verify `compressed` against `pinned_hash`, decompress it (bounded by [`MAX_DICT`]), cache the
+/// result at `cache_path` (creating `cache_dir`), and return the decompressed bytes.
+///
+/// The shared **verify → decompress → cache** tail of both provisioning entry points; they differ
+/// only in how `compressed` was acquired (a local read vs a network fetch).
+fn verify_decompress_and_cache(
+    host: &dyn Host,
+    cache_dir: &Path,
+    cache_path: &Path,
+    compressed: &[u8],
+    pinned_hash: &[u8; 32],
+) -> Result<Vec<u8>, DictError> {
     // Verify before decompressing: never process the contents of an unverified blob.
-    if blake3::hash(&compressed).as_bytes() != pinned_hash {
+    if blake3::hash(compressed).as_bytes() != pinned_hash {
         return Err(DictError::HashMismatch);
     }
-    let decompressed = zstd_decompress(&compressed, MAX_DICT)?;
+    let decompressed = zstd_decompress(compressed, MAX_DICT)?;
 
     host.create_dir_all(cache_dir)?;
-    host.write_atomic(&cache_path, &decompressed)?;
+    host.write_atomic(cache_path, &decompressed)?;
     Ok(decompressed)
 }
 
@@ -177,6 +229,66 @@ mod tests {
     fn pin_of(blob: &[u8]) -> [u8; 32] {
         *blake3::hash(blob).as_bytes()
     }
+
+    /// A [`Host`] whose filesystem operations are the real [`NativeHost`] (so caching is exercised
+    /// against a temp dir) but whose [`fetch`](Host::fetch) returns a canned response — modeling the
+    /// CLI's network host without any actual networking. Counts fetches so a test can assert a cache
+    /// hit (or a rejected URL) never reached the network.
+    struct FetchHost {
+        fs: NativeHost,
+        response: Vec<u8>,
+        fail: bool,
+        fetches: std::cell::Cell<u32>,
+    }
+
+    impl FetchHost {
+        fn serving(response: &[u8]) -> Self {
+            FetchHost {
+                fs: NativeHost,
+                response: response.to_vec(),
+                fail: false,
+                fetches: std::cell::Cell::new(0),
+            }
+        }
+        fn failing() -> Self {
+            FetchHost {
+                fs: NativeHost,
+                response: Vec::new(),
+                fail: true,
+                fetches: std::cell::Cell::new(0),
+            }
+        }
+    }
+
+    impl Host for FetchHost {
+        fn read_to_string(&self, path: &Path, limit: usize) -> Result<String, IoError> {
+            self.fs.read_to_string(path, limit)
+        }
+        fn write_atomic(&self, path: &Path, contents: &[u8]) -> Result<(), IoError> {
+            self.fs.write_atomic(path, contents)
+        }
+        fn exists(&self, path: &Path) -> bool {
+            self.fs.exists(path)
+        }
+        fn read_bytes(&self, path: &Path, limit: usize) -> Result<Vec<u8>, IoError> {
+            self.fs.read_bytes(path, limit)
+        }
+        fn create_dir_all(&self, dir: &Path) -> Result<(), IoError> {
+            self.fs.create_dir_all(dir)
+        }
+        fn fetch(&self, _url: &str, limit: usize) -> Result<Vec<u8>, IoError> {
+            self.fetches.set(self.fetches.get() + 1);
+            if self.fail {
+                return Err(IoError::Other("network down".to_string()));
+            }
+            if self.response.len() > limit {
+                return Err(IoError::TooLarge { limit });
+            }
+            Ok(self.response.clone())
+        }
+    }
+
+    const SOURCE_URL: &str = "https://dict.example.com/ja/ipadic.dict.zst";
 
     #[test]
     fn provision_decompresses_caches_and_then_serves_from_the_cache() {
@@ -258,7 +370,83 @@ mod tests {
     }
 
     #[test]
+    fn provision_from_url_fetches_verifies_caches_then_serves_offline() {
+        let dir = temp_dir();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+        let host = FetchHost::serving(FIXTURE);
+
+        // Cache miss: the SSRF guard passes, the blob is fetched, verified, decompressed, cached.
+        let first = provision_dictionary_from_url(&host, &cache_dir, SOURCE_URL, &pinned).unwrap();
+        assert_eq!(first, PAYLOAD.as_bytes());
+        assert_eq!(host.fetches.get(), 1);
+        assert!(host.exists(&cache_dir.join(cache_file_name(&pinned))));
+
+        // Second call hits the cache and must NOT touch the network (works offline once pinned).
+        let second = provision_dictionary_from_url(&host, &cache_dir, SOURCE_URL, &pinned).unwrap();
+        assert_eq!(second, PAYLOAD.as_bytes());
+        assert_eq!(host.fetches.get(), 1, "a cache hit must not fetch");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn provision_from_url_rejects_an_unsafe_url_before_fetching() {
+        let dir = temp_dir();
+        let host = FetchHost::serving(FIXTURE);
+        let pinned = pin_of(FIXTURE);
+        // A cleartext (non-https) URL is refused by the guard …
+        let err = provision_dictionary_from_url(
+            &host,
+            &dir.join("cache"),
+            "http://dict.example.com/d.zst",
+            &pinned,
+        )
+        .unwrap_err();
+        assert!(matches!(err, DictError::InvalidUrl(_)));
+        // … as is a loopback host (an SSRF probe).
+        let err = provision_dictionary_from_url(
+            &host,
+            &dir.join("cache"),
+            "https://127.0.0.1/d.zst",
+            &pinned,
+        )
+        .unwrap_err();
+        assert!(matches!(err, DictError::InvalidUrl(_)));
+        assert_eq!(host.fetches.get(), 0, "an unsafe URL must never be fetched");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn provision_from_url_rejects_a_fetched_blob_whose_hash_is_not_pinned() {
+        let dir = temp_dir();
+        let host = FetchHost::serving(FIXTURE);
+        // The fetched bytes are FIXTURE, but the pin is wrong → rejected after fetch, before
+        // decompression, with nothing cached.
+        let wrong = [0u8; 32];
+        let err = provision_dictionary_from_url(&host, &dir.join("cache"), SOURCE_URL, &wrong)
+            .unwrap_err();
+        assert!(matches!(err, DictError::HashMismatch));
+        assert_eq!(host.fetches.get(), 1);
+        assert!(!host.exists(&dir.join("cache").join(cache_file_name(&wrong))));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn provision_from_url_propagates_a_fetch_failure_as_an_io_error() {
+        let dir = temp_dir();
+        let host = FetchHost::failing();
+        let err =
+            provision_dictionary_from_url(&host, &dir.join("cache"), SOURCE_URL, &pin_of(FIXTURE))
+                .unwrap_err();
+        assert!(matches!(err, DictError::Io(IoError::Other(_))));
+        assert_eq!(host.fetches.get(), 1);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn dict_error_display_and_source() {
+        use crate::net::UrlPolicyError;
         use std::error::Error;
         assert_eq!(
             DictError::HashMismatch.to_string(),
@@ -277,5 +465,9 @@ mod tests {
         assert_eq!(io.to_string(), "file not found");
         assert!(io.source().is_some()); // the Io variant chains its source
         assert!(DictError::HashMismatch.source().is_none());
+        // The InvalidUrl variant forwards the guard's message and chains its source.
+        let bad_url = DictError::InvalidUrl(UrlPolicyError::NotHttps);
+        assert_eq!(bad_url.to_string(), "dictionary URL must use https");
+        assert!(bad_url.source().is_some());
     }
 }

--- a/crates/tzlint_core/src/io.rs
+++ b/crates/tzlint_core/src/io.rs
@@ -150,6 +150,27 @@ pub trait Host {
             "directory creation is not supported by this host".to_string(),
         ))
     }
+
+    /// Fetch the bytes at the (already SSRF-validated) `url` over the network, rejecting a response
+    /// larger than `limit` bytes.
+    ///
+    /// This is the **single network-egress boundary**: morphology-dictionary acquisition reaches
+    /// the network only here, never via a raw socket / HTTP client elsewhere. It is the network
+    /// analogue of [`read_bytes`](Host::read_bytes) and follows the same contract — bounded by
+    /// `limit` (over-size ⇒ [`IoError::TooLarge`]) and **default-`Err`** so a host without network
+    /// access (the wasm-clean core's own [`NativeHost`], a browser embedder) need not provide it.
+    /// The native CLI supplies an implementation (an HTTPS client living *outside* this crate, so
+    /// `tzlint_core` stays free of any networking dependency and keeps building for `wasm32`).
+    ///
+    /// `url` is expected to have already passed [`crate::net::validate_dictionary_url`]; an
+    /// implementation should still apply connect/read timeouts and, ideally, re-validate the
+    /// resolved address (DNS-rebinding defense — see the `net` module docs).
+    fn fetch(&self, url: &str, limit: usize) -> Result<Vec<u8>, IoError> {
+        let _ = (url, limit);
+        Err(IoError::Other(
+            "network fetch is not supported by this host".to_string(),
+        ))
+    }
 }
 
 // The real-filesystem host. Not compiled for `wasm32`, where the embedder injects its own
@@ -527,6 +548,23 @@ mod native {
             ));
             assert!(matches!(host.create_dir_all(p), Err(IoError::Other(_))));
             assert!(matches!(host.list_dir(p), Err(IoError::Other(_))));
+            // `fetch` is likewise optional and network-free hosts (this one, and the core's own
+            // `NativeHost`) inherit the default error rather than reaching the network.
+            assert!(matches!(
+                host.fetch("https://example.com/d.zst", MAX_DICT),
+                Err(IoError::Other(_))
+            ));
+        }
+
+        #[test]
+        fn native_host_does_not_fetch_keeping_the_core_network_free() {
+            // The core's `NativeHost` deliberately does NOT implement `fetch`: the HTTPS client
+            // lives in the CLI so `tzlint_core` carries no networking dependency and stays
+            // wasm-clean. So it inherits the default error rather than reaching the network.
+            assert!(matches!(
+                NativeHost.fetch("https://example.com/d.zst", MAX_DICT),
+                Err(IoError::Other(_))
+            ));
         }
 
         #[test]

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod dict;
 pub mod engine;
 pub mod fix;
 pub mod io;
+pub mod net;
 pub mod parse;
 pub mod position;
 
@@ -31,9 +32,10 @@ pub use config::{
     CONFIG_SCHEMA, Config, ConfigError, ConfigFormat, DiscoveredConfig, Preset, RuleSetting,
     ShadowedCandidate, discover, resolve,
 };
-pub use dict::{DictError, provision_dictionary};
+pub use dict::{DictError, provision_dictionary, provision_dictionary_from_url};
 pub use engine::Engine;
 pub use fix::{FixPass, MAX_FIX_PASSES, apply_fixes, fix};
 pub use io::{DirEntry, EntryKind, Host, IoError};
+pub use net::{UrlPolicyError, validate_dictionary_url};
 pub use parse::{ParseError, parse};
 pub use position::LineIndex;

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -1,0 +1,309 @@
+//! URL safety guard for dictionary fetches — SSRF hardening at the boundary.
+//!
+//! Network acquisition of a morphology dictionary ([`provision_dictionary_from_url`]) hands an
+//! operator-configured URL to a host-side HTTP client. Before any request is made, the URL is run
+//! through [`validate_dictionary_url`], a pure (no-I/O, `wasm32`-clean) guard that rejects the
+//! obvious SSRF vectors so the linter cannot be coaxed into probing internal services:
+//!
+//! - **scheme** must be `https` (no `http`/`file`/`ftp`/… and no cleartext);
+//! - **no credentials** in the authority (`user:pass@host` is refused);
+//! - **literal IP hosts** in loopback / private / link-local / unique-local / multicast /
+//!   unspecified / reserved ranges (IPv4 and IPv6, including IPv4-mapped IPv6) are refused;
+//! - the `localhost` name (and `*.localhost`) is refused.
+//!
+//! What it deliberately does **not** do: resolve DNS. A hostname that *resolves* to an internal
+//! address (DNS-rebinding) is not caught here — that check needs the resolved socket address and
+//! therefore belongs to the host-side fetch, alongside connect/read timeouts. The pinned-hash
+//! verification in [`crate::dict`] is the backstop: even a successful fetch of the wrong endpoint
+//! cannot pass `blake3 == pin`, so the residual risk is "use as a request proxy", which the
+//! literal-IP and `localhost` blocks already cover for the common cases. Resolved-address
+//! re-validation is a documented follow-up on the native fetch.
+//!
+//! [`provision_dictionary_from_url`]: crate::dict::provision_dictionary_from_url
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use url::{Host as UrlHost, Url};
+
+/// Why a candidate dictionary URL was rejected by [`validate_dictionary_url`].
+#[derive(Debug)]
+pub enum UrlPolicyError {
+    /// The string is not a valid absolute URL.
+    Parse(String),
+    /// The scheme is not `https`.
+    NotHttps,
+    /// The authority embeds a username and/or password (`user:pass@host`).
+    HasCredentials,
+    /// The URL has no host component.
+    MissingHost,
+    /// The host is not allowed to be fetched: the `localhost` name or a literal IP address in a
+    /// loopback / private / link-local / unique-local / multicast / unspecified / reserved range.
+    BlockedHost(String),
+}
+
+impl core::fmt::Display for UrlPolicyError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            UrlPolicyError::Parse(reason) => write!(f, "dictionary URL is invalid: {reason}"),
+            UrlPolicyError::NotHttps => write!(f, "dictionary URL must use https"),
+            UrlPolicyError::HasCredentials => {
+                write!(f, "dictionary URL must not embed credentials")
+            }
+            UrlPolicyError::MissingHost => write!(f, "dictionary URL has no host"),
+            UrlPolicyError::BlockedHost(host) => {
+                write!(
+                    f,
+                    "dictionary URL host is not allowed to be fetched: {host}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for UrlPolicyError {}
+
+/// Validate a candidate dictionary URL, returning the parsed [`Url`] when it is safe to fetch.
+///
+/// See the [module docs](self) for the policy and its limits.
+pub fn validate_dictionary_url(raw: &str) -> Result<Url, UrlPolicyError> {
+    let url = Url::parse(raw).map_err(|e| UrlPolicyError::Parse(e.to_string()))?;
+    if url.scheme() != "https" {
+        return Err(UrlPolicyError::NotHttps);
+    }
+    // `username()` is empty and `password()` is `None` when no credentials are present.
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(UrlPolicyError::HasCredentials);
+    }
+    match url.host() {
+        None => return Err(UrlPolicyError::MissingHost),
+        Some(UrlHost::Domain(name)) if is_blocked_domain(name) => {
+            return Err(UrlPolicyError::BlockedHost(name.to_string()));
+        }
+        Some(UrlHost::Ipv4(addr)) if ipv4_is_blocked(addr) => {
+            return Err(UrlPolicyError::BlockedHost(addr.to_string()));
+        }
+        Some(UrlHost::Ipv6(addr)) if ipv6_is_blocked(addr) => {
+            return Err(UrlPolicyError::BlockedHost(addr.to_string()));
+        }
+        Some(_) => {}
+    }
+    Ok(url)
+}
+
+/// Whether a domain name resolves *by name* to the local host (we cannot resolve DNS here, so this
+/// only catches the literal `localhost` family — see the [module docs](self) on what is left to the
+/// host-side fetch).
+///
+/// A single trailing dot is stripped first: the WHATWG parser keeps it on a domain (`localhost.` →
+/// `Domain("localhost.")`), but the fully-qualified `localhost.` still resolves to the loopback
+/// host, so it must match the same rule (otherwise it is a trivial bypass).
+fn is_blocked_domain(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    let normalized = lower.strip_suffix('.').unwrap_or(&lower);
+    normalized == "localhost" || normalized.ends_with(".localhost")
+}
+
+/// Whether an IPv4 literal is in a range that must not be fetched (loopback / private / link-local /
+/// CGNAT-shared / unspecified / broadcast / documentation / multicast / reserved).
+fn ipv4_is_blocked(addr: Ipv4Addr) -> bool {
+    let [a, b, _, _] = addr.octets();
+    addr.is_loopback()        // 127.0.0.0/8
+        || addr.is_private()  // 10/8, 172.16/12, 192.168/16
+        || addr.is_link_local() // 169.254.0.0/16
+        || addr.is_unspecified() // 0.0.0.0
+        || addr.is_broadcast()   // 255.255.255.255
+        || addr.is_documentation() // 192.0.2/24, 198.51.100/24, 203.0.113/24
+        || addr.is_multicast()     // 224.0.0.0/4
+        || a == 0                  // 0.0.0.0/8 ("this network")
+        || (a == 100 && (64..=127).contains(&b)) // 100.64.0.0/10 (CGNAT shared)
+        || a >= 240 // 240.0.0.0/4 (reserved, includes the 255/8 broadcast block)
+}
+
+/// Whether an IPv6 literal is in a range that must not be fetched. An IPv4-mapped address
+/// (`::ffff:a.b.c.d`) is re-checked through the IPv4 rules so a mapped private address cannot slip
+/// through as "just an IPv6 host".
+fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
+    if let Some(mapped) = addr.to_ipv4_mapped() {
+        return ipv4_is_blocked(mapped);
+    }
+    let segments = addr.segments();
+    addr.is_loopback()        // ::1
+        || addr.is_unspecified() // ::
+        || addr.is_multicast()   // ff00::/8
+        || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
+        || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_a_plain_https_url_with_a_public_host() {
+        let url = validate_dictionary_url("https://dict.example.com/ja/ipadic.dict.zst").unwrap();
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), Some("dict.example.com"));
+    }
+
+    #[test]
+    fn accepts_a_public_ipv4_literal() {
+        // A routable public address (one of Google's DNS) is allowed.
+        validate_dictionary_url("https://8.8.8.8/d.zst").unwrap();
+    }
+
+    #[test]
+    fn rejects_a_non_https_scheme() {
+        assert!(matches!(
+            validate_dictionary_url("http://dict.example.com/d.zst"),
+            Err(UrlPolicyError::NotHttps)
+        ));
+        assert!(matches!(
+            validate_dictionary_url("file:///etc/passwd"),
+            Err(UrlPolicyError::NotHttps)
+        ));
+    }
+
+    #[test]
+    fn rejects_embedded_credentials() {
+        assert!(matches!(
+            validate_dictionary_url("https://user:pass@dict.example.com/d.zst"),
+            Err(UrlPolicyError::HasCredentials)
+        ));
+        assert!(matches!(
+            validate_dictionary_url("https://user@dict.example.com/d.zst"),
+            Err(UrlPolicyError::HasCredentials)
+        ));
+    }
+
+    #[test]
+    fn rejects_the_localhost_name() {
+        assert!(matches!(
+            validate_dictionary_url("https://localhost/d.zst"),
+            Err(UrlPolicyError::BlockedHost(_))
+        ));
+        assert!(matches!(
+            validate_dictionary_url("https://LocalHost/d.zst"),
+            Err(UrlPolicyError::BlockedHost(_))
+        ));
+        assert!(matches!(
+            validate_dictionary_url("https://api.localhost/d.zst"),
+            Err(UrlPolicyError::BlockedHost(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_the_localhost_family_with_a_trailing_dot() {
+        // The WHATWG parser keeps a trailing dot on a *domain* (`localhost.` → `Domain("localhost.")`),
+        // and `localhost.` still resolves to the loopback host — so the fully-qualified form must be
+        // blocked too, or it is a trivial bypass of the `localhost` rule.
+        for raw in [
+            "https://localhost./d.zst",
+            "https://LOCALHOST./d.zst",
+            "https://api.localhost./d.zst",
+        ] {
+            assert!(
+                matches!(
+                    validate_dictionary_url(raw),
+                    Err(UrlPolicyError::BlockedHost(_))
+                ),
+                "expected {raw} to be blocked"
+            );
+        }
+        // A public domain with a trailing dot is still allowed (the dot-strip must not over-block).
+        validate_dictionary_url("https://dict.example.com./d.zst").unwrap();
+    }
+
+    #[test]
+    fn rejects_blocked_ipv4_literals() {
+        for host in [
+            "127.0.0.1",       // loopback
+            "10.0.0.5",        // private
+            "172.16.0.1",      // private
+            "192.168.1.1",     // private
+            "169.254.0.1",     // link-local
+            "0.0.0.0",         // unspecified
+            "100.64.0.1",      // CGNAT shared
+            "240.0.0.1",       // reserved
+            "255.255.255.255", // broadcast
+            "224.0.0.1",       // multicast
+            "127.0.0.1.",      // trailing dot — the parser normalizes it to the Ipv4 literal
+            "2130706433",      // 127.0.0.1 in integer form — normalized to the Ipv4 literal
+            "0x7f.0.0.1",      // 127.0.0.1 with a hex octet — normalized to the Ipv4 literal
+        ] {
+            let url = format!("https://{host}/d.zst");
+            assert!(
+                matches!(
+                    validate_dictionary_url(&url),
+                    Err(UrlPolicyError::BlockedHost(_))
+                ),
+                "expected {host} to be blocked"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_blocked_ipv6_literals() {
+        for host in [
+            "[::1]",              // loopback
+            "[::]",               // unspecified
+            "[fc00::1]",          // unique local
+            "[fe80::1]",          // link-local
+            "[ff02::1]",          // multicast
+            "[::ffff:127.0.0.1]", // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",  // IPv4-mapped private
+        ] {
+            let url = format!("https://{host}/d.zst");
+            assert!(
+                matches!(
+                    validate_dictionary_url(&url),
+                    Err(UrlPolicyError::BlockedHost(_))
+                ),
+                "expected {host} to be blocked"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_a_public_ipv6_literal() {
+        validate_dictionary_url("https://[2001:4860:4860::8888]/d.zst").unwrap();
+    }
+
+    #[test]
+    fn rejects_an_unparseable_url() {
+        assert!(matches!(
+            validate_dictionary_url("not a url"),
+            Err(UrlPolicyError::Parse(_))
+        ));
+        // A relative reference has no scheme/host → parse error (it is not an absolute URL).
+        assert!(matches!(
+            validate_dictionary_url("/just/a/path"),
+            Err(UrlPolicyError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn error_display_is_human_readable() {
+        assert_eq!(
+            UrlPolicyError::NotHttps.to_string(),
+            "dictionary URL must use https"
+        );
+        assert_eq!(
+            UrlPolicyError::HasCredentials.to_string(),
+            "dictionary URL must not embed credentials"
+        );
+        assert_eq!(
+            UrlPolicyError::MissingHost.to_string(),
+            "dictionary URL has no host"
+        );
+        assert!(
+            UrlPolicyError::BlockedHost("127.0.0.1".into())
+                .to_string()
+                .contains("127.0.0.1")
+        );
+        assert!(
+            UrlPolicyError::Parse("bad".into())
+                .to_string()
+                .contains("bad")
+        );
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,10 @@ allow = [
     "ISC",
     "Unicode-3.0",
     "Zlib",
+    # Data (not code) license: the Mozilla CA root bundle shipped by `webpki-roots`, pulled in by
+    # `ureq`'s rustls TLS for the CLI dictionary fetch. CDLA-Permissive-2.0 is a permissive,
+    # attribution-only data-sharing license, compatible with this Apache-2.0 project.
+    "CDLA-Permissive-2.0",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

The **network-acquisition** half of dictionary provisioning — the follow-up deliberately deferred from M2g (#38). The compressed blob is now fetched over HTTPS when it is not already cached; the cache-hit path stays fully offline.

The headline design constraint: the SSRF guard and the boundary live in the **wasm-clean core** with **no networking dependency**, while the actual HTTP client lives only in the CLI binary.

### Core (`tzlint_core`, wasm-clean, network-free)
- **`net::validate_dictionary_url`** — a pure (no-I/O) SSRF guard using the `url` crate (spec-conformant parsing avoids parser-differential bypasses). Requires `https`, refuses credentials (`user:pass@`), and blocks the `localhost` family plus literal IPs in loopback / private / link-local / unique-local / multicast / unspecified / reserved ranges — IPv4, IPv6, **and IPv4-mapped IPv6**. It does **not** resolve DNS; resolved-address re-validation (DNS-rebinding) is a documented follow-up, with the pinned-hash check as the backstop.
- **`Host::fetch(url, limit)`** — the single network-egress boundary. Default-`Err` (like `read_bytes` / `create_dir_all`), so the core's own `NativeHost` stays network-free and the wasm build is untouched.
- **`provision_dictionary_from_url`** — cache-hit → guard → `Host::fetch` → the shared verify(`blake3 == pin`) → decompress → cache tail (extracted as `verify_decompress_and_cache`, shared with the existing local-path entry point). New `DictError::InvalidUrl`.

### CLI (`tzlint_cli`, native only)
- **`CliHost`** (`src/host.rs`) — `NativeHost`'s filesystem plus a real HTTPS `fetch` via **`ureq` (rustls)**. `https_only`, `max_redirects(0)` (a redirect target is *not* re-checked by the guard, so following a `3xx` to an internal address would bypass it — operators pin the final URL), connect/recv timeouts, and the one-past-`limit` size cap (`read_to_limit`, unit-testable without a network). The HTTP client lives in the binary, never `tzlint_core`. `main` now runs on `CliHost`.

### Guards / deps
- io-guard CI gains a **network-egress grep**: `ureq` may appear only in `host.rs` (mirrors the existing `std::fs` guard).
- `url` (workspace → core) and `ureq` (rustls; workspace → CLI) added. `cargo-deny` allows webpki-roots' `CDLA-Permissive-2.0` data license (the Mozilla CA bundle).

## Dependency decision (vetted)

- **HTTP client = `ureq` + rustls**, in the CLI (pure-Rust TLS, blocking, no async runtime — fits a one-shot fetch; keeps the core network-free).
- **URL parsing = `url` crate**, in the core (robust SSRF-safe parsing; pure Rust, wasm-clean).

## Tests

TDD throughout: 10 SSRF-guard cases (accept/reject for scheme, credentials, `localhost`, blocked & public IPv4/IPv6, IPv4-mapped, parse errors), 4 `provision_dictionary_from_url` cases (fetch+verify+cache, offline cache hit that never fetches, SSRF reject *before* fetch, post-fetch hash mismatch, fetch-error propagation), `Host::fetch` default-`Err` (+ core `NativeHost` stays network-free), and `CliHost` delegation + `read_to_limit` cap + offline https-only rejection.

`just check` (351 nextest + clippy `-D warnings` + doctests), `just wasm`, both io-guards, and `cargo deny` all green. Coverage: `net.rs` 97.9% / `host.rs` 97.6% lines (the only host gap is the live-transport happy path, an inherent network-I/O boundary).

## Not in scope (follow-ups)
- Resolved-address re-validation (DNS-rebinding) on the native fetch.
- **Cache-hit integrity hardening** (self-verifying cache entry + `NotFound`-as-miss/TOCTOU) — raised by CodeRabbit on #38, deferred by design to **M2m** ("native dict cache hardening"), where it covers both the path and URL entry points coherently. The cache is a trusted local boundary like the document cache; the pin verifies the untrusted *download* once.

## Frozen-ABI / boundary invariants
No AST/ABI change. All network egress goes through `Host::fetch`; all filesystem I/O through `Host`. No `unwrap`/`expect`/`panic!` in library code; core remains `wasm32`-clean and dependency-network-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLIがHTTPSで辞書を取得・検証してキャッシュし、オフラインでも利用可能になりました。
  * ネットワークリクエストにサイズ上限・個別タイムアウト・リダイレクト無効化を導入しました。

* **Security**
  * 辞書URLの厳格な検証（HTTPS限定・資格情報や許可されないホストの拒否）でSSRFを防止します。
  * ネットワーク取得は制約された境界経由のみ許可されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->