### PR TITLE
feat(core): morphology analysis pass integration and WASM spike (M2i)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,14 @@ jobs:
         with:
           targets: wasm32-unknown-unknown, wasm32-wasip1
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build -p tzlint_core --target wasm32-unknown-unknown
+      # The morphology seam must stay wasm-clean with NO native backend (M2i): the frozen model
+      # (`tzlint_ast`), the injected-provider trait (`tzlint_pdk`), and the engine + provider
+      # registry + cache fingerprint (`tzlint_core`) are dictionary-free by default — embedders
+      # inject providers Host-style. Build all three wasm-facing crates for both wasm targets. When
+      # the native morphology backend lands (M2j, lindera) it MUST be cfg/feature-gated so it can
+      # never enter this build; a regression here is the tripwire.
+      - run: cargo build -p tzlint_ast -p tzlint_pdk -p tzlint_core --target wasm32-unknown-unknown
+      - run: cargo build -p tzlint_ast -p tzlint_pdk -p tzlint_core --target wasm32-wasip1
 
   io-guard:
     name: io-guard

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,38 +94,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
 
 [[package]]
 name = "base64"
@@ -222,8 +194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -274,51 +244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -345,12 +280,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "email_address"
@@ -396,12 +325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,61 +347,6 @@ checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
-]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -511,25 +379,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
 
 [[package]]
 name = "hashbrown"
@@ -565,92 +414,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "hyper"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "icu_collections"
@@ -766,12 +533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,72 +545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -875,8 +576,6 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest",
- "rustls",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -942,17 +641,6 @@ name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
-
-[[package]]
-name = "mio"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "munge"
@@ -1066,12 +754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,12 +787,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
@@ -1259,45 +935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,21 +976,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1361,18 +988,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -1385,39 +1000,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1445,57 +1032,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1547,42 +1087,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1614,39 +1128,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1677,113 +1162,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.52.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
@@ -1964,25 +1342,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,16 +1367,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2053,40 +1402,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -253,7 +253,8 @@ fn lint_source(
 ) -> Result<Vec<Diagnostic>, String> {
     let pcfg = processor_config_for(config, ext);
     let rr = region_rules_for(config, ext);
-    lint_document(ext, source, registry, &pcfg, &rr).map_err(|e| e.to_string())
+    // No morphology providers are wired into the CLI yet (native backend is M2j); pass `None`.
+    lint_document(ext, source, registry, &pcfg, &rr, None).map_err(|e| e.to_string())
 }
 
 /// `fix`: lint-and-fix each file to a fixpoint; write changed files in place (or just report

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -294,7 +294,7 @@ fn fix(
             Ok(source) => {
                 let pcfg = processor_config_for(&config, None);
                 let rr = region_rules_for(&config, None);
-                let fixed = tzlint_core::fix(None, &source, &registry, &pcfg, &rr);
+                let fixed = tzlint_core::fix(None, &source, &registry, &pcfg, &rr, None);
                 let did_change = fixed != source;
                 if dry_run {
                     if did_change {
@@ -340,7 +340,7 @@ fn fix(
         let ext = extension_of(path);
         let pcfg = processor_config_for(&config, ext);
         let rr = region_rules_for(&config, ext);
-        let fixed = tzlint_core::fix(ext, &source, &registry, &pcfg, &rr);
+        let fixed = tzlint_core::fix(ext, &source, &registry, &pcfg, &rr, None);
         if fixed == source {
             continue;
         }

--- a/crates/tzlint_core/Cargo.toml
+++ b/crates/tzlint_core/Cargo.toml
@@ -26,5 +26,9 @@ url = { workspace = true }
 # Reference Draft 2020-12 validator used ONLY by `tests/config_schema.rs` to prove the published
 # `CONFIG_SCHEMA` matches the loader. Dev-only: never shipped, never in the wasm32 lib build or
 # the MSRV `cargo build --workspace`. Pinned because its API churns across minor versions.
-jsonschema = "=0.46.5"
+# `default-features = false` drops jsonschema's `resolve-http` retriever (which pulls `reqwest` +
+# `rustls`/`aws-lc-rs` + `tokio`): the test validates a self-contained schema in memory and never
+# fetches remote `$ref`s, so no HTTP client is needed. Keeps the lone vetted HTTP client `ureq`
+# (CLI host) as the only network stack in the tree.
+jsonschema = { version = "=0.46.5", default-features = false }
 serde_json = { workspace = true }

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -548,8 +548,9 @@ pub fn lint_cached(
         return Ok(hit);
     }
 
-    let diagnostics = crate::lint_document(ext, content, registry, processor_cfg, rules)
-        .map_err(CacheError::Parse)?;
+    let diagnostics =
+        crate::lint_document(ext, content, registry, processor_cfg, rules, morphology)
+            .map_err(CacheError::Parse)?;
     cache.insert(key, diagnostics.clone());
     Ok(diagnostics)
 }
@@ -1012,6 +1013,12 @@ mod tests {
             1,
             "miss caches one entry under the morphology-fingerprinted key"
         );
+        // The analysis pass ran through lint_cached: MorphFlag saw the table and fired.
+        assert_eq!(
+            miss.iter().map(|d| d.message.as_str()).collect::<Vec<_>>(),
+            vec!["morph"],
+            "lint_cached must forward the registry so the morphology rule fires"
+        );
         let hit = lint_cached(
             &mut cache,
             Some("md"),
@@ -1067,9 +1074,12 @@ mod tests {
         );
 
         // An active registry (a JA provider + the JA-needing MorphFlag rule) yields a non-empty
-        // fingerprint, so the key differs from `pre_m2`: the call MISSES the seed and recomputes
-        // (MorphFlag is skipped on the None-table path → 0 diagnostics), rather than returning the
-        // marker (len 1). Under the mutant the fingerprint is empty → same key → HIT → marker.
+        // fingerprint, so the key differs from `pre_m2`: the call MISSES the seed and recomputes.
+        // The analysis pass then feeds the table to `Engine::lint`, so MorphFlag FIRES ("morph") —
+        // distinct from the seeded marker ("m") a hit would return. This kills two mutants at once:
+        //   * fingerprint ignores the registry (`Some(_) => Vec::new()`) → same key → HIT → "m";
+        //   * lint_cached drops the registry instead of forwarding it to lint_document → MISS but
+        //     MorphFlag skipped (None table) → empty.
         let mut active = MorphologyRegistry::new();
         active.insert(
             Box::new(WhitespaceProvider::new(Lang::JA)),
@@ -1088,8 +1098,12 @@ mod tests {
         .unwrap();
         assert_eq!(
             out.len(),
-            0,
-            "an active registry must MISS the pre-M2 key (a hit means the fingerprint was not applied)"
+            1,
+            "an active registry must MISS the seed and recompute"
+        );
+        assert_eq!(
+            out[0].message, "morph",
+            "the recompute must run morphology (MorphFlag fired), not return the seeded marker"
         );
     }
 
@@ -1260,7 +1274,8 @@ mod tests {
         let build_rules = || RegionRules::base_only(vec![Box::new(FlagKind::new(NodeKind::TEXT))]);
 
         let fresh =
-            crate::lint_document(Some("csv"), source, &registry, &pcfg, &build_rules()).unwrap();
+            crate::lint_document(Some("csv"), source, &registry, &pcfg, &build_rules(), None)
+                .unwrap();
         assert_eq!(fresh.len(), 2, "two body cells flagged");
 
         let mut cache = DocumentCache::new();

--- a/crates/tzlint_core/src/fix.rs
+++ b/crates/tzlint_core/src/fix.rs
@@ -88,7 +88,9 @@ pub fn fix(
 ) -> String {
     let mut text = source.to_string();
     for _ in 0..MAX_FIX_PASSES {
-        let Ok(diagnostics) = crate::lint_document(ext, &text, registry, processor_cfg, rules)
+        // Morphology is not threaded into the fix loop yet (no provider source until M2j); `None`.
+        let Ok(diagnostics) =
+            crate::lint_document(ext, &text, registry, processor_cfg, rules, None)
         else {
             break;
         };

--- a/crates/tzlint_core/src/fix.rs
+++ b/crates/tzlint_core/src/fix.rs
@@ -85,12 +85,12 @@ pub fn fix(
     registry: &crate::Registry,
     processor_cfg: &crate::ProcessorConfig,
     rules: &crate::RegionRules,
+    morphology: Option<&crate::MorphologyRegistry>,
 ) -> String {
     let mut text = source.to_string();
     for _ in 0..MAX_FIX_PASSES {
-        // Morphology is not threaded into the fix loop yet (no provider source until M2j); `None`.
         let Ok(diagnostics) =
-            crate::lint_document(ext, &text, registry, processor_cfg, rules, None)
+            crate::lint_document(ext, &text, registry, processor_cfg, rules, morphology)
         else {
             break;
         };
@@ -212,7 +212,8 @@ mod tests {
                 "BAD\n",
                 &registry,
                 &crate::ProcessorConfig::default(),
-                &rules
+                &rules,
+                None
             ),
             "ok\n"
         );
@@ -260,7 +261,7 @@ mod tests {
             }),
         };
         let rules = RegionRules::base_only(vec![Box::new(ReplaceXWithY::new())]);
-        let out = fix(Some("csv"), source, &registry, &pcfg, &rules);
+        let out = fix(Some("csv"), source, &registry, &pcfg, &rules, None);
         assert_eq!(out, "id,body\n1,y\n2,y\n");
     }
 
@@ -291,7 +292,76 @@ mod tests {
             &registry,
             &crate::ProcessorConfig::default(),
             &rules,
+            None,
         );
         assert_eq!(out, format!("a{}", "!".repeat(MAX_FIX_PASSES)));
+    }
+
+    struct ReplaceMorphToken {
+        meta: RuleMeta,
+    }
+    impl ReplaceMorphToken {
+        fn new() -> Self {
+            ReplaceMorphToken {
+                meta: RuleMeta::new("replace-morph", Severity::Warning, vec![NodeKind::TEXT])
+                    .with_morphology(tzlint_ast::morphology::Lang::JA),
+            }
+        }
+    }
+    impl Rule for ReplaceMorphToken {
+        fn meta(&self) -> &RuleMeta {
+            &self.meta
+        }
+        fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+            if cx.morphology().is_some() {
+                let spans: Vec<Span> = cx
+                    .tokens_of(node.id())
+                    .filter_map(|token| {
+                        let text = cx.ast().text();
+                        let span = token.surface();
+                        let word = &text[span.start as usize..span.end as usize];
+                        if word == "one" { Some(span) } else { None }
+                    })
+                    .collect();
+                for span in spans {
+                    cx.report_with_fixes(span, "replace-one", [Fix::replace(span, "1")]);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn fix_runs_morphology_when_provided() {
+        use crate::{DictId, MorphologyRegistry};
+        use tzlint_ast::morphology::Lang;
+        use tzlint_pdk::WhitespaceProvider;
+
+        let registry = crate::Registry::with_builtins();
+        let rules = crate::RegionRules::base_only(vec![Box::new(ReplaceMorphToken::new())]);
+        let mut morph = MorphologyRegistry::new();
+        morph.insert(
+            Box::new(WhitespaceProvider::new(Lang::JA)),
+            DictId::from_pin([1; 32]),
+        );
+
+        let out_none = fix(
+            Some("md"),
+            "one two",
+            &registry,
+            &crate::ProcessorConfig::default(),
+            &rules,
+            None,
+        );
+        assert_eq!(out_none, "one two");
+
+        let out_some = fix(
+            Some("md"),
+            "one two",
+            &registry,
+            &crate::ProcessorConfig::default(),
+            &rules,
+            Some(&morph),
+        );
+        assert_eq!(out_some, "1 two");
     }
 }

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -64,6 +64,7 @@ mod tests {
             &reg,
             &ProcessorConfig::default(),
             &RegionRules::base_only(vec![]),
+            None,
         )
         .unwrap();
         assert!(diags.is_empty());

--- a/crates/tzlint_core/src/morphology.rs
+++ b/crates/tzlint_core/src/morphology.rs
@@ -5,22 +5,27 @@
 //! with. `tzlint_core` ships no providers, so an unconfigured run holds an empty registry and is
 //! byte-for-byte identical to the pre-morphology cache key.
 //!
-//! This module's one job today is the **cache fingerprint**: [`MorphologyRegistry::fingerprint`]
-//! folds the *active* dictionaries (registered ∩ required-by-the-enabled-rules) into the
-//! `morphology_fingerprint` slot of the document cache key, so a dictionary upgrade invalidates
-//! stale cached diagnostics. Running providers over a document to build a
-//! [`MorphologyV1`](tzlint_ast::morphology::MorphologyV1) and feeding `Engine::lint` is the
-//! **analysis pass**, deferred to M2l (the first rule that reads tokens); the engine is untouched
-//! here and each registered `provider` is stored but only its [`lang`](MorphologyProvider::lang)
-//! is read this slice. The registry never touches [`Host`](crate::Host), `dict`, or the network,
-//! so it stays `wasm32`-clean and dictionary-free by default.
+//! This module does two things. (1) The **cache fingerprint**:
+//! [`MorphologyRegistry::fingerprint`] folds the *active* dictionaries (registered ∩
+//! required-by-the-enabled-rules) into the `morphology_fingerprint` slot of the document cache key,
+//! so a dictionary upgrade invalidates stale cached diagnostics. (2) The **analysis pass**:
+//! [`MorphologyRegistry::build_table`] runs the active providers over a document's archived AST and
+//! merges their tokens into one [`MorphologyV1`](tzlint_ast::morphology::MorphologyV1) for
+//! `Engine::lint` (wired in at `lint_document`), keyed to the nodes the morphology rules visit. A
+//! real tokenizing backend (lindera, M2j) and the rule that reads the tokens (`no-doubled-joshi`,
+//! M2l) are still to come; the dictionary-free [`WhitespaceProvider`] exercises the seam
+//! end-to-end today. The registry never touches [`Host`](crate::Host), `dict`, or the network, so
+//! it stays `wasm32`-clean and dictionary-free by default.
 
 use core::fmt;
 
 use blake3::Hasher;
 
-use tzlint_ast::morphology::{Lang, MORPHOLOGY_INTERFACE_VERSION};
-use tzlint_pdk::MorphologyProvider;
+use tzlint_ast::morphology::{
+    FeatureKey, Lang, MORPHOLOGY_INTERFACE_VERSION, MorphologyBuilder, MorphologyV1, TokenAttrs,
+};
+use tzlint_ast::{ArchivedAst, NodeKind};
+use tzlint_pdk::{MorphologyError, MorphologyProvider, NodeRef, Rule};
 
 use crate::RegionRules;
 
@@ -56,13 +61,8 @@ impl DictId {
 /// only [`lang`](MorphologyProvider::lang) is read this slice) and the dictionary identity folded
 /// into the fingerprint.
 struct MorphologyEntry {
-    // Stored now so M2l's analysis pass reads the provider for exactly this language without a
-    // second parallel map; only `lang()` is consulted this slice (at `insert`), so the field itself
-    // is not yet read. `expect` (not `allow`) so this trips once M2l uses it — a prompt to drop it.
-    #[expect(
-        dead_code,
-        reason = "read by M2l's analysis pass; only lang() is used this slice"
-    )]
+    // The provider that tokenizes this language; read by [`MorphologyRegistry::active_providers`]
+    // (the analysis pass runs it over the document) and keyed by its own `lang()` at `insert`.
     provider: Box<dyn MorphologyProvider>,
     dict_id: DictId,
 }
@@ -135,6 +135,95 @@ impl MorphologyRegistry {
         }
         hasher.finalize().as_bytes().to_vec()
     }
+
+    /// The providers **active** for `rules`: the registered languages that some rule in `rules`
+    /// requires (`required_lang()`), each with its provider, in `Lang::as_u32()` order. This is the
+    /// analysis-pass counterpart of [`fingerprint`](Self::fingerprint)'s active set, but keyed off
+    /// the already-`for_tag`-resolved rule slice the engine will run (not a whole `RegionRules`).
+    /// Empty when no enabled rule needs a registered language — the analysis pass then builds no
+    /// table (`Engine::lint` runs with `None`, exactly as before morphology).
+    pub(crate) fn active_providers<'a>(
+        &'a self,
+        rules: &[&dyn Rule],
+    ) -> Vec<(Lang, &'a dyn MorphologyProvider)> {
+        let mut required: Vec<Lang> = rules
+            .iter()
+            .filter_map(|r| r.meta().required_lang())
+            .collect();
+        required.sort_by_key(|l| l.as_u32());
+        required.dedup();
+        self.entries
+            .iter()
+            .filter(|(lang, _)| {
+                required
+                    .binary_search_by_key(&lang.as_u32(), |l| l.as_u32())
+                    .is_ok()
+            })
+            .map(|(lang, entry)| (*lang, entry.provider.as_ref()))
+            .collect()
+    }
+
+    /// Run the active providers over `archived` and merge their per-node tokens into one
+    /// [`MorphologyV1`] for `Engine::lint`. Returns `Ok(None)` when no provider is active for
+    /// `rules` (the analysis pass builds no table and the engine runs with `None`, exactly as
+    /// before morphology). Tokens are keyed to the nodes whose kind the active morphology rules
+    /// visit (today `TEXT`) — so `token NodeId == visited NodeId` and `cx.tokens_of(node.id())`
+    /// returns that node's tokens. Each matching node is tokenized in place at its absolute
+    /// `node.span().start`, so every surface stays an absolute `Span` into `Ast::text`.
+    ///
+    /// A provider failure propagates as [`MorphologyError`] (the caller maps it to a parse-style
+    /// error and fails the region's lint) rather than silently dropping a node.
+    pub(crate) fn build_table(
+        &self,
+        archived: &ArchivedAst,
+        rules: &[&dyn Rule],
+    ) -> Result<Option<MorphologyV1>, MorphologyError> {
+        let providers = self.active_providers(rules);
+        if providers.is_empty() {
+            return Ok(None);
+        }
+        // The node kinds the active morphology rules visit — tokens key to exactly these nodes.
+        let active_kinds: Vec<NodeKind> = rules
+            .iter()
+            .filter(|rule| rule.meta().needs_morphology())
+            .flat_map(|rule| rule.meta().node_kinds.iter().copied())
+            .collect();
+
+        // Collect matching nodes via a cycle-safe pre-order walk (mirrors `Engine::lint`), then sort
+        // node-ascending so tokens land in the documented `(node, surface.start)` order.
+        let mut nodes: Vec<NodeRef> = Vec::new();
+        if let Some(root) = NodeRef::root(archived) {
+            let mut visited = vec![false; archived.len()];
+            if let Some(slot) = visited.get_mut(root.id().0 as usize) {
+                *slot = true;
+            }
+            let mut stack = vec![root];
+            while let Some(node) = stack.pop() {
+                if active_kinds.contains(&node.kind()) {
+                    nodes.push(node);
+                }
+                for child in node.children() {
+                    if let Some(slot) = visited.get_mut(child.id().0 as usize)
+                        && !*slot
+                    {
+                        *slot = true;
+                        stack.push(child);
+                    }
+                }
+            }
+        }
+        nodes.sort_by_key(|node| node.id().0);
+
+        let mut builder = MorphologyBuilder::new();
+        for node in nodes {
+            let text = node.text();
+            let base = node.span().start;
+            for (_lang, provider) in &providers {
+                append_table(&mut builder, &provider.analyze(text, base, node.id())?);
+            }
+        }
+        Ok(Some(builder.finish()))
+    }
 }
 
 impl fmt::Debug for MorphologyRegistry {
@@ -159,6 +248,36 @@ impl fmt::Debug for MorphologyRegistry {
 fn put(hasher: &mut Hasher, field: &[u8]) {
     hasher.update(&(field.len() as u64).to_le_bytes());
     hasher.update(field);
+}
+
+/// Re-push every token of `table` into `builder`, re-interning its strings and feature ranges into
+/// the shared pool. This is the only sound merge: concatenating finished tables would corrupt the
+/// pool-local `StrRef`/feature offsets. Out-of-range feature ranges are clamped (never panic),
+/// mirroring the defensive archived accessors.
+fn append_table(builder: &mut MorphologyBuilder, table: &MorphologyV1) {
+    let pool = table.strings.as_str();
+    for token in &table.tokens {
+        let start = (token.features_start as usize).min(table.features.len());
+        let end = start
+            .saturating_add(token.features_len as usize)
+            .min(table.features.len());
+        let features: Vec<(FeatureKey, &str)> = table.features[start..end]
+            .iter()
+            .filter_map(|feature| feature.value.get(pool).map(|value| (feature.key, value)))
+            .collect();
+        builder.push_token(
+            TokenAttrs {
+                node: token.node,
+                surface: token.surface,
+                lang: token.lang,
+                tagset: token.tagset,
+                flags: token.flags,
+            },
+            token.reading.get(pool),
+            token.base_form.get(pool),
+            &features,
+        );
+    }
 }
 
 #[cfg(test)]
@@ -321,6 +440,47 @@ mod tests {
         assert_ne!(
             fold(MORPHOLOGY_INTERFACE_VERSION),
             fold(MORPHOLOGY_INTERFACE_VERSION + 1)
+        );
+    }
+
+    fn as_refs(boxes: &[Box<dyn Rule>]) -> Vec<&dyn Rule> {
+        boxes.iter().map(|b| b.as_ref()).collect()
+    }
+
+    #[test]
+    fn active_providers_is_the_registered_required_intersection() {
+        let mut reg = MorphologyRegistry::new();
+        reg.insert(provider(Lang::JA), DictId::from_pin([1; 32]));
+        reg.insert(provider(Lang::KO), DictId::from_pin([2; 32]));
+
+        // A JA-needing rule → exactly the JA provider.
+        let ja = vec![morph_rule("ja", Lang::JA)];
+        let active = reg.active_providers(&as_refs(&ja));
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].0, Lang::JA);
+        assert_eq!(active[0].1.lang(), Lang::JA);
+
+        // JA + KO needed → both, Lang-ascending (JA=0 before KO=1).
+        let jako = vec![morph_rule("ja", Lang::JA), morph_rule("ko", Lang::KO)];
+        let active = reg.active_providers(&as_refs(&jako));
+        assert_eq!(
+            active.iter().map(|(l, _)| *l).collect::<Vec<_>>(),
+            vec![Lang::JA, Lang::KO]
+        );
+
+        // A required lang with no registered provider is dropped (only JA survives).
+        let mut ja_only = MorphologyRegistry::new();
+        ja_only.insert(provider(Lang::JA), DictId::from_pin([1; 32]));
+        let active = ja_only.active_providers(&as_refs(&jako));
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].0, Lang::JA);
+
+        // No rules → empty; empty registry → empty even when a rule needs JA.
+        assert!(reg.active_providers(&[]).is_empty());
+        assert!(
+            MorphologyRegistry::new()
+                .active_providers(&as_refs(&ja))
+                .is_empty()
         );
     }
 }

--- a/crates/tzlint_core/src/morphology.rs
+++ b/crates/tzlint_core/src/morphology.rs
@@ -219,14 +219,10 @@ impl MorphologyRegistry {
             let text = node.text();
             let base = node.span().start;
 
-            // Keep the analyzed tables alive for the duration of node's temp_tokens collection.
-            let mut tables = Vec::new();
-            for (_lang, provider) in &providers {
-                tables.push(provider.analyze(text, base, node.id())?);
-            }
-
-            let mut temp_tokens = Vec::new();
-            for table in &tables {
+            if providers.len() == 1 {
+                // Fast path: only one provider active (the common case). No temp sorting buffer.
+                let (_lang, provider) = &providers[0];
+                let table = provider.analyze(text, base, node.id())?;
                 let pool = table.strings.as_str();
                 for token in &table.tokens {
                     let start = (token.features_start as usize).min(table.features.len());
@@ -239,7 +235,7 @@ impl MorphologyRegistry {
                             feature.value.get(pool).map(|value| (feature.key, value))
                         })
                         .collect();
-                    temp_tokens.push((
+                    builder.push_token(
                         TokenAttrs {
                             node: token.node,
                             surface: token.surface,
@@ -249,17 +245,53 @@ impl MorphologyRegistry {
                         },
                         token.reading.get(pool),
                         token.base_form.get(pool),
-                        features,
-                    ));
+                        &features,
+                    );
                 }
-            }
+            } else {
+                // Slow path: multiple providers are active (e.g. multi-lingual region).
+                // Collect all tokens, sort them by surface.start to preserve the documented
+                // (node, surface.start) order, and then merge.
+                let mut tables = Vec::new();
+                for (_lang, provider) in &providers {
+                    tables.push(provider.analyze(text, base, node.id())?);
+                }
 
-            // Sort by surface.start to preserve documented (node, surface.start) order
-            // when multiple providers are active for the same node.
-            temp_tokens.sort_by_key(|(attrs, _, _, _)| attrs.surface.start);
+                let mut temp_tokens = Vec::new();
+                for table in &tables {
+                    let pool = table.strings.as_str();
+                    for token in &table.tokens {
+                        let start = (token.features_start as usize).min(table.features.len());
+                        let end = start
+                            .saturating_add(token.features_len as usize)
+                            .min(table.features.len());
+                        let features: Vec<(FeatureKey, &str)> = table.features[start..end]
+                            .iter()
+                            .filter_map(|feature| {
+                                feature.value.get(pool).map(|value| (feature.key, value))
+                            })
+                            .collect();
+                        temp_tokens.push((
+                            TokenAttrs {
+                                node: token.node,
+                                surface: token.surface,
+                                lang: token.lang,
+                                tagset: token.tagset,
+                                flags: token.flags,
+                            },
+                            token.reading.get(pool),
+                            token.base_form.get(pool),
+                            features,
+                        ));
+                    }
+                }
 
-            for (attrs, reading, base_form, features) in temp_tokens {
-                builder.push_token(attrs, reading, base_form, &features);
+                // Sort by surface.start to preserve documented (node, surface.start) order.
+                temp_tokens.sort_by_key(|(attrs, _, _, _)| attrs.surface.start);
+
+                for (attrs, reading, base_form, features) in temp_tokens {
+                    builder.push_token(attrs, reading, base_form, &features);
+                }
             }
         }
         Ok(Some(builder.finish()))

--- a/crates/tzlint_core/src/morphology.rs
+++ b/crates/tzlint_core/src/morphology.rs
@@ -218,8 +218,48 @@ impl MorphologyRegistry {
         for node in nodes {
             let text = node.text();
             let base = node.span().start;
+
+            // Keep the analyzed tables alive for the duration of node's temp_tokens collection.
+            let mut tables = Vec::new();
             for (_lang, provider) in &providers {
-                append_table(&mut builder, &provider.analyze(text, base, node.id())?);
+                tables.push(provider.analyze(text, base, node.id())?);
+            }
+
+            let mut temp_tokens = Vec::new();
+            for table in &tables {
+                let pool = table.strings.as_str();
+                for token in &table.tokens {
+                    let start = (token.features_start as usize).min(table.features.len());
+                    let end = start
+                        .saturating_add(token.features_len as usize)
+                        .min(table.features.len());
+                    let features: Vec<(FeatureKey, &str)> = table.features[start..end]
+                        .iter()
+                        .filter_map(|feature| {
+                            feature.value.get(pool).map(|value| (feature.key, value))
+                        })
+                        .collect();
+                    temp_tokens.push((
+                        TokenAttrs {
+                            node: token.node,
+                            surface: token.surface,
+                            lang: token.lang,
+                            tagset: token.tagset,
+                            flags: token.flags,
+                        },
+                        token.reading.get(pool),
+                        token.base_form.get(pool),
+                        features,
+                    ));
+                }
+            }
+
+            // Sort by surface.start to preserve documented (node, surface.start) order
+            // when multiple providers are active for the same node.
+            temp_tokens.sort_by_key(|(attrs, _, _, _)| attrs.surface.start);
+
+            for (attrs, reading, base_form, features) in temp_tokens {
+                builder.push_token(attrs, reading, base_form, &features);
             }
         }
         Ok(Some(builder.finish()))
@@ -248,36 +288,6 @@ impl fmt::Debug for MorphologyRegistry {
 fn put(hasher: &mut Hasher, field: &[u8]) {
     hasher.update(&(field.len() as u64).to_le_bytes());
     hasher.update(field);
-}
-
-/// Re-push every token of `table` into `builder`, re-interning its strings and feature ranges into
-/// the shared pool. This is the only sound merge: concatenating finished tables would corrupt the
-/// pool-local `StrRef`/feature offsets. Out-of-range feature ranges are clamped (never panic),
-/// mirroring the defensive archived accessors.
-fn append_table(builder: &mut MorphologyBuilder, table: &MorphologyV1) {
-    let pool = table.strings.as_str();
-    for token in &table.tokens {
-        let start = (token.features_start as usize).min(table.features.len());
-        let end = start
-            .saturating_add(token.features_len as usize)
-            .min(table.features.len());
-        let features: Vec<(FeatureKey, &str)> = table.features[start..end]
-            .iter()
-            .filter_map(|feature| feature.value.get(pool).map(|value| (feature.key, value)))
-            .collect();
-        builder.push_token(
-            TokenAttrs {
-                node: token.node,
-                surface: token.surface,
-                lang: token.lang,
-                tagset: token.tagset,
-                flags: token.flags,
-            },
-            token.reading.get(pool),
-            token.base_form.get(pool),
-            &features,
-        );
-    }
 }
 
 #[cfg(test)]
@@ -482,5 +492,98 @@ mod tests {
                 .active_providers(&as_refs(&ja))
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn build_table_sorts_tokens_by_surface_start_when_multiple_providers_active() {
+        use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+        use tzlint_ast::{NodeId, Span};
+        use tzlint_pdk::MorphologyError;
+
+        // A mock provider that returns a token starting at `start`
+        struct StartMockProvider {
+            lang: Lang,
+            start: u32,
+        }
+        impl MorphologyProvider for StartMockProvider {
+            fn lang(&self) -> Lang {
+                self.lang
+            }
+            fn analyze(
+                &self,
+                _text: &str,
+                base: u32,
+                node: NodeId,
+            ) -> Result<MorphologyV1, MorphologyError> {
+                let mut builder = MorphologyBuilder::new();
+                builder.push_token(
+                    TokenAttrs {
+                        node,
+                        surface: Span::new(base + self.start, base + self.start + 1),
+                        lang: self.lang,
+                        tagset: Tagset::IPADIC,
+                        flags: 0,
+                    },
+                    None,
+                    None,
+                    &[],
+                );
+                Ok(builder.finish())
+            }
+        }
+
+        let mut reg = MorphologyRegistry::new();
+        // JA provider returns a token starting at base + 5
+        reg.insert(
+            Box::new(StartMockProvider {
+                lang: Lang::JA,
+                start: 5,
+            }),
+            DictId::from_pin([1; 32]),
+        );
+        // KO provider returns a token starting at base + 2
+        reg.insert(
+            Box::new(StartMockProvider {
+                lang: Lang::KO,
+                start: 2,
+            }),
+            DictId::from_pin([2; 32]),
+        );
+
+        let rule_boxes = [morph_rule("ja", Lang::JA), morph_rule("ko", Lang::KO)];
+        let rules = as_refs(&rule_boxes);
+
+        let source = "0123456789";
+        use tzlint_ast::{Node, OptionNodeId};
+        let ast = tzlint_ast::Ast {
+            nodes: vec![
+                Node {
+                    kind: NodeKind::ROOT,
+                    span: Span::new(0, 10),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::some(NodeId(1)),
+                    next_sibling: OptionNodeId::NONE,
+                },
+                Node {
+                    kind: NodeKind::TEXT,
+                    span: Span::new(0, 10),
+                    parent: NodeId(0),
+                    first_child: OptionNodeId::NONE,
+                    next_sibling: OptionNodeId::NONE,
+                },
+            ],
+            text: source.to_string(),
+            root: NodeId(0),
+        };
+        let bytes = tzlint_ast::to_archive(&ast).unwrap();
+        let archived = tzlint_ast::access(&bytes).unwrap();
+
+        let table = reg.build_table(archived, &rules).unwrap().unwrap();
+        assert_eq!(table.tokens.len(), 2);
+        // KO token (start: 2) must come before JA token (start: 5)
+        assert_eq!(table.tokens[0].lang, Lang::KO);
+        assert_eq!(table.tokens[0].surface.start, 2);
+        assert_eq!(table.tokens[1].lang, Lang::JA);
+        assert_eq!(table.tokens[1].surface.start, 5);
     }
 }

--- a/crates/tzlint_core/src/processor/mod.rs
+++ b/crates/tzlint_core/src/processor/mod.rs
@@ -289,6 +289,7 @@ pub fn lint_document(
     registry: &Registry,
     processor_cfg: &ProcessorConfig,
     rules: &RegionRules,
+    morphology: Option<&crate::MorphologyRegistry>,
 ) -> Result<Vec<Diagnostic>, ParseError> {
     let processor = registry.for_ext(ext);
     let parsed = processor.parse(source, processor_cfg)?;
@@ -296,13 +297,13 @@ pub fn lint_document(
     match parsed {
         Parsed::Ast(ast) => {
             let region_rules = rules.for_tag(&RegionTag::whole());
-            lint_ast_into(&ast, &region_rules, &mut diagnostics)?;
+            lint_ast_into(&ast, &region_rules, morphology, &mut diagnostics)?;
         }
         Parsed::Regions(regions) => {
             for region in &regions {
                 let region_rules = rules.for_tag(&region.tag);
                 for ast in build_region_asts(core::slice::from_ref(region), source)? {
-                    lint_ast_into(&ast, &region_rules, &mut diagnostics)?;
+                    lint_ast_into(&ast, &region_rules, morphology, &mut diagnostics)?;
                 }
             }
         }
@@ -313,17 +314,22 @@ pub fn lint_document(
     Ok(diagnostics)
 }
 
-/// Archive `ast`, lint it with `rules`, and append the diagnostics into `out`.
+/// Archive `ast`, build the morphology table (if a registry is supplied and active for `rules`),
+/// lint with `rules`, and append the diagnostics into `out`.
 ///
-/// This is the **M2 morphology integration point**. Morphology is `None` for now, matching the
-/// cached/CLI/fix paths (M2e/M2h wire the document table elsewhere). For a region produced by a
-/// delimited processor, each cell is an *independent mini-document* with its own text spine and
-/// absolute spans, so a whole-document morphology table would be wrong; per-region provisioning
-/// (segment-the-cell vs skip-on-CSV) is an open question — see design §16. Until then, rules that
-/// require morphology are skipped here by `Engine::lint`.
+/// This is the **M2 morphology integration point**. When `morphology` is `Some` and some enabled
+/// rule requires a registered language, the registry's providers tokenize this AST's nodes into a
+/// [`MorphologyV1`] table that is archived and passed to [`Engine::lint`]; otherwise the table is
+/// `None` and morphology-requiring rules are skipped, byte-for-byte as before. The archived AST and
+/// morphology buffers are siblings in this scope, so both outlive the borrow `Engine::lint` takes.
+///
+/// For a region produced by a delimited processor, each cell is an *independent mini-document* with
+/// its own text spine and absolute spans, so it is tokenized independently here (correct per-cell);
+/// reconciling that with the whole-`RegionRules` cache fingerprint is deferred (see design §16).
 fn lint_ast_into(
     ast: &Ast,
     rules: &[&dyn Rule],
+    morphology: Option<&crate::MorphologyRegistry>,
     out: &mut Vec<Diagnostic>,
 ) -> Result<(), ParseError> {
     let bytes = tzlint_ast::to_archive(ast).map_err(|e| ParseError {
@@ -332,7 +338,33 @@ fn lint_ast_into(
     let archived = tzlint_ast::access(&bytes).map_err(|e| ParseError {
         message: format!("archive failed: {e}"),
     })?;
-    out.extend(crate::Engine::lint(archived, None, rules));
+    // Build the per-document morphology table (None when no provider is active for these rules).
+    let table = match morphology {
+        Some(registry) => registry
+            .build_table(archived, rules)
+            .map_err(|e| ParseError {
+                message: format!("morphology failed: {e}"),
+            })?,
+        None => None,
+    };
+    // Archive it into a sibling buffer that outlives the `Engine::lint` borrow below.
+    let morph_bytes = match &table {
+        Some(table) => Some(
+            tzlint_ast::morphology::to_archive_morphology(table).map_err(|e| ParseError {
+                message: format!("morphology archive failed: {e}"),
+            })?,
+        ),
+        None => None,
+    };
+    let morphology = match &morph_bytes {
+        Some(bytes) => Some(
+            tzlint_ast::morphology::access_morphology(bytes).map_err(|e| ParseError {
+                message: format!("morphology archive failed: {e}"),
+            })?,
+        ),
+        None => None,
+    };
+    out.extend(crate::Engine::lint(archived, morphology, rules));
     Ok(())
 }
 
@@ -456,6 +488,7 @@ mod tests {
             &reg,
             &ProcessorConfig::default(),
             &RegionRules::base_only(vec![]),
+            None,
         )
         .unwrap();
         assert!(diags.is_empty());
@@ -661,8 +694,15 @@ mod tests {
         let rules: Vec<&dyn Rule> = vec![&rule];
         let rr = RegionRules::base_only(vec![Box::new(FlagText::new())]);
 
-        let via_document =
-            lint_document(Some("md"), source, &reg, &ProcessorConfig::default(), &rr).unwrap();
+        let via_document = lint_document(
+            Some("md"),
+            source,
+            &reg,
+            &ProcessorConfig::default(),
+            &rr,
+            None,
+        )
+        .unwrap();
 
         let ast = crate::parse(source).unwrap();
         let bytes = tzlint_ast::to_archive(&ast).unwrap();
@@ -706,6 +746,7 @@ mod tests {
             &reg,
             &ProcessorConfig::default(),
             &rr,
+            None,
         )
         .unwrap();
         assert!(
@@ -718,6 +759,7 @@ mod tests {
             &reg,
             &ProcessorConfig::default(),
             &rr_with_col,
+            None,
         )
         .unwrap();
         assert_eq!(
@@ -876,9 +918,297 @@ mod tests {
             &reg,
             &ProcessorConfig::default(),
             &rr,
+            None,
         )
         .unwrap();
         // The single TEXT node spans the slice 2..7 absolutely.
         assert_eq!(diag_spans(&diags), vec![(2, 7)]);
+    }
+
+    /// End-to-end: an injected `WhitespaceProvider` is run over the document, the per-node
+    /// `MorphologyV1` is built + archived, and a morphology rule reads its tokens via the engine.
+    #[test]
+    fn lint_document_runs_morphology_via_injected_provider() {
+        use crate::{DictId, MorphologyRegistry};
+        use tzlint_ast::morphology::Lang;
+        use tzlint_pdk::WhitespaceProvider;
+
+        struct MorphCount(RuleMeta);
+        impl Rule for MorphCount {
+            fn meta(&self) -> &RuleMeta {
+                &self.0
+            }
+            fn check<'a>(&self, node: NodeRef<'a>, cx: &mut Context<'a>) {
+                let n = cx.tokens_of(node.id()).count();
+                cx.report(node.span(), format!("{n}"));
+            }
+        }
+        let rules = RegionRules::base_only(vec![Box::new(MorphCount(
+            RuleMeta::new("morph-count", Severity::Warning, vec![NodeKind::TEXT])
+                .with_morphology(Lang::JA),
+        ))]);
+        let mut reg = MorphologyRegistry::new();
+        reg.insert(
+            Box::new(WhitespaceProvider::new(Lang::JA)),
+            DictId::from_pin([9; 32]),
+        );
+
+        let diags = lint_document(
+            Some("md"),
+            "one two\n\nthree",
+            &Registry::with_builtins(),
+            &ProcessorConfig::default(),
+            &rules,
+            Some(&reg),
+        )
+        .unwrap();
+
+        // Two TEXT leaves: "one two" → 2 whitespace tokens, "three" → 1. Sorted by span,
+        // paragraph-1's leaf (count 2) precedes paragraph-2's (count 1).
+        assert_eq!(
+            diags.iter().map(|d| d.message.as_str()).collect::<Vec<_>>(),
+            vec!["2", "1"]
+        );
+    }
+
+    /// With no registry (or one with no active language), the morphology rule is skipped and the
+    /// document lints exactly as before — no panic, no spurious tokens.
+    #[test]
+    fn lint_document_without_registry_skips_morphology_rules() {
+        use crate::MorphologyRegistry;
+        use tzlint_ast::morphology::Lang;
+
+        struct MorphFlag(RuleMeta);
+        impl Rule for MorphFlag {
+            fn meta(&self) -> &RuleMeta {
+                &self.0
+            }
+            fn check<'a>(&self, node: NodeRef<'a>, cx: &mut Context<'a>) {
+                cx.report(node.span(), "morph");
+            }
+        }
+        let rules = RegionRules::base_only(vec![Box::new(MorphFlag(
+            RuleMeta::new("morph", Severity::Warning, vec![NodeKind::TEXT])
+                .with_morphology(Lang::JA),
+        ))]);
+        let reg = Registry::with_builtins();
+        let pcfg = ProcessorConfig::default();
+        // None registry and an empty registry both skip the morphology rule entirely.
+        let none = lint_document(Some("md"), "hi", &reg, &pcfg, &rules, None).unwrap();
+        let empty = lint_document(
+            Some("md"),
+            "hi",
+            &reg,
+            &pcfg,
+            &rules,
+            Some(&MorphologyRegistry::new()),
+        )
+        .unwrap();
+        assert!(none.is_empty(), "no registry → morphology rule skipped");
+        assert!(empty.is_empty(), "empty registry → morphology rule skipped");
+    }
+
+    /// Surfaces are absolute `Span`s into the document. A second paragraph's tokens are shifted by
+    /// that node's base offset, so resolving them against `ast.text` yields the original words —
+    /// catching a broken base offset that token counts alone would not (a 0-based offset would make
+    /// paragraph-2's first token resolve to "one t", not "three").
+    #[test]
+    fn lint_document_morphology_surfaces_are_absolute() {
+        use crate::{DictId, MorphologyRegistry};
+        use tzlint_ast::Span;
+        use tzlint_ast::morphology::Lang;
+        use tzlint_pdk::WhitespaceProvider;
+
+        struct MorphSurfaces(RuleMeta);
+        impl Rule for MorphSurfaces {
+            fn meta(&self) -> &RuleMeta {
+                &self.0
+            }
+            fn check<'a>(&self, node: NodeRef<'a>, cx: &mut Context<'a>) {
+                let resolved: Vec<(Span, String)> = {
+                    let text = cx.ast().text();
+                    cx.tokens_of(node.id())
+                        .map(|token| {
+                            let span = token.surface();
+                            let word = text
+                                .get(span.start as usize..span.end as usize)
+                                .unwrap_or("")
+                                .to_string();
+                            (span, word)
+                        })
+                        .collect()
+                };
+                for (span, word) in resolved {
+                    cx.report(span, word);
+                }
+            }
+        }
+        let rules = RegionRules::base_only(vec![Box::new(MorphSurfaces(
+            RuleMeta::new("surfaces", Severity::Warning, vec![NodeKind::TEXT])
+                .with_morphology(Lang::JA),
+        ))]);
+        let mut reg = MorphologyRegistry::new();
+        reg.insert(
+            Box::new(WhitespaceProvider::new(Lang::JA)),
+            DictId::from_pin([1; 32]),
+        );
+
+        let diags = lint_document(
+            Some("md"),
+            "one two\n\nthree",
+            &Registry::with_builtins(),
+            &ProcessorConfig::default(),
+            &rules,
+            Some(&reg),
+        )
+        .unwrap();
+        assert_eq!(
+            diags.iter().map(|d| d.message.as_str()).collect::<Vec<_>>(),
+            vec!["one", "two", "three"]
+        );
+    }
+
+    /// A provider failure propagates as a `ParseError` (the region's lint fails loudly), never a
+    /// panic and never a silently dropped node.
+    #[test]
+    fn lint_document_propagates_provider_errors() {
+        use crate::{DictId, MorphologyRegistry};
+        use tzlint_ast::NodeId;
+        use tzlint_ast::morphology::{Lang, MorphologyV1};
+        use tzlint_pdk::{MorphologyError, MorphologyProvider};
+
+        struct FailingProvider;
+        impl MorphologyProvider for FailingProvider {
+            fn lang(&self) -> Lang {
+                Lang::JA
+            }
+            fn analyze(
+                &self,
+                _text: &str,
+                _base: u32,
+                _node: NodeId,
+            ) -> Result<MorphologyV1, MorphologyError> {
+                Err(MorphologyError::Backend("boom".into()))
+            }
+        }
+        struct NeedsJa(RuleMeta);
+        impl Rule for NeedsJa {
+            fn meta(&self) -> &RuleMeta {
+                &self.0
+            }
+            fn check<'a>(&self, _node: NodeRef<'a>, _cx: &mut Context<'a>) {}
+        }
+        let rules = RegionRules::base_only(vec![Box::new(NeedsJa(
+            RuleMeta::new("needs-ja", Severity::Warning, vec![NodeKind::TEXT])
+                .with_morphology(Lang::JA),
+        ))]);
+        let mut reg = MorphologyRegistry::new();
+        reg.insert(Box::new(FailingProvider), DictId::from_pin([2; 32]));
+
+        let err = lint_document(
+            Some("md"),
+            "hi",
+            &Registry::with_builtins(),
+            &ProcessorConfig::default(),
+            &rules,
+            Some(&reg),
+        )
+        .unwrap_err();
+        assert!(
+            err.message.contains("morphology failed"),
+            "provider error must surface as a ParseError: {}",
+            err.message
+        );
+    }
+
+    /// The merge re-interns each token's reading, base form, and features into the shared pool —
+    /// not just its surface. A provider that emits a rich token must have those fields survive
+    /// `build_table` and be readable by a rule (`WhitespaceProvider` emits none, so it cannot
+    /// exercise this path).
+    #[test]
+    fn lint_document_morphology_merge_preserves_reading_and_features() {
+        use crate::{DictId, MorphologyRegistry};
+        use tzlint_ast::Span;
+        use tzlint_ast::morphology::{
+            FeatureKey, Lang, MorphologyBuilder, MorphologyV1, Tagset, TokenAttrs,
+        };
+        use tzlint_pdk::{MorphologyError, MorphologyProvider};
+
+        struct RichProvider;
+        impl MorphologyProvider for RichProvider {
+            fn lang(&self) -> Lang {
+                Lang::JA
+            }
+            fn analyze(
+                &self,
+                text: &str,
+                base: u32,
+                node: tzlint_ast::NodeId,
+            ) -> Result<MorphologyV1, MorphologyError> {
+                let mut builder = MorphologyBuilder::new();
+                builder.push_token(
+                    TokenAttrs {
+                        node,
+                        surface: Span::new(base, base + text.len() as u32),
+                        lang: Lang::JA,
+                        tagset: Tagset::IPADIC,
+                        flags: 0,
+                    },
+                    Some("ヨミ"),
+                    Some("辞書形"),
+                    &[(FeatureKey::POS, "助詞")],
+                );
+                Ok(builder.finish())
+            }
+        }
+
+        // A rule that reads back each token's reading and POS feature through the merged table.
+        struct ReadFields(RuleMeta);
+        impl Rule for ReadFields {
+            fn meta(&self) -> &RuleMeta {
+                &self.0
+            }
+            fn check<'a>(&self, node: NodeRef<'a>, cx: &mut Context<'a>) {
+                let Some(table) = cx.morphology() else {
+                    return;
+                };
+                let lines: Vec<String> = cx
+                    .tokens_of(node.id())
+                    .map(|token| {
+                        let reading = token.reading(table).unwrap_or("");
+                        let pos = token
+                            .features(table)
+                            .find(|(key, _)| *key == FeatureKey::POS)
+                            .and_then(|(_, value)| value)
+                            .unwrap_or("");
+                        format!("{reading}|{pos}")
+                    })
+                    .collect();
+                for line in lines {
+                    cx.report(node.span(), line);
+                }
+            }
+        }
+        let rules = RegionRules::base_only(vec![Box::new(ReadFields(
+            RuleMeta::new("read-fields", Severity::Warning, vec![NodeKind::TEXT])
+                .with_morphology(Lang::JA),
+        ))]);
+        let mut reg = MorphologyRegistry::new();
+        reg.insert(Box::new(RichProvider), DictId::from_pin([3; 32]));
+
+        let diags = lint_document(
+            Some("md"),
+            "あ",
+            &Registry::with_builtins(),
+            &ProcessorConfig::default(),
+            &rules,
+            Some(&reg),
+        )
+        .unwrap();
+        // The reading and POS feature survived the re-intern in `append_table`.
+        assert_eq!(
+            diags.iter().map(|d| d.message.as_str()).collect::<Vec<_>>(),
+            vec!["ヨミ|助詞"]
+        );
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,6 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-3.0",
-    "Zlib",
     # Data (not code) license: the Mozilla CA root bundle shipped by `webpki-roots`, pulled in by
     # `ureq`'s rustls TLS for the CLI dictionary fetch. CDLA-Permissive-2.0 is a permissive,
     # attribution-only data-sharing license, compatible with this Apache-2.0 project.

--- a/justfile
+++ b/justfile
@@ -23,8 +23,12 @@ lint:
     cargo fmt --all --check
     cargo clippy --workspace --all-targets -- -D warnings
 
+# wasm32 build of the morphology-seam crates (model + injected-provider seam + engine), no native
+# backend — mirrors CI. Both wasm targets; run `rustup target add wasm32-unknown-unknown
+# wasm32-wasip1` once if missing.
 wasm:
-    cargo build -p tzlint_core --target wasm32-unknown-unknown
+    cargo build -p tzlint_ast -p tzlint_pdk -p tzlint_core --target wasm32-unknown-unknown
+    cargo build -p tzlint_ast -p tzlint_pdk -p tzlint_core --target wasm32-wasip1
 
 bench:
     cargo bench --workspace


### PR DESCRIPTION
Part of #41 (M2 morphology). This PR completes the morphology analysis pass integration and builds the morphology seam for `wasm32` target (M2i), and optimizes development dependencies.

## What

Integrates morphology table construction directly into the core analysis loop, wires it up through `lint_cached` / `lint_document`, and hardens `wasm32` build support.

- **Analysis Pass Integration**:
  - Wire `MorphologyRegistry::build_table` into `lint_document` and `lint_ast_into` inside `tzlint_core::processor`.
  - When a `MorphologyRegistry` is supplied and active for the rules, the providers tokenize the AST nodes (like `TEXT`) in-place.
  - The merged table is archived via `to_archive_morphology` and passed to `Engine::lint`, enabling rules needing morphology to receive tokenized data through `Context`.
  - *(Note: The actual `no-doubled-joshi` rule (M2l) is NOT included in this PR and will be implemented as a subsequent step. This PR only implements the analysis pass plumbing needed for it.)*
- **WASM Support (M2i)**:
  - Configure compilation so the entire morphology seam compiles successfully under `wasm32` with no native backend, fulfilling the WASM sandbox constraint.
- **Dependency Cleanups**:
  - Disable `jsonschema`'s default HTTP resolver feature in `Cargo.toml`. This drops transitively-pulled `reqwest`, `tokio`, and TLS dependencies from the dev dependency tree, keeping the build tree minimal.

## Scope (deferred items)

- The actual `no-doubled-joshi` rule (M2l).
- Integrating morphology into the `fix` loop and wiring provider sources into the CLI binary are deferred to **M2j**.
- Delimited processors (like CSV) run analysis per-cell; reconciling that with the whole-`RegionRules` cache fingerprint is deferred (see design §16).

## Tests / quality

- 439 tests, including new unit tests verifying:
  - Absolute byte `Span` alignment for token surfaces.
  - Failure propagation (provider error mapped to `ParseError` and failing the region's lint loudly instead of panicking).
  - High-fidelity merging (re-interning string pool and keeping POS/reading attributes intact).
  - Proper `surface.start` sorting for multi-provider merges.
  - Parity verification in the `fix()` logic when a registry is supplied.
- `fmt`, `clippy -D warnings`, `wasm32` target build (`just wasm`), io-guard, `cargo deny`, and doctests all green.

## Frozen-ABI / boundary invariants

No AST/ABI change to `AstCoreV1` or `MorphologyV1`. The archived AST and morphology buffers are siblings and outlive the `Engine::lint` borrow. All boundary I/O rules are respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)