### PR TITLE
feat(rules): the no-doubled-joshi rule (M2l)

### DIFF
--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -9,8 +9,8 @@
 //! [`RULE_IDS`] is the id list (single source of truth). [`build_rule`] constructs one rule by
 //! id, applying config `options` (via the rule's `from_options`, where it has one) and an
 //! optional severity override; [`builtin_rules`] is the default-constructed full set (every id,
-//! default options, no override). Morphology-dependent rules (e.g. `no-doubled-joshi`) are
-//! deferred to M2 and are not in this crate yet.
+//! default options, no override). The morphology-dependent [`NoDoubledJoshi`] declares
+//! `with_morphology` and runs only when a Japanese morphology table is available.
 
 pub mod rules;
 mod util;
@@ -22,14 +22,14 @@ use serde_json::Value;
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use rules::{
-    ja_no_mixed_period, max_kanji_continuous_len, max_ten, no_exclamation_question_mark,
-    no_hankaku_kana, no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_zero_width_spaces,
-    sentence_length,
+    ja_no_mixed_period, max_kanji_continuous_len, max_ten, no_doubled_joshi,
+    no_exclamation_question_mark, no_hankaku_kana, no_mixed_zenkaku_hankaku_alphabet, no_nfd,
+    no_todo, no_zero_width_spaces, sentence_length,
 };
 pub use rules::{
     ja_no_mixed_period::JaNoMixedPeriod, max_kanji_continuous_len::MaxKanjiContinuousLen,
-    max_ten::MaxTen, no_exclamation_question_mark::NoExclamationQuestionMark,
-    no_hankaku_kana::NoHankakuKana,
+    max_ten::MaxTen, no_doubled_joshi::NoDoubledJoshi,
+    no_exclamation_question_mark::NoExclamationQuestionMark, no_hankaku_kana::NoHankakuKana,
     no_mixed_zenkaku_hankaku_alphabet::NoMixedZenkakuHankakuAlphabet, no_nfd::NoNfd,
     no_todo::NoTodo, no_zero_width_spaces::NoZeroWidthSpaces, sentence_length::SentenceLength,
 };
@@ -47,6 +47,7 @@ pub const RULE_IDS: &[&str] = &[
     no_exclamation_question_mark::ID,
     ja_no_mixed_period::ID,
     no_todo::ID,
+    no_doubled_joshi::ID,
 ];
 
 /// Construct a single built-in rule by `id`, applying config `options` (through the rule's
@@ -69,6 +70,7 @@ pub fn build_rule(id: &str, options: &Value, severity: Option<Severity>) -> Opti
         }
         ja_no_mixed_period::ID => Box::new(JaNoMixedPeriod::new()),
         no_todo::ID => Box::new(NoTodo::from_options(options)),
+        no_doubled_joshi::ID => Box::new(NoDoubledJoshi::from_options(options)),
         _ => return None,
     };
     Some(match severity {
@@ -180,6 +182,10 @@ mod tests {
             "ja-no-mixed-period"
         );
         assert_eq!(NoTodo::default().meta().id.as_str(), "no-todo");
+        assert_eq!(
+            NoDoubledJoshi::default().meta().id.as_str(),
+            "no-doubled-joshi"
+        );
     }
 
     #[test]

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -3,6 +3,7 @@
 pub mod ja_no_mixed_period;
 pub mod max_kanji_continuous_len;
 pub mod max_ten;
+pub mod no_doubled_joshi;
 pub mod no_exclamation_question_mark;
 pub mod no_hankaku_kana;
 pub mod no_mixed_zenkaku_hankaku_alphabet;

--- a/crates/tzlint_rules/src/rules/no_doubled_joshi.rs
+++ b/crates/tzlint_rules/src/rules/no_doubled_joshi.rs
@@ -1,0 +1,846 @@
+//! `no-doubled-joshi` — flag a Japanese 助詞 (particle) repeated within a short same-sentence
+//! window (e.g. 「〜の〜の」), which reads awkwardly.
+//!
+//! This is the first **morphology-dependent** built-in: it declares
+//! [`with_morphology`](RuleMeta::with_morphology) for Japanese, so the engine runs it only when a
+//! morphology table is available (a JA provider is injected). It reads the dictionary
+//! part-of-speech to decide what is a 助詞 and groups repeats by surface + POS, then flags a pair
+//! whose in-sentence gap is shorter than `min_interval`.
+//!
+//! Detection keys on the **IPADIC** POS literal `"助詞"` and IPADIC sub-type strings
+//! (連体化 / 格助詞 / 接続助詞 / 並立助詞). A different tagset (e.g. a UniDic fused `"助詞-係助詞"`)
+//! simply does not match, so the rule no-ops rather than mis-firing — a false negative, never a
+//! false positive. Reconciling the exact POS strings with a real backend is a follow-up (M2j).
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use tzlint_ast::morphology::{ArchivedMorphologyV1, ArchivedToken, FeatureKey, Lang};
+use tzlint_ast::{ArchivedAst, NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-doubled-joshi";
+
+const DEFAULT_MIN_INTERVAL: usize = 1;
+const DEFAULT_SEPARATORS: [char; 7] = ['.', '．', '。', '?', '!', '？', '！'];
+const DEFAULT_COMMAS: [char; 2] = ['、', '，'];
+/// Bracket characters that each add 1 to the gap weight (legacy-fixed, not configurable).
+const BRACKETS: [char; 6] = ['(', ')', '（', '）', '「', '」'];
+/// Particles dropped in non-strict mode (surface, POS sub-type): a repeat of these is idiomatic.
+const EXCEPTIONS: [(&str, &str); 3] = [("の", "連体化"), ("を", "格助詞"), ("て", "接続助詞")];
+
+/// Flags a 助詞 doubled within a short same-sentence window.
+pub struct NoDoubledJoshi {
+    meta: RuleMeta,
+    min_interval: usize,
+    strict: bool,
+    allow: Vec<String>,
+    separator_characters: Vec<char>,
+    comma_characters: Vec<char>,
+}
+
+impl NoDoubledJoshi {
+    /// Construct with default options (`min_interval` 1, non-strict, no `allow`, the default
+    /// separator/comma sets).
+    pub fn new() -> Self {
+        NoDoubledJoshi {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .with_morphology(Lang::JA),
+            min_interval: DEFAULT_MIN_INTERVAL,
+            strict: false,
+            allow: Vec::new(),
+            separator_characters: DEFAULT_SEPARATORS.to_vec(),
+            comma_characters: DEFAULT_COMMAS.to_vec(),
+        }
+    }
+
+    /// Construct from config `options`, leniently (missing/wrong-typed values keep defaults):
+    /// `min_interval` (integer), `strict` (bool), `allow` (array of surface strings),
+    /// `separator_characters` / `comma_characters` (arrays of strings; the first char of each).
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        if let Some(value) = options.get("min_interval").and_then(Value::as_u64) {
+            // Fail open toward "never flag" on a 32-bit target rather than truncating.
+            rule.min_interval = usize::try_from(value).unwrap_or(usize::MAX);
+        }
+        if let Some(strict) = options.get("strict").and_then(Value::as_bool) {
+            rule.strict = strict;
+        }
+        if let Some(array) = options.get("allow").and_then(Value::as_array) {
+            rule.allow = array
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect();
+        }
+        if let Some(chars) = char_list(options, "separator_characters") {
+            rule.separator_characters = chars;
+        }
+        if let Some(chars) = char_list(options, "comma_characters") {
+            rule.comma_characters = chars;
+        }
+        rule
+    }
+}
+
+/// Parse an option that is an array of strings into the first char of each (skipping empties).
+fn char_list(options: &Value, key: &str) -> Option<Vec<char>> {
+    options.get(key).and_then(Value::as_array).map(|array| {
+        array
+            .iter()
+            .filter_map(Value::as_str)
+            .filter_map(|s| s.chars().next())
+            .collect()
+    })
+}
+
+impl Default for NoDoubledJoshi {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoDoubledJoshi {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let Some(table) = cx.morphology() else {
+            return; // belt-and-suspenders over the engine's morphology gate
+        };
+        let ast = cx.ast();
+        let base = node.span().start;
+        let text = node.text();
+
+        // 1. Collect this node's tokens, source-ordered. The `(node, surface.start)` emission order
+        //    is a producer contract the builder does not enforce, so sort defensively.
+        let mut tokens: Vec<&ArchivedToken> = cx.tokens_of(node.id()).collect();
+        tokens.sort_by_key(|t| (t.surface().start, t.surface().end));
+
+        // 2. Extract particles, skipping OOV guesses, `allow`ed surfaces, and (non-strict) the
+        //    idiomatic exceptions の/を/て.
+        let mut particles: Vec<Particle<'ast>> = Vec::new();
+        for (idx, &tok) in tokens.iter().enumerate() {
+            if tok.is_unknown() {
+                continue;
+            }
+            if feature(tok, table, FeatureKey::POS) != Some("助詞") {
+                continue;
+            }
+            let span = tok.surface();
+            let surface = ast.text_of(span).unwrap_or("");
+            if self.allow.iter().any(|allowed| allowed == surface) {
+                continue;
+            }
+            let subtype = feature(tok, table, FeatureKey::POS_SUB_1);
+            if !self.strict
+                && EXCEPTIONS
+                    .iter()
+                    .any(|(s, st)| *s == surface && subtype == Some(*st))
+            {
+                continue;
+            }
+            let prev_word = idx
+                .checked_sub(1)
+                .and_then(|i| ast.text_of(tokens[i].surface()))
+                .unwrap_or("");
+            let key = match subtype {
+                Some(st) => format!("{surface}:助詞.{st}"),
+                None => format!("{surface}:助詞"),
+            };
+            particles.push(Particle {
+                surface,
+                key,
+                start: span.start,
+                end: span.end,
+                tok_idx: idx,
+                prev_word,
+                subtype,
+            });
+        }
+
+        // 3. Merge byte-contiguous particles into 連語 compounds (に+は → には), re-keyed by surface.
+        let mut merged: Vec<Particle<'ast>> = Vec::new();
+        for particle in particles {
+            if let Some(last) = merged.last_mut()
+                && last.end == particle.start
+            {
+                last.end = particle.end;
+                last.surface = ast.text_of(Span::new(last.start, last.end)).unwrap_or("");
+                last.key = format!("{}:連語", last.surface);
+                last.subtype = Some("連語");
+                continue;
+            }
+            merged.push(particle);
+        }
+
+        // 4+5. Group by (sentence index, key). The BTreeMap is deterministic and each group's Vec is
+        //      source-ordered because `merged` is sorted by start.
+        let sentence_idx = |start: u32| -> usize {
+            let upto = start.saturating_sub(base) as usize;
+            text.get(..upto)
+                .unwrap_or("")
+                .chars()
+                .filter(|c| self.separator_characters.contains(c))
+                .count()
+        };
+        let mut groups: BTreeMap<(usize, &str), Vec<usize>> = BTreeMap::new();
+        for (i, particle) in merged.iter().enumerate() {
+            groups
+                .entry((sentence_idx(particle.start), particle.key.as_str()))
+                .or_default()
+                .push(i);
+        }
+
+        // 6. Flag adjacent same-key pairs whose in-sentence gap is under `min_interval`.
+        let mut violations: Vec<(Span, String)> = Vec::new();
+        for members in groups.values() {
+            if members.len() < 2 {
+                continue;
+            }
+            // Non-strict: a group made up only of 並立助詞 (parallel particles) is idiomatic.
+            if !self.strict
+                && members
+                    .iter()
+                    .all(|&i| merged[i].subtype == Some("並立助詞"))
+            {
+                continue;
+            }
+            for pair in members.windows(2) {
+                let prev = &merged[pair[0]];
+                let curr = &merged[pair[1]];
+                if !self.strict && is_ka_douka(prev, curr, &tokens, ast) {
+                    continue;
+                }
+                if self.interval(prev, curr, text, base) < self.min_interval {
+                    violations.push((Span::new(curr.start, curr.end), self.message(prev, curr)));
+                }
+            }
+        }
+
+        for (span, message) in violations {
+            cx.report(span, message);
+        }
+    }
+}
+
+impl NoDoubledJoshi {
+    /// The weighted gap between two particles in the **same** sentence: 0 when they touch; otherwise
+    /// each comma/bracket char in the source between them adds 1. (Separators need no handling here —
+    /// two particles only reach this comparison when they share a sentence index, and by
+    /// construction no separator can lie between same-sentence particles.)
+    fn interval(&self, prev: &Particle, curr: &Particle, text: &str, base: u32) -> usize {
+        if curr.start <= prev.end {
+            return 0;
+        }
+        let lo = prev.end.saturating_sub(base) as usize;
+        let hi = curr.start.saturating_sub(base) as usize;
+        let mut weight = 0usize;
+        for ch in text.get(lo..hi).unwrap_or("").chars() {
+            if self.comma_characters.contains(&ch) || BRACKETS.contains(&ch) {
+                weight += 1;
+            }
+        }
+        weight
+    }
+
+    /// The Japanese diagnostic for a doubled particle (the second occurrence's surface names it).
+    fn message(&self, prev: &Particle, curr: &Particle) -> String {
+        format!(
+            "一文に二回以上利用されている助詞 \"{name}\" がみつかりました。\n\n\
+             次の助詞が連続しているため、文を読みにくくしています。\n\n\
+             {prev_line}\n{curr_line}\n\n\
+             同じ助詞を連続して利用しない、文の中で順番を入れ替える、文を分割するなどを検討してください。",
+            name = curr.surface,
+            prev_line = body_line(prev),
+            curr_line = body_line(curr),
+        )
+    }
+}
+
+/// One extracted particle: its surface text + grouping `key` (surface + POS + sub-type), absolute
+/// byte span, index into the source-sorted token list, the preceding token's surface (for the
+/// message), and its POS sub-type.
+struct Particle<'a> {
+    surface: &'a str,
+    key: String,
+    start: u32,
+    end: u32,
+    tok_idx: usize,
+    prev_word: &'a str,
+    subtype: Option<&'a str>,
+}
+
+/// A message body line: `- {prev_word}"{surface}"`, or `- "{surface}"` at the start of the node.
+fn body_line(particle: &Particle) -> String {
+    if particle.prev_word.is_empty() {
+        format!("- \"{}\"", particle.surface)
+    } else {
+        format!("- {}\"{}\"", particle.prev_word, particle.surface)
+    }
+}
+
+/// Whether `prev`/`curr` are the two か of a かどうか pattern (token-precise: exactly one token
+/// between them in the source stream, whose surface is どう) — skipped in non-strict mode.
+fn is_ka_douka(
+    prev: &Particle,
+    curr: &Particle,
+    tokens: &[&ArchivedToken],
+    ast: &ArchivedAst,
+) -> bool {
+    prev.surface == "か"
+        && curr.surface == "か"
+        && curr.tok_idx == prev.tok_idx + 2
+        && tokens
+            .get(prev.tok_idx + 1)
+            .and_then(|t| ast.text_of(t.surface()))
+            == Some("どう")
+}
+
+/// Resolve a feature value (e.g. POS) of `token` against `table`, or `None`.
+fn feature<'a>(
+    token: &ArchivedToken,
+    table: &'a ArchivedMorphologyV1,
+    key: FeatureKey,
+) -> Option<&'a str> {
+    token
+        .features(table)
+        .find(|(k, _)| *k == key)
+        .and_then(|(_, value)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{diagnose, diagnose_with_morphology};
+    use tzlint_ast::NodeId;
+    use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+
+    /// Push a 助詞 token: surface `[start,end)`, POS=助詞, POS_SUB_1=`subtype`.
+    fn joshi(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32, subtype: &str) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags: 0,
+            },
+            None,
+            None,
+            &[(FeatureKey::POS, "助詞"), (FeatureKey::POS_SUB_1, subtype)],
+        );
+    }
+
+    /// Push a non-particle (noun) token at `[start,end)`.
+    fn word(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags: 0,
+            },
+            None,
+            None,
+            &[(FeatureKey::POS, "名詞")],
+        );
+    }
+
+    #[test]
+    fn flags_doubled_particle() {
+        // 私は彼は : は(係助詞) at 3..6 and 9..12, "彼" between (weight 0 < min 1) → flag the 2nd は.
+        let diags = diagnose_with_morphology(&NoDoubledJoshi::new(), "私は彼は", |pid, b| {
+            word(b, pid, 0, 3); // 私
+            joshi(b, pid, 3, 6, "係助詞"); // は
+            word(b, pid, 6, 9); // 彼
+            joshi(b, pid, 9, 12, "係助詞"); // は
+        });
+        assert_eq!(diags.len(), 1);
+        assert!(
+            diags[0]
+                .message
+                .contains("一文に二回以上利用されている助詞 \"は\""),
+            "{}",
+            diags[0].message
+        );
+        assert_eq!((diags[0].span.start, diags[0].span.end), (9, 12));
+    }
+
+    #[test]
+    fn exception_no_is_not_flagged() {
+        // の(連体化)×2 in non-strict mode → dropped at extraction → no diagnostic.
+        let diags =
+            diagnose_with_morphology(&NoDoubledJoshi::new(), "本のペンの色", |pid, b| {
+                word(b, pid, 0, 3); // 本
+                joshi(b, pid, 3, 6, "連体化"); // の
+                word(b, pid, 6, 12); // ペン
+                joshi(b, pid, 12, 15, "連体化"); // の
+                word(b, pid, 15, 18); // 色
+            });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn sentence_boundary_resets_the_window() {
+        // 私は。彼は : the 。 separator splits the sentences → the two は are not paired.
+        let diags =
+            diagnose_with_morphology(&NoDoubledJoshi::new(), "私は。彼は", |pid, b| {
+                word(b, pid, 0, 3); // 私
+                joshi(b, pid, 3, 6, "係助詞"); // は
+                word(b, pid, 9, 12); // 彼  (。 at 6..9)
+                joshi(b, pid, 12, 15, "係助詞"); // は
+            });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn no_op_without_a_morphology_table() {
+        // In production today (no JA provider injected) the engine passes no table → rule skipped.
+        assert!(diagnose(&NoDoubledJoshi::new(), "私は彼は").is_empty());
+    }
+
+    /// Push a 助詞 token with explicit `flags` (e.g. `Token::FLAG_UNKNOWN`).
+    fn joshi_flagged(
+        b: &mut MorphologyBuilder,
+        node: NodeId,
+        start: u32,
+        end: u32,
+        sub: &str,
+        flags: u32,
+    ) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags,
+            },
+            None,
+            None,
+            &[(FeatureKey::POS, "助詞"), (FeatureKey::POS_SUB_1, sub)],
+        );
+    }
+
+    #[test]
+    fn exception_wo_and_te_are_not_flagged() {
+        // を(格助詞)×2 and て(接続助詞)×2 — idiomatic in non-strict mode.
+        let wo = diagnose_with_morphology(&NoDoubledJoshi::new(), "本を物を", |p, b| {
+            word(b, p, 0, 3);
+            joshi(b, p, 3, 6, "格助詞"); // を
+            word(b, p, 6, 9);
+            joshi(b, p, 9, 12, "格助詞"); // を
+        });
+        assert!(wo.is_empty(), "{wo:?}");
+        let te = diagnose_with_morphology(&NoDoubledJoshi::new(), "見て言て", |p, b| {
+            word(b, p, 0, 3);
+            joshi(b, p, 3, 6, "接続助詞"); // て
+            word(b, p, 6, 9);
+            joshi(b, p, 9, 12, "接続助詞"); // て
+        });
+        assert!(te.is_empty(), "{te:?}");
+    }
+
+    #[test]
+    fn different_subtypes_are_not_doubled() {
+        // と as 格助詞 vs 接続助詞 → different keys → not a repeat.
+        let diags = diagnose_with_morphology(&NoDoubledJoshi::new(), "犬と猫と", |p, b| {
+            word(b, p, 0, 3);
+            joshi(b, p, 3, 6, "格助詞"); // と
+            word(b, p, 6, 9);
+            joshi(b, p, 9, 12, "接続助詞"); // と
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn flags_doubled_de() {
+        // で(格助詞)×2 → flagged.
+        let diags = diagnose_with_morphology(&NoDoubledJoshi::new(), "車で家で", |p, b| {
+            word(b, p, 0, 3);
+            joshi(b, p, 3, 6, "格助詞"); // で
+            word(b, p, 6, 9);
+            joshi(b, p, 9, 12, "格助詞"); // で
+        });
+        assert_eq!(diags.len(), 1);
+        assert!(
+            diags[0].message.contains("助詞 \"で\""),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn parallel_particles_group_is_skipped() {
+        // たり(並立助詞)×2 — a 並立助詞-only group is idiomatic, not flagged.
+        let diags =
+            diagnose_with_morphology(&NoDoubledJoshi::new(), "見たり聞たり", |p, b| {
+                word(b, p, 0, 3);
+                joshi(b, p, 3, 9, "並立助詞"); // たり
+                word(b, p, 9, 12);
+                joshi(b, p, 12, 18, "並立助詞"); // たり
+            });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn ka_douka_pattern_is_not_flagged() {
+        // か…どう…か (かどうか) → the か pair is skipped in non-strict mode.
+        let diags = diagnose_with_morphology(&NoDoubledJoshi::new(), "行かどうか", |p, b| {
+            word(b, p, 0, 3); // 行
+            joshi(b, p, 3, 6, "副助詞"); // か
+            word(b, p, 6, 12); // どう
+            joshi(b, p, 12, 15, "副助詞"); // か
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn three_ka_flags_only_the_non_ka_douka_pair() {
+        // 見かどうか来か: (か1,か3) is かどうか (skipped); (か3,か5) has 来 between (non-contiguous,
+        // not merged) and flags exactly once. The third か is separated by a word so the two later
+        // か are not fused into a 連語.
+        let diags =
+            diagnose_with_morphology(&NoDoubledJoshi::new(), "見かどうか来か", |p, b| {
+                word(b, p, 0, 3); // 見            tok 0
+                joshi(b, p, 3, 6, "副助詞"); // か   tok 1
+                word(b, p, 6, 12); // どう          tok 2
+                joshi(b, p, 12, 15, "副助詞"); // か  tok 3
+                word(b, p, 15, 18); // 来           tok 4
+                joshi(b, p, 18, 21, "副助詞"); // か  tok 5
+            });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (18, 21));
+    }
+
+    #[test]
+    fn comma_raises_interval_to_the_default_threshold() {
+        // 雨は、風は: one 、 between the two は → interval 1, not < default min 1 → passes.
+        let diags = diagnose_with_morphology(&NoDoubledJoshi::new(), "雨は、風は", |p, b| {
+            word(b, p, 0, 3);
+            joshi(b, p, 3, 6, "係助詞"); // は
+            word(b, p, 9, 12); // 風  (、 at 6..9)
+            joshi(b, p, 12, 15, "係助詞"); // は
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+        // min_interval:2 makes interval 1 < 2 → flagged.
+        let strict_gap = diagnose_with_morphology(
+            &NoDoubledJoshi::from_options(&serde_json::json!({"min_interval": 2})),
+            "雨は、風は",
+            |p, b| {
+                word(b, p, 0, 3);
+                joshi(b, p, 3, 6, "係助詞");
+                word(b, p, 9, 12);
+                joshi(b, p, 12, 15, "係助詞");
+            },
+        );
+        assert_eq!(strict_gap.len(), 1);
+    }
+
+    #[test]
+    fn rengo_compound_doubled_is_flagged_but_distinct_keys_are_not() {
+        // 東京には大阪には: に+は merge to には twice → same 連語 key → flagged.
+        let dup = diagnose_with_morphology(
+            &NoDoubledJoshi::new(),
+            "東京には大阪には",
+            |p, b| {
+                word(b, p, 0, 6); // 東京
+                joshi(b, p, 6, 9, "格助詞"); // に
+                joshi(b, p, 9, 12, "係助詞"); // は (contiguous → には)
+                word(b, p, 12, 18); // 大阪
+                joshi(b, p, 18, 21, "格助詞"); // に
+                joshi(b, p, 21, 24, "係助詞"); // は (→ には)
+            },
+        );
+        assert_eq!(dup.len(), 1, "{dup:?}");
+        assert!(
+            dup[0].message.contains("助詞 \"には\""),
+            "{}",
+            dup[0].message
+        );
+        // 東京に大阪には: lone に vs には → different keys → not doubled.
+        let distinct =
+            diagnose_with_morphology(&NoDoubledJoshi::new(), "東京に大阪には", |p, b| {
+                word(b, p, 0, 6); // 東京
+                joshi(b, p, 6, 9, "格助詞"); // に (lone — 大阪 is a word)
+                word(b, p, 9, 15); // 大阪
+                joshi(b, p, 15, 18, "格助詞"); // に
+                joshi(b, p, 18, 21, "係助詞"); // は (→ には)
+            });
+        assert!(distinct.is_empty(), "{distinct:?}");
+    }
+
+    #[test]
+    fn strict_mode_flags_exceptions() {
+        // strict:true disables the の/を/て exception → の×2 flags.
+        let rule = NoDoubledJoshi::from_options(&serde_json::json!({"strict": true}));
+        let diags = diagnose_with_morphology(&rule, "本のペンの", |p, b| {
+            word(b, p, 0, 3); // 本
+            joshi(b, p, 3, 6, "連体化"); // の
+            word(b, p, 6, 12); // ペン
+            joshi(b, p, 12, 15, "連体化"); // の
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn allow_suppresses_a_surface() {
+        // allow:["も"] drops も before any other logic.
+        let rule = NoDoubledJoshi::from_options(&serde_json::json!({"allow": ["も"]}));
+        let diags = diagnose_with_morphology(&rule, "犬も猫も", |p, b| {
+            word(b, p, 0, 3);
+            joshi(b, p, 3, 6, "係助詞"); // も
+            word(b, p, 6, 9);
+            joshi(b, p, 9, 12, "係助詞"); // も
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+        // Without allow, も×2 flags.
+        let flagged = diagnose_with_morphology(&NoDoubledJoshi::new(), "犬も猫も", |p, b| {
+            word(b, p, 0, 3);
+            joshi(b, p, 3, 6, "係助詞");
+            word(b, p, 6, 9);
+            joshi(b, p, 9, 12, "係助詞");
+        });
+        assert_eq!(flagged.len(), 1);
+    }
+
+    #[test]
+    fn detection_is_coupled_to_the_ipadic_pos_literal() {
+        // A token whose major POS is NOT the bare "助詞" literal (e.g. a UniDic-style fused tag) is
+        // not treated as a particle → the rule no-ops (a false negative, never a false positive).
+        let diags = diagnose_with_morphology(&NoDoubledJoshi::new(), "私は彼は", |p, b| {
+            word(b, p, 0, 3);
+            b.push_token(
+                TokenAttrs {
+                    node: p,
+                    surface: Span::new(3, 6),
+                    lang: Lang::JA,
+                    tagset: Tagset::UNIDIC,
+                    flags: 0,
+                },
+                None,
+                None,
+                &[(FeatureKey::POS, "助詞-係助詞")],
+            );
+            word(b, p, 6, 9);
+            b.push_token(
+                TokenAttrs {
+                    node: p,
+                    surface: Span::new(9, 12),
+                    lang: Lang::JA,
+                    tagset: Tagset::UNIDIC,
+                    flags: 0,
+                },
+                None,
+                None,
+                &[(FeatureKey::POS, "助詞-係助詞")],
+            );
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn oov_tokens_are_not_trusted() {
+        use tzlint_ast::morphology::Token;
+        // Both は flagged FLAG_UNKNOWN → skipped (OOV guess not trusted) → 0.
+        let oov = diagnose_with_morphology(&NoDoubledJoshi::new(), "私は彼は", |p, b| {
+            word(b, p, 0, 3);
+            joshi_flagged(b, p, 3, 6, "係助詞", Token::FLAG_UNKNOWN);
+            word(b, p, 6, 9);
+            joshi_flagged(b, p, 9, 12, "係助詞", Token::FLAG_UNKNOWN);
+        });
+        assert!(oov.is_empty(), "{oov:?}");
+        // The same pair without the flag IS flagged — proves the skip is causal.
+        let known = diagnose_with_morphology(&NoDoubledJoshi::new(), "私は彼は", |p, b| {
+            word(b, p, 0, 3);
+            joshi(b, p, 3, 6, "係助詞");
+            word(b, p, 6, 9);
+            joshi(b, p, 9, 12, "係助詞");
+        });
+        assert_eq!(known.len(), 1);
+    }
+
+    #[test]
+    fn defensive_sort_handles_unordered_tokens() {
+        // Push the two は OUT of source order; the rule sorts by surface.start, so it still flags
+        // once at the source-second は (9..12) — proving the in-rule sort, not the producer order.
+        let diags = diagnose_with_morphology(&NoDoubledJoshi::new(), "私は彼は", |p, b| {
+            joshi(b, p, 9, 12, "係助詞"); // は (source-second) pushed FIRST
+            word(b, p, 6, 9);
+            joshi(b, p, 3, 6, "係助詞"); // は (source-first) pushed LAST
+            word(b, p, 0, 3);
+        });
+        assert_eq!(diags.len(), 1);
+        assert_eq!((diags[0].span.start, diags[0].span.end), (9, 12));
+    }
+
+    #[test]
+    fn build_rule_routes_options() {
+        use crate::build_rule;
+        // The options reach the constructed rule: strict flags の×2, default does not.
+        let strict = build_rule(
+            "no-doubled-joshi",
+            &serde_json::json!({"strict": true}),
+            None,
+        )
+        .unwrap();
+        let diags = diagnose_with_morphology(strict.as_ref(), "本のペンの", |p, b| {
+            word(b, p, 0, 3);
+            joshi(b, p, 3, 6, "連体化");
+            word(b, p, 6, 12);
+            joshi(b, p, 12, 15, "連体化");
+        });
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn message_for_a_leading_particle_omits_the_prev_word() {
+        // は犬は: the first は is the very first token (no preceding word) → its body line is the
+        // bare `- "は"` form. Both は share a key and flag once.
+        let diags = diagnose_with_morphology(&NoDoubledJoshi::new(), "は犬は", |p, b| {
+            joshi(b, p, 0, 3, "係助詞"); // は (token 0 — no prev word)
+            word(b, p, 3, 6); // 犬
+            joshi(b, p, 6, 9, "係助詞"); // は
+        });
+        assert_eq!(diags.len(), 1);
+        assert!(
+            diags[0].message.contains("- \"は\""),
+            "{}",
+            diags[0].message
+        );
+        assert!(
+            diags[0].message.contains("- 犬\"は\""),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn custom_separator_splits_sentences() {
+        // A custom separator `♪` resets the window; without it the two は are one sentence → flagged.
+        let src = "雨は♪風は";
+        let build = |p: NodeId, b: &mut MorphologyBuilder| {
+            word(b, p, 0, 3); // 雨
+            joshi(b, p, 3, 6, "係助詞"); // は
+            word(b, p, 9, 12); // 風  (♪ = 3 bytes at 6..9)
+            joshi(b, p, 12, 15, "係助詞"); // は
+        };
+        let custom =
+            NoDoubledJoshi::from_options(&serde_json::json!({"separator_characters": ["♪"]}));
+        assert!(diagnose_with_morphology(&custom, src, build).is_empty());
+        assert_eq!(
+            diagnose_with_morphology(&NoDoubledJoshi::new(), src, build).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn custom_comma_raises_the_interval() {
+        // A custom comma `・` raises the gap to 1 (not < default min 1) → suppressed; default does not.
+        let src = "雨は・風は";
+        let build = |p: NodeId, b: &mut MorphologyBuilder| {
+            word(b, p, 0, 3); // 雨
+            joshi(b, p, 3, 6, "係助詞"); // は
+            word(b, p, 9, 12); // 風  (・ = 3 bytes at 6..9)
+            joshi(b, p, 12, 15, "係助詞"); // は
+        };
+        let custom = NoDoubledJoshi::from_options(&serde_json::json!({"comma_characters": ["・"]}));
+        assert!(diagnose_with_morphology(&custom, src, build).is_empty());
+        assert_eq!(
+            diagnose_with_morphology(&NoDoubledJoshi::new(), src, build).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_bracket_raises_the_interval() {
+        // A bracket between two は raises the gap to 1 (not < default min 1) → suppressed; deleting
+        // the BRACKETS arm of `interval` would flag it instead (mirror of the comma test).
+        let src = "雨は(風は"; // half-width '(' = 1 byte at offset 6
+        let build = |p: NodeId, b: &mut MorphologyBuilder| {
+            word(b, p, 0, 3); // 雨
+            joshi(b, p, 3, 6, "係助詞"); // は
+            word(b, p, 7, 10); // 風  ('(' at 6..7)
+            joshi(b, p, 10, 13, "係助詞"); // は
+        };
+        assert!(diagnose_with_morphology(&NoDoubledJoshi::new(), src, build).is_empty());
+        // min_interval 2 makes the weight-1 bracket gap flag.
+        let strict = NoDoubledJoshi::from_options(&serde_json::json!({"min_interval": 2}));
+        let diags = diagnose_with_morphology(&strict, src, build);
+        assert_eq!(diags.len(), 1);
+        assert_eq!((diags[0].span.start, diags[0].span.end), (10, 13));
+    }
+
+    #[test]
+    fn flags_a_subtype_less_particle() {
+        // A 助詞 with POS but no POS_SUB_1 → key "さ:助詞" (the no-subtype key arm); two flag once.
+        fn joshi_no_subtype(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+            b.push_token(
+                TokenAttrs {
+                    node,
+                    surface: Span::new(start, end),
+                    lang: Lang::JA,
+                    tagset: Tagset::IPADIC,
+                    flags: 0,
+                },
+                None,
+                None,
+                &[(FeatureKey::POS, "助詞")],
+            );
+        }
+        let diags = diagnose_with_morphology(&NoDoubledJoshi::new(), "私さ彼さ", |p, b| {
+            word(b, p, 0, 3);
+            joshi_no_subtype(b, p, 3, 6); // さ
+            word(b, p, 6, 9);
+            joshi_no_subtype(b, p, 9, 12); // さ
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (9, 12));
+    }
+
+    #[test]
+    fn each_sentence_flags_its_own_repeat() {
+        // Positive multi-sentence: は×2 in sentence 0 AND も×2 in sentence 1 → a flag in EACH.
+        let diags = diagnose_with_morphology(
+            &NoDoubledJoshi::new(),
+            "猫は犬は。魚も鳥も",
+            |p, b| {
+                word(b, p, 0, 3); // 猫
+                joshi(b, p, 3, 6, "係助詞"); // は  sentence 0
+                word(b, p, 6, 9); // 犬
+                joshi(b, p, 9, 12, "係助詞"); // は  sentence 0
+                word(b, p, 15, 18); // 魚  (。 at 12..15)
+                joshi(b, p, 18, 21, "係助詞"); // も  sentence 1
+                word(b, p, 21, 24); // 鳥
+                joshi(b, p, 24, 27, "係助詞"); // も  sentence 1
+            },
+        );
+        assert_eq!(diags.len(), 2, "{diags:?}");
+        assert!(diags.iter().any(|d| d.span.end <= 12), "{diags:?}"); // sentence 0
+        assert!(diags.iter().any(|d| d.span.start >= 15), "{diags:?}"); // sentence 1
+    }
+
+    #[test]
+    fn same_particle_across_distant_sentences_is_not_paired() {
+        // は once in sentence 1 and once in sentence 2 → never grouped (sentence_idx 1 vs 2). This
+        // pins that the per-particle sentence index is the sole sentence boundary now the redundant
+        // interval separator-guard is gone: a `min(idx, 1)` clamp would wrongly fuse them and flag.
+        let diags =
+            diagnose_with_morphology(&NoDoubledJoshi::new(), "口。猫は。犬は", |p, b| {
+                word(b, p, 0, 3); // 口  (。 at 3..6)
+                word(b, p, 6, 9); // 猫
+                joshi(b, p, 9, 12, "係助詞"); // は  sentence 1
+                word(b, p, 15, 18); // 犬  (。 at 12..15)
+                joshi(b, p, 18, 21, "係助詞"); // は  sentence 2
+            });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+}

--- a/crates/tzlint_rules/src/test_support.rs
+++ b/crates/tzlint_rules/src/test_support.rs
@@ -19,19 +19,25 @@ pub(crate) fn diagnose(rule: &dyn Rule, source: &str) -> Vec<Diagnostic> {
 
 /// The id of the first `PARAGRAPH` node in document order — discovered at runtime (never
 /// hardcoded), so a parser renumber surfaces as a wrong/empty token set rather than silently.
+///
+/// "First" is decided by absolute byte offset ([`NodeRef::span`]`.start`), *not* by `NodeId`
+/// value: the parser numbers nodes pre-order today, so the two coincide, but selecting on the
+/// byte position keeps this helper honest to its "document order" contract even if a future
+/// renumber breaks that coincidence.
 pub(crate) fn first_paragraph_id(ast: &ArchivedAst) -> NodeId {
-    let mut best: Option<NodeId> = None;
+    let mut best: Option<(u32, NodeId)> = None;
     let mut stack: Vec<NodeRef> = NodeRef::root(ast).into_iter().collect();
     while let Some(node) = stack.pop() {
         if node.kind() == NodeKind::PARAGRAPH {
+            let start = node.span().start;
             best = Some(match best {
-                Some(id) if id.0 <= node.id().0 => id,
-                _ => node.id(),
+                Some((best_start, best_id)) if best_start <= start => (best_start, best_id),
+                _ => (start, node.id()),
             });
         }
         stack.extend(node.children());
     }
-    best.expect("test source has a paragraph")
+    best.map(|(_, id)| id).expect("test source has a paragraph")
 }
 
 /// Run a morphology-reading `rule` over `source` with a **synthetic** [`MorphologyV1`] table: the
@@ -63,4 +69,26 @@ pub(crate) fn diagnose_with_morphology(
     let mbytes = to_archive_morphology(&table).expect("archive morphology");
     let morph = access_morphology(&mbytes).expect("access morphology");
     tzlint_core::Engine::lint(archived, Some(morph), &[rule])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins [`first_paragraph_id`]'s "document order" contract: with two paragraphs it returns
+    /// the byte-first one. Under today's pre-order `NodeId` numbering a min-`NodeId` selection
+    /// would agree, so this can't *fail* against the current parser — it's a regression guard
+    /// that keeps the byte-offset selection honest if a future renumber breaks that coincidence.
+    #[test]
+    fn first_paragraph_id_picks_the_byte_first_paragraph() {
+        let ast = tzlint_core::parse("first para\n\nsecond para\n").expect("parses");
+        let bytes = tzlint_ast::to_archive(&ast).expect("archive");
+        let archived = tzlint_ast::access(&bytes).expect("access");
+
+        let pid = first_paragraph_id(archived);
+        let node = NodeRef::at(archived, pid).expect("the id resolves to a node");
+        assert_eq!(node.kind(), NodeKind::PARAGRAPH);
+        assert_eq!(node.span().start, 0, "must select the byte-first paragraph");
+        assert_eq!(node.text(), "first para");
+    }
 }

--- a/crates/tzlint_rules/src/test_support.rs
+++ b/crates/tzlint_rules/src/test_support.rs
@@ -4,7 +4,9 @@
 //! normal dependency graph, so the rules crate stays free of the engine (and of any future
 //! `tzlint_core → tzlint_rules` cycle).
 
-use tzlint_pdk::{Diagnostic, Rule};
+use tzlint_ast::morphology::{MorphologyBuilder, access_morphology, to_archive_morphology};
+use tzlint_ast::{ArchivedAst, NodeId, NodeKind};
+use tzlint_pdk::{Diagnostic, NodeRef, Rule};
 
 /// Parse `source`, archive it, and run `rule` through `Engine::lint`, returning its diagnostics
 /// (engine-sorted, kind-filtered exactly as in production).
@@ -13,4 +15,52 @@ pub(crate) fn diagnose(rule: &dyn Rule, source: &str) -> Vec<Diagnostic> {
     let bytes = tzlint_ast::to_archive(&ast).expect("archive");
     let archived = tzlint_ast::access(&bytes).expect("access");
     tzlint_core::Engine::lint(archived, None, &[rule])
+}
+
+/// The id of the first `PARAGRAPH` node in document order — discovered at runtime (never
+/// hardcoded), so a parser renumber surfaces as a wrong/empty token set rather than silently.
+pub(crate) fn first_paragraph_id(ast: &ArchivedAst) -> NodeId {
+    let mut best: Option<NodeId> = None;
+    let mut stack: Vec<NodeRef> = NodeRef::root(ast).into_iter().collect();
+    while let Some(node) = stack.pop() {
+        if node.kind() == NodeKind::PARAGRAPH {
+            best = Some(match best {
+                Some(id) if id.0 <= node.id().0 => id,
+                _ => node.id(),
+            });
+        }
+        stack.extend(node.children());
+    }
+    best.expect("test source has a paragraph")
+}
+
+/// Run a morphology-reading `rule` over `source` with a **synthetic** [`MorphologyV1`] table: the
+/// `build` callback receives the first paragraph's [`NodeId`] and a builder, and pushes tokens keyed
+/// to that node (surfaces are absolute byte offsets into the parsed paragraph text). The table is
+/// archived and threaded through `Engine::lint` exactly as the real analysis pass does — so a
+/// `with_morphology` rule actually fires without a real tokenizer backend.
+///
+/// **Fail-loud:** asserts the callback produced ≥1 token keyed to the paragraph, so a `NodeId`/offset
+/// mismatch is a hard failure rather than a vacuously-green (zero-token) test.
+pub(crate) fn diagnose_with_morphology(
+    rule: &dyn Rule,
+    source: &str,
+    build: impl FnOnce(NodeId, &mut MorphologyBuilder),
+) -> Vec<Diagnostic> {
+    let ast = tzlint_core::parse(source).expect("test source parses");
+    let bytes = tzlint_ast::to_archive(&ast).expect("archive");
+    let archived = tzlint_ast::access(&bytes).expect("access");
+    let pid = first_paragraph_id(archived);
+
+    let mut builder = MorphologyBuilder::new();
+    build(pid, &mut builder);
+    let table = builder.finish();
+    assert!(
+        table.tokens.iter().any(|t| t.node == pid),
+        "the build callback pushed no tokens keyed to the paragraph (NodeId/offset mismatch?)"
+    );
+
+    let mbytes = to_archive_morphology(&table).expect("archive morphology");
+    let morph = access_morphology(&mbytes).expect("access morphology");
+    tzlint_core::Engine::lint(archived, Some(morph), &[rule])
 }


### PR DESCRIPTION
Part of #41 (M2 morphology) — the headline deferred rule. The morphology analysis pass is already in `main` (#44), so this targets `main` directly.

## What

Adds `no-doubled-joshi`, the first **morphology-dependent** built-in. It flags a Japanese 助詞 (particle) doubled within a short same-sentence window (「〜の〜の」), reading the frozen `MorphologyV1` table the analysis pass produces. It declares `with_morphology(JA)`, so the engine runs it **only when a Japanese provider is injected** — a no-op in production until the native lindera backend (M2j) lands. It also flips the `builtin_morphology_rules_pin_a_language` tripwire from vacuous to a real guard.

### Algorithm (ported from the legacy prototype, bugs fixed)
- 助詞 detection from the IPADIC POS literal `"助詞"` + sub-types; **の/を/て exceptions**, **並立助詞** group-skip, **連語 merge** (に+は → には), and the **かどうか** pattern.
- 6 legacy bugs fixed: real per-sentence segmentation; token-precise かどうか (not a substring match); deterministic `BTreeMap` grouping; a defensive token sort; multi-codepoint `separator`/`comma`; OOV (`FLAG_UNKNOWN`) skipped before trusting POS.
- Options: `min_interval`, `strict`, `allow`, `separator_characters`, `comma_characters`.

## Scope / safety
- Reads only the frozen `MorphologyV1`; no I/O; `wasm32`-clean; no `unwrap`/`expect`/`panic` in non-test code.
- A non-IPADIC tagset (e.g. a UniDic fused tag) simply no-ops — a false negative, never a false positive; reconciling the exact POS strings with the real backend is an M2j follow-up.
- **Not added to any preset** this slice (it no-ops without a backend).

## Tests / quality
- 25 unit tests against **synthetic `MorphologyV1` tables** via a new `diagnose_with_morphology` seam, mirroring the legacy behavior spec + adversarial-review-driven mutation-resistance tests (bracket weight, subtype-less key, multi-sentence flagging, cross-sentence non-pairing — the last pins that the per-particle sentence index is the sole boundary after a proven-unreachable interval guard was removed).
- Rule coverage 99% line / 100% fn. `fmt`, `clippy -D warnings`, `wasm32`, doctests, and the full 464-test suite green.
- An adversarial review (17 agents) found **0 production bugs**; its 3 confirmed test-coverage gaps were closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 日本語テキスト内の二重助詞を形態素情報を使って検出するルールを追加。形態素テーブルがある場合のみ動作し、strict/allow 等の設定で振る舞いを調整可能。
* **テスト**
  * 形態素対応のテスト支援と多数のユニットテストを追加し、境界・カンマ・括弧・例外パターン等の挙動を検証。
* **その他**
  * 検出メッセージを日本語の文脈付きで生成。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->