### PR TITLE
feat(core): self-verifying dict cache + TOCTOU-safe hit path (M2m)

### DIFF
--- a/crates/tzlint_core/src/dict.rs
+++ b/crates/tzlint_core/src/dict.rs
@@ -8,10 +8,13 @@
 //! download, or an embedder-provided file) and is read through [`Host::read_bytes`].
 //!
 //! The pinned hash is BLAKE3 over the **compressed** blob and is checked *before* decompression,
-//! so a tampered or wrong file is rejected without processing its contents. The decompressed
-//! dictionary is cached **hash-addressed** (filename = hex of the pinned hash), so a dictionary
-//! upgrade — which changes the pinned hash — is a different cache file and never serves the old
-//! one (the cache-invalidation property the dictionary-version tests rely on).
+//! so a tampered or wrong file is rejected without processing its contents. The **verified
+//! compressed blob** is then cached **hash-addressed** (filename = hex of the pinned hash): the
+//! cache stores exactly the bytes the pin verifies, so every load — hit or miss — re-checks
+//! `blake3(file) == pinned_hash` and decompresses on use. A dictionary upgrade changes the pinned
+//! hash, so it is a different cache file and never serves the old one (the cache-invalidation
+//! property the dictionary-version tests rely on); an old pre-M2m cache that stored *decompressed*
+//! bytes simply fails the pin re-check and is transparently re-provisioned once.
 
 use std::io::Read;
 use std::path::Path;
@@ -96,25 +99,27 @@ fn cache_file_name(hash: &[u8; 32]) -> String {
 ///
 /// Returns the dictionary **in memory** (owned bytes), the one representation every host can use —
 /// a browser/wasm embedder has no filesystem path to memory-map. A caller that needs the
-/// dictionary repeatedly should hold onto the returned bytes: the cache-hit path below is an
-/// `O(size)` read, so this is a provision-once-then-reuse API, not a per-use lookup. (A native
-/// backend that would rather mmap the cached file can grow a path-returning variant later, when
-/// such a consumer actually lands — there is none yet.)
+/// dictionary repeatedly should hold onto the returned bytes: even a cache hit re-reads, re-hashes,
+/// and re-decompresses the blob, so this is a provision-once-then-reuse API, not a per-use lookup.
+/// (That per-load decompress is a one-time setup cost under that contract; a native backend that
+/// would rather mmap the cached file can grow a path-returning variant later, when such a consumer
+/// actually lands — there is none yet.)
 ///
-/// **Cache hit:** if the decompressed result is already cached under `cache_dir`, read and return
-/// it. The cache is hash-addressed and was written by a prior successful verification, so the
-/// cached bytes correspond to exactly this pinned blob (the cache is trusted within its directory,
-/// like the document cache). A failed hit-read — a corrupt, truncated, or over-`MAX_DICT` cache
-/// entry — is **surfaced as an error**, not silently treated as a miss: the operator should clear
-/// the cache, matching the cache-write stance below (the document cache, by contrast, rebuilds
-/// best-effort; a soft-miss self-heal here is a deliberate policy left for when the registry lands).
+/// **Cache hit:** [`try_cache_hit`] reads the cached **compressed** blob, re-checks
+/// `blake3(file) == pinned_hash`, and decompresses it on use. Because the cache is content-addressed
+/// by the pin, a verified hit returns offline without touching `compressed_source`. A hit whose
+/// bytes no longer match the pin (bit-rot, truncation, a stale pre-M2m decompressed entry) can only
+/// be benign corruption — the pin cannot be forged — so it is treated as a miss and **self-healed**
+/// by re-provisioning over it. A genuine read fault ([`IoError::TooLarge`]/[`IoError::Other`]) is
+/// **surfaced**, never silently re-provisioned, so a flaky disk is not masked.
 ///
 /// **Cache miss:** read the compressed blob from `compressed_source` through the [`Host`], verify
 /// `blake3(blob) == pinned_hash` **before** decompressing (never process an unverified blob),
-/// zstd-decompress it (bounded by [`MAX_DICT`]), cache the result (creating `cache_dir` and
-/// writing atomically), and return it. A cache-write failure is **surfaced**, not swallowed:
-/// provisioning is a setup step, so a non-writable cache directory is an environment problem the
-/// operator should fix rather than have masked by silently re-decompressing on every run.
+/// zstd-decompress it (bounded by [`MAX_DICT`]) to produce the return value, cache the **verified
+/// compressed blob** (creating `cache_dir` and writing atomically), and return the decompressed
+/// bytes. A cache-write failure is **surfaced**, not swallowed: provisioning is a setup step, so a
+/// non-writable cache directory is an environment problem the operator should fix rather than have
+/// masked by silently re-decompressing on every run.
 pub fn provision_dictionary(
     host: &dyn Host,
     cache_dir: &Path,
@@ -122,8 +127,8 @@ pub fn provision_dictionary(
     pinned_hash: &[u8; 32],
 ) -> Result<Vec<u8>, DictError> {
     let cache_path = cache_dir.join(cache_file_name(pinned_hash));
-    if host.exists(&cache_path) {
-        return Ok(host.read_bytes(&cache_path, MAX_DICT)?);
+    if let Some(hit) = try_cache_hit(host, &cache_path, pinned_hash)? {
+        return Ok(hit);
     }
 
     let compressed = host.read_bytes(compressed_source, MAX_DICT)?;
@@ -135,10 +140,11 @@ pub fn provision_dictionary(
 ///
 /// Identical to [`provision_dictionary`] except the cache-miss source is the network rather than a
 /// local path: `url` is first run through [`validate_dictionary_url`] (the SSRF guard) and only a
-/// URL that passes is handed to [`Host::fetch`]. Everything after acquisition is shared — verify
-/// `blake3 == pin` **before** decompressing, zstd-decompress (bounded by [`MAX_DICT`]), cache the
-/// result, and return it in memory. A cache hit never touches the network at all (so a pinned, already
-/// provisioned dictionary works offline).
+/// URL that passes is handed to [`Host::fetch`]. Everything else is shared — the cache hit (read +
+/// pin re-check + decompress, self-healing a corrupt entry via a re-fetch) and the miss tail
+/// (verify `blake3 == pin` **before** decompressing, zstd-decompress bounded by [`MAX_DICT`], cache
+/// the verified compressed blob, return it in memory). A *verified* cache hit never touches the
+/// network at all (so a pinned, already provisioned dictionary works offline).
 pub fn provision_dictionary_from_url(
     host: &dyn Host,
     cache_dir: &Path,
@@ -146,8 +152,8 @@ pub fn provision_dictionary_from_url(
     pinned_hash: &[u8; 32],
 ) -> Result<Vec<u8>, DictError> {
     let cache_path = cache_dir.join(cache_file_name(pinned_hash));
-    if host.exists(&cache_path) {
-        return Ok(host.read_bytes(&cache_path, MAX_DICT)?);
+    if let Some(hit) = try_cache_hit(host, &cache_path, pinned_hash)? {
+        return Ok(hit);
     }
 
     // Guard the URL *before* any network access, then fetch through the single egress boundary.
@@ -156,11 +162,48 @@ pub fn provision_dictionary_from_url(
     verify_decompress_and_cache(host, cache_dir, &cache_path, &compressed, pinned_hash)
 }
 
+/// Try to serve the dictionary from the hash-addressed cache at `cache_path`.
+///
+/// Returns `Ok(Some(bytes))` for a verified hit (the cached compressed blob re-checked against
+/// `pinned_hash` and decompressed), or `Ok(None)` to fall through to a re-provisioning **miss**.
+/// Two cases become a miss rather than an error:
+/// - **vanished** — [`Host::read_bytes`] returns [`IoError::NotFound`]: either a cold cache or a
+///   file removed between an `exists()` check and the read. Reading directly (no pre-check) and
+///   mapping `NotFound` to a miss closes that TOCTOU window — a benign miss never becomes fatal.
+/// - **corrupt** — the bytes no longer hash to `pinned_hash`: in a content-addressed cache only
+///   benign corruption (bit-rot/truncation/a stale pre-M2m decompressed entry) can do this, since
+///   the pin cannot be forged; self-heal by re-provisioning over it.
+///
+/// Any *other* read fault ([`IoError::TooLarge`]/[`IoError::Other`] — e.g. EIO, or a present but
+/// unreadable file) is **surfaced** as [`DictError::Io`], never silently downgraded to a miss, so a
+/// failing disk is loud rather than masked. `NotFound` is matched specifically for exactly this
+/// reason. A post-verify decompression failure is a logical impossibility (the blob hashed to the
+/// pin, and the pinned blob decompressed cleanly when first cached) but is surfaced if it occurs.
+fn try_cache_hit(
+    host: &dyn Host,
+    cache_path: &Path,
+    pinned_hash: &[u8; 32],
+) -> Result<Option<Vec<u8>>, DictError> {
+    let compressed = match host.read_bytes(cache_path, MAX_DICT) {
+        Ok(bytes) => bytes,
+        Err(IoError::NotFound) => return Ok(None), // vanished/cold → miss
+        Err(other) => return Err(DictError::Io(other)), // genuine fault → surface
+    };
+    if blake3::hash(&compressed).as_bytes() != pinned_hash {
+        return Ok(None); // benign corruption → self-heal as a miss
+    }
+    Ok(Some(zstd_decompress(&compressed, MAX_DICT)?))
+}
+
 /// Verify `compressed` against `pinned_hash`, decompress it (bounded by [`MAX_DICT`]), cache the
-/// result at `cache_path` (creating `cache_dir`), and return the decompressed bytes.
+/// **verified compressed blob** at `cache_path` (creating `cache_dir`), and return the decompressed
+/// bytes.
 ///
 /// The shared **verify → decompress → cache** tail of both provisioning entry points; they differ
-/// only in how `compressed` was acquired (a local read vs a network fetch).
+/// only in how `compressed` was acquired (a local read vs a network fetch). The cached bytes are the
+/// *compressed* blob — the exact bytes the pin hashes — so [`try_cache_hit`] can re-verify a hit
+/// against `pinned_hash`. Decompression happens before the cache write, so a verified-but-corrupt
+/// (non-zstd) blob errors out without leaving a cache entry behind.
 fn verify_decompress_and_cache(
     host: &dyn Host,
     cache_dir: &Path,
@@ -175,7 +218,8 @@ fn verify_decompress_and_cache(
     let decompressed = zstd_decompress(compressed, MAX_DICT)?;
 
     host.create_dir_all(cache_dir)?;
-    host.write_atomic(cache_path, &decompressed)?;
+    // Cache the verified COMPRESSED blob, not the decompressed bytes, so the pin re-verifies a hit.
+    host.write_atomic(cache_path, compressed)?;
     Ok(decompressed)
 }
 
@@ -213,6 +257,19 @@ mod tests {
         0x83, 0x88, 0x85, 0x9e, 0x8c, 0x61,
     ];
     const PAYLOAD: &str = "tsuzulint morphology dictionary fixture — 形態素辞書テスト";
+
+    /// A *second*, distinct payload zstd-compressed offline (`zstd -q -c`); decompresses to
+    /// [`OTHER_PAYLOAD`]. Used to poison the cache with a blob that is **valid zstd** yet whose hash
+    /// differs from the pin — so the `blake3 == pin` re-check (not the decompressor) is what must
+    /// reject it.
+    const OTHER_FIXTURE: &[u8] = &[
+        0x28, 0xb5, 0x2f, 0xfd, 0x24, 0x37, 0xb9, 0x01, 0x00, 0x64, 0x69, 0x66, 0x66, 0x65, 0x72,
+        0x65, 0x6e, 0x74, 0x20, 0x76, 0x61, 0x6c, 0x69, 0x64, 0x20, 0x70, 0x61, 0x79, 0x6c, 0x6f,
+        0x61, 0x64, 0x20, 0xe2, 0x80, 0x94, 0x20, 0xe5, 0x88, 0xa5, 0xe3, 0x81, 0xae, 0xe6, 0x9c,
+        0x89, 0xe5, 0x8a, 0xb9, 0xe3, 0x83, 0x9a, 0xe3, 0x82, 0xa4, 0xe3, 0x83, 0xad, 0xe3, 0x83,
+        0xbc, 0xe3, 0x83, 0x89, 0xcb, 0xeb, 0x70, 0x82,
+    ];
+    const OTHER_PAYLOAD: &str = "different valid payload — 別の有効ペイロード";
 
     /// A unique, freshly-created temp directory (cleaned up by the caller).
     fn temp_dir() -> PathBuf {
@@ -469,5 +526,244 @@ mod tests {
         let bad_url = DictError::InvalidUrl(UrlPolicyError::NotHttps);
         assert_eq!(bad_url.to_string(), "dictionary URL must use https");
         assert!(bad_url.source().is_some());
+    }
+
+    /// A path is a dictionary *cache* entry iff its name ends in `.dict` (see [`cache_file_name`]);
+    /// the source blob is a `.zst`. The fault-injecting mock hosts below key their behavior off
+    /// this so they disturb only the cache read, never the source read.
+    fn is_cache_entry(path: &Path) -> bool {
+        path.extension().is_some_and(|ext| ext == "dict")
+    }
+
+    /// The fault a [`CacheFaultHost`] injects when the *cache* entry is read.
+    enum CacheFault {
+        /// The entry is gone by read time ([`IoError::NotFound`]) — models a cold cache or a file
+        /// removed between an `exists()` hint and the read (the TOCTOU race). Must become a miss.
+        Vanished,
+        /// A genuine read fault ([`IoError::Other`]) — must be **surfaced**, never downgraded to a
+        /// miss (only `NotFound` self-heals).
+        Unreadable,
+        /// An over-[`MAX_DICT`] entry ([`IoError::TooLarge`]) — like `Unreadable`, a genuine fault
+        /// that must be **surfaced**, never treated as a benign miss.
+        Oversize,
+    }
+
+    /// A host that injects a [`CacheFault`] on the *cache* read while source reads/writes stay the
+    /// real [`NativeHost`], so provisioning can still recover. Source-vs-cache is keyed off
+    /// [`is_cache_entry`], so only the cache read is disturbed.
+    ///
+    /// `exists()` answers `true` for the cache entry: the fault models a file that is *present then
+    /// gone/faulty by read time*, not a cold miss. That also makes these hosts discriminate a
+    /// regression that re-introduces an `exists()` pre-check — such a mutant would take the read
+    /// branch (and surface the injected fault) where the current pre-check-free code does not.
+    struct CacheFaultHost {
+        fs: NativeHost,
+        fault: CacheFault,
+    }
+
+    impl Host for CacheFaultHost {
+        fn read_to_string(&self, path: &Path, limit: usize) -> Result<String, IoError> {
+            self.fs.read_to_string(path, limit)
+        }
+        fn write_atomic(&self, path: &Path, contents: &[u8]) -> Result<(), IoError> {
+            self.fs.write_atomic(path, contents)
+        }
+        fn exists(&self, path: &Path) -> bool {
+            is_cache_entry(path) || self.fs.exists(path)
+        }
+        fn read_bytes(&self, path: &Path, limit: usize) -> Result<Vec<u8>, IoError> {
+            if is_cache_entry(path) {
+                return Err(match self.fault {
+                    CacheFault::Vanished => IoError::NotFound,
+                    CacheFault::Unreadable => {
+                        IoError::Other("simulated disk read error".to_string())
+                    }
+                    CacheFault::Oversize => IoError::TooLarge { limit },
+                });
+            }
+            self.fs.read_bytes(path, limit)
+        }
+        fn create_dir_all(&self, dir: &Path) -> Result<(), IoError> {
+            self.fs.create_dir_all(dir)
+        }
+    }
+
+    #[test]
+    fn cache_stores_the_verified_compressed_blob_not_the_decompressed_bytes() {
+        let dir = temp_dir();
+        let host = NativeHost;
+        let source = dir.join("ipadic.zst");
+        host.write_atomic(&source, FIXTURE).unwrap();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+
+        let out = provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap();
+        assert_eq!(out, PAYLOAD.as_bytes());
+        // The cache holds the COMPRESSED blob — the exact bytes `pinned_hash` verifies — so a hit
+        // can re-check `blake3(file) == pin`. (A decompressed cache could not be pin-verified.)
+        // Read the cache file through the host boundary (raw filesystem reads are disallowed here).
+        let cached = host
+            .read_bytes(&cache_dir.join(cache_file_name(&pinned)), MAX_DICT)
+            .unwrap();
+        assert_eq!(
+            cached, FIXTURE,
+            "the cache must store the compressed, pin-verifiable blob"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_corrupt_cache_hit_self_heals_by_reprovisioning() {
+        let dir = temp_dir();
+        let host = NativeHost;
+        let source = dir.join("ipadic.zst");
+        host.write_atomic(&source, FIXTURE).unwrap();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+        let cache_path = cache_dir.join(cache_file_name(&pinned));
+
+        provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap();
+        // Corrupt the entry (bit-rot / truncation analog): bytes that do NOT hash to the pin.
+        host.write_atomic(&cache_path, b"corrupted not-a-dictionary")
+            .unwrap();
+
+        // The next hit re-verifies `blake3 == pin`, finds the mismatch, and self-heals from source.
+        let healed = provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap();
+        assert_eq!(healed, PAYLOAD.as_bytes());
+        // …and the cache is repaired back to the verifiable compressed blob.
+        assert_eq!(host.read_bytes(&cache_path, MAX_DICT).unwrap(), FIXTURE);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_corrupt_cache_hit_with_no_recoverable_source_surfaces_the_error() {
+        let dir = temp_dir();
+        let host = NativeHost;
+        let source = dir.join("ipadic.zst");
+        host.write_atomic(&source, FIXTURE).unwrap();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+        let cache_path = cache_dir.join(cache_file_name(&pinned));
+
+        provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap();
+        host.write_atomic(&cache_path, b"corrupted").unwrap();
+        std::fs::remove_file(&source).unwrap();
+
+        // Self-heal re-acquires; with the source gone the acquisition error is surfaced — the
+        // corrupt bytes are NEVER served.
+        let err = provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap_err();
+        assert!(matches!(err, DictError::Io(IoError::NotFound)));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_vanished_cache_between_check_and_read_is_a_miss_not_a_fatal_error() {
+        // TOCTOU: the entry passes an `exists()` hint but is gone by read time (`NotFound`).
+        // Dropping the pre-check and mapping `NotFound` to a miss keeps provisioning succeeding.
+        let dir = temp_dir();
+        let host = CacheFaultHost {
+            fs: NativeHost,
+            fault: CacheFault::Vanished,
+        };
+        let source = dir.join("ipadic.zst");
+        NativeHost.write_atomic(&source, FIXTURE).unwrap();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+
+        let out = provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap();
+        assert_eq!(out, PAYLOAD.as_bytes());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_corrupt_cache_hit_that_is_still_valid_zstd_but_wrong_hash_self_heals() {
+        // Isolates the `blake3 == pin` re-check from the zstd-decompress guard: the poison entry is
+        // a DIFFERENT but perfectly decodable zstd blob, so the decompressor would happily serve it
+        // — only the pin re-check can reject it. (Models bit-rot landing on a still-valid frame, or
+        // a stale pre-M2m entry.) Without the re-check the wrong dictionary would be served silently.
+        let dir = temp_dir();
+        let host = NativeHost;
+        let source = dir.join("ipadic.zst");
+        host.write_atomic(&source, FIXTURE).unwrap();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+        let cache_path = cache_dir.join(cache_file_name(&pinned));
+
+        provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap();
+        // The poison is valid zstd (it decompresses cleanly) but its hash is not the pin.
+        assert_eq!(
+            zstd_decompress(OTHER_FIXTURE, MAX_DICT).unwrap(),
+            OTHER_PAYLOAD.as_bytes()
+        );
+        assert_ne!(pin_of(OTHER_FIXTURE), pinned);
+        host.write_atomic(&cache_path, OTHER_FIXTURE).unwrap();
+
+        // The pin re-check (not the decompressor) catches the mismatch and self-heals from source.
+        let healed = provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap();
+        assert_eq!(healed, PAYLOAD.as_bytes());
+        assert_eq!(host.read_bytes(&cache_path, MAX_DICT).unwrap(), FIXTURE);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_genuinely_faulty_cache_read_is_surfaced_not_silently_missed() {
+        // Guard: only `NotFound` (and a content hash-mismatch) become a soft miss. A real I/O fault
+        // (`Other`/`TooLarge`) must surface, so a flaky disk is never masked as a re-provision.
+        let dir = temp_dir();
+        let host = CacheFaultHost {
+            fs: NativeHost,
+            fault: CacheFault::Unreadable,
+        };
+        let source = dir.join("ipadic.zst");
+        NativeHost.write_atomic(&source, FIXTURE).unwrap();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+
+        let err = provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap_err();
+        assert!(matches!(err, DictError::Io(IoError::Other(_))));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn an_oversize_cache_entry_is_surfaced_not_silently_re_provisioned() {
+        // `TooLarge` on the cache read is a genuine fault, not a benign miss: it must surface, and
+        // provisioning must NOT fall through to re-read the source (the returned error — rather than
+        // an `Ok` from a healed re-provision — is itself proof there was no fall-through).
+        let dir = temp_dir();
+        let host = CacheFaultHost {
+            fs: NativeHost,
+            fault: CacheFault::Oversize,
+        };
+        let source = dir.join("ipadic.zst");
+        NativeHost.write_atomic(&source, FIXTURE).unwrap();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+
+        let err = provision_dictionary(&host, &cache_dir, &source, &pinned).unwrap_err();
+        assert!(matches!(err, DictError::Io(IoError::TooLarge { .. })));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn from_url_corrupt_cache_hit_self_heals_by_refetching() {
+        let dir = temp_dir();
+        let cache_dir = dir.join("cache");
+        let pinned = pin_of(FIXTURE);
+        let cache_path = cache_dir.join(cache_file_name(&pinned));
+        let host = FetchHost::serving(FIXTURE);
+
+        provision_dictionary_from_url(&host, &cache_dir, SOURCE_URL, &pinned).unwrap();
+        assert_eq!(host.fetches.get(), 1);
+        // Corrupt the cache; the next hit must re-verify, miss, and re-fetch to self-heal.
+        host.fs.write_atomic(&cache_path, b"corrupted").unwrap();
+        let healed = provision_dictionary_from_url(&host, &cache_dir, SOURCE_URL, &pinned).unwrap();
+        assert_eq!(healed, PAYLOAD.as_bytes());
+        assert_eq!(
+            host.fetches.get(),
+            2,
+            "a corrupt cache must trigger a healing re-fetch"
+        );
+        assert_eq!(host.read_bytes(&cache_path, MAX_DICT).unwrap(), FIXTURE);
+        std::fs::remove_dir_all(&dir).ok();
     }
 }


### PR DESCRIPTION
## M2m — dictionary cache hardening

Closes the two cache gaps CodeRabbit flagged on PR #38 (deferred to M2m).

### Problem
- The cache stored the **decompressed** dictionary, but `pinned_hash` is BLAKE3 over the **compressed** blob — so a cache **hit was served with no re-verification** (bit-rot, truncation, or a stale entry passed silently), and a naive `blake3(cache)==pin` would have failed on every hit.
- `host.exists(cache)` → `host.read_bytes(cache)` had a **TOCTOU window**: a file vanishing between the check and the read turned a benign cache miss into a fatal `DictError::Io(NotFound)`.

### Fix — cache the verified compressed blob, reuse the pin
Design picked by a judge-panel (3 integrity schemes, unanimous) and user-approved.

- Cache content changes from the decompressed dictionary to the **verified compressed blob** (filename unchanged, `hex(pin).dict`). Every load re-checks `blake3(file) == pinned_hash` and decompresses on use, so the **pin is an honest content-address** — no new on-disk format, magic, version byte, sidecar, or second hash.
- **TOCTOU**: drop the `exists()` pre-check, read directly, match `IoError::NotFound` **specifically** → soft miss. `TooLarge`/`Other` are **surfaced**, never downgraded to a miss.
- **Corrupt hit → self-heal**: a hash-mismatch on a hit can only be benign corruption (the pin can't be forged), so it re-provisions over the bad entry. Old pre-M2m decompressed entries auto-invalidate and re-provision once.
- Hit logic factored into a shared `try_cache_hit` helper used by both `provision_dictionary` and `provision_dictionary_from_url`.

### Tests
TDD (5 red drivers watched fail first) + 3 mutation-resistance guards added after an adversarial review (4 dims × 3-lens verify, 13 agents → 0 production bugs, 3 test-coverage gaps, all closed):
- valid-zstd-but-wrong-hash entry self-heals (isolates the `blake3` re-check from the decompress guard)
- re-added `exists()` pre-check is discriminated (TOCTOU)
- oversize (`TooLarge`) cache read is surfaced, not silently re-provisioned

All three mutant kills verified empirically (each test FAILs under its mutant, passes after revert).

### Verification
- No new deps, public signatures unchanged, wasm32-clean, no panics/unwraps in lib code.
- `just check` (fmt + clippy -D + tests) ✅, `just wasm` ✅, io-guard greps clean ✅, **447 workspace tests** ✅.
- dict.rs coverage **97.46% line / 95.87% region**; production code fully covered (residual = test-only mock trait methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 辞書キャッシュの整合性検証を強化し、破損したキャッシュの自動修復機能を改善しました。

* **改善**
  * I/O障害時のエラーハンドリングを明確化し、キャッシュ関連の障害からのリカバリーをより堅牢にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->