### PR TITLE
🦀 Ferris: Refactor RuleId to use Arc<str>

### DIFF
--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -11,12 +11,12 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(alloc::sync::Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
     pub fn new(id: impl Into<String>) -> Self {
-        RuleId(id.into())
+        RuleId(alloc::sync::Arc::from(id.into()))
     }
     /// The id as a string slice.
     pub fn as_str(&self) -> &str {
@@ -32,13 +32,13 @@ impl core::fmt::Display for RuleId {
 
 impl From<&str> for RuleId {
     fn from(s: &str) -> Self {
-        RuleId(s.into())
+        RuleId(alloc::sync::Arc::from(s))
     }
 }
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(alloc::sync::Arc::from(s))
     }
 }
 


### PR DESCRIPTION
💡 Improvement: Changed `RuleId` wrapper string type from `String` to `alloc::sync::Arc<str>`. Updated its constructors to use `Arc::from`.
🦀 Why: `RuleId` is an identifier that is frequently cloned during Rule checks and cache operations. Using `Arc<str>` aligns with Ferris's goal of zero-cost abstractions by avoiding an O(N) allocation and string copy for every `.clone()` call, replacing it with an O(1) atomic increment, heavily improving performance for tzlint.
🔍 Verification: Ran `cargo fmt`, `cargo clippy`, and `cargo test`. All pass without regressions.

---
*PR created automatically by Jules for task [16665189420883393318](https://jules.google.com/task/16665189420883393318) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * ルール識別子の内部表現を最適化し、メモリ効率を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->