### PR TITLE
⚡ Bolt: Use Arc<str> for RuleId to reduce cloning overhead

### DIFF
--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -11,12 +11,12 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(alloc::sync::Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
     pub fn new(id: impl Into<String>) -> Self {
-        RuleId(id.into())
+        RuleId(id.into().into())
     }
     /// The id as a string slice.
     pub fn as_str(&self) -> &str {
@@ -38,7 +38,7 @@ impl From<&str> for RuleId {
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(s.into())
     }
 }
 


### PR DESCRIPTION
💡 **What:** The inner type of `RuleId` was changed from `String` to `Arc<str>`.
🎯 **Why:** `RuleId` instances are frequently cloned during parsing and reporting diagnostics, leading to multiple costly string allocations. 
📊 **Impact:** Reduces memory allocations for cloning `RuleId` identifiers to effectively zero (just a reference count increment).
🔬 **Measurement:** Verification passes on `cargo test --workspace` without any regressions. The API is preserved.

---
*PR created automatically by Jules for task [3193943484452365334](https://jules.google.com/task/3193943484452365334) started by @simorgh3196*