### PR TITLE
🦀 Ferris: [Use Arc<str> for RuleId to avoid cloning overhead]

### DIFF
--- a/.jules/ferris.md
+++ b/.jules/ferris.md
@@ -1,0 +1,3 @@
+## 2024-06-07 - [Arc<str> over String for immutable identifiers]
+**Learning:** Using `Arc<str>` for types that are used extensively as identifiers (e.g. `RuleId`) provides significant performance improvements compared to a plain `String` since these are mostly read-only, avoiding many expensive deep clones.
+**Action:** Use `Arc<str>` or `Arc<[T]>` for similar types when implementing or refactoring codebase identifiers and immutable types.

--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -1,6 +1,7 @@
 //! The diagnostic model rules emit and the engine aggregates.
 
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use tzlint_ast::Span;
@@ -11,11 +12,11 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
-    pub fn new(id: impl Into<String>) -> Self {
+    pub fn new(id: impl Into<Arc<str>>) -> Self {
         RuleId(id.into())
     }
     /// The id as a string slice.
@@ -38,7 +39,7 @@ impl From<&str> for RuleId {
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(s.into())
     }
 }
 


### PR DESCRIPTION
Use `Arc<str>` for `RuleId` to avoid expensive cloning overhead. `RuleId` is read-only and frequently cloned; using an `Arc` simplifies cloning by an atomic increment. Updated `ferris.md` journal with learnings.

---
*PR created automatically by Jules for task [11665394697921089441](https://jules.google.com/task/11665394697921089441) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 最適化のため、内部データ構造を変更しました。

* **Documentation**
  * 開発メモを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->