### PR TITLE
⚡ Bolt: Optimize `RuleId` memory usage using `Arc<str>`

### DIFF
--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -1,6 +1,7 @@
 //! The diagnostic model rules emit and the engine aggregates.
 
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use tzlint_ast::Span;
@@ -11,12 +12,13 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
     pub fn new(id: impl Into<String>) -> Self {
-        RuleId(id.into())
+        let s: String = id.into();
+        RuleId(Arc::from(s))
     }
     /// The id as a string slice.
     pub fn as_str(&self) -> &str {
@@ -32,13 +34,13 @@ impl core::fmt::Display for RuleId {
 
 impl From<&str> for RuleId {
     fn from(s: &str) -> Self {
-        RuleId(s.into())
+        RuleId(Arc::from(s))
     }
 }
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(Arc::from(s))
     }
 }
 


### PR DESCRIPTION
💡 What: Replaced the internal representation of `RuleId` from an owned `String` to a reference-counted string slice (`Arc<str>`).
🎯 Why: `RuleId` objects act as identifiers for diagnostic structures and configuration lookups. Consequently, they are heavily cloned and copied. An `Arc<str>` avoids deep copying, substituting heap allocations and memory copies with atomic reference count increments.
📊 Impact: Considerably faster copying, directly saving both memory and CPU cycles without compromising any existing guarantees.
🔬 Measurement: Verify changes locally with standard `cargo check --workspace` and `cargo test --workspace` confirming logic remains fully intact and unchanged outwardly.

---
*PR created automatically by Jules for task [4369652796346478220](https://jules.google.com/task/4369652796346478220) started by @simorgh3196*