### PR TITLE
feat(morphology): native lindera JA backend crate (M2j)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,22 @@ jobs:
       - run: cargo build -p tzlint_ast -p tzlint_pdk -p tzlint_core --target wasm32-unknown-unknown
       - run: cargo build -p tzlint_ast -p tzlint_pdk -p tzlint_core --target wasm32-wasip1
 
+  morphology-native:
+    name: morphology-native
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+      # The native lindera backend's mapping tests need a real dictionary; they run against
+      # lindera's embedded IPADIC behind the default-off `embed-ipadic` feature (the dictionary is
+      # compiled into the test binary — no network at test time, no committed fixture). Linux-only
+      # and separate from the OS-matrix `test` job: embedding IPADIC is a heavy, host-independent
+      # build, while the host-sensitive path handling is covered by the default-feature tests in
+      # `test`. The provider crate never enters the wasm graph (see the io-guard lindera tripwire).
+      - run: cargo nextest run -p tzlint_morphology_native --features embed-ipadic
+
   io-guard:
     name: io-guard
     runs-on: ubuntu-latest
@@ -88,6 +104,14 @@ jobs:
         run: |
           ! git grep -nE '\bureq\b' -- 'crates/*/src/**.rs' \
             ':!crates/tzlint_cli/src/host.rs' || (echo "network egress (ureq) must go through CliHost::fetch in host.rs"; exit 1)
+      # The native morphology backend (lindera) must stay native-only: it lives ONLY in
+      # `tzlint_morphology_native` (cfg(not(wasm32)), depended on only by the native CLI/LSP), so it
+      # can never enter the wasm build graph. Reject `lindera` in any other crate manifest — a
+      # fast, explicit tripwire next to the (slow) wasm build that would also catch the regression.
+      - name: reject lindera outside the native morphology crate
+        run: |
+          ! git grep -nE '\blindera\b' -- 'crates/*/Cargo.toml' \
+            ':!crates/tzlint_morphology_native/Cargo.toml' || (echo "lindera must stay in tzlint_morphology_native (native-only; never in the wasm graph)"; exit 1)
       # blake3 must stay pure-Rust: without `features = ["pure"]` it builds a SIMD backend via a
       # C compiler, breaking the uniform/reproducible build and wasm32. Guard the manifest.
       - name: blake3 must keep features = ["pure"]
@@ -133,8 +157,14 @@ jobs:
       # Coverage is measured over the nextest-run tests (stable toolchain). Doctests are
       # exercised for pass/fail in the `test` job; doctest *line* coverage requires nightly
       # (`cargo llvm-cov --doctests`) and is intentionally omitted here.
+      # Accumulate two runs into one report: the default workspace tests, then the native backend's
+      # mapping tests behind `embed-ipadic` (otherwise `LinderaProvider::analyze` would read as
+      # uncovered, since the default run only exercises its error paths).
       - name: Generate coverage (lcov)
-        run: cargo llvm-cov nextest --workspace --no-tests=warn --lcov --output-path lcov.info
+        run: |
+          cargo llvm-cov nextest --workspace --no-tests=warn --no-report
+          cargo llvm-cov nextest -p tzlint_morphology_native --features embed-ipadic --no-report
+          cargo llvm-cov report --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +88,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,10 +106,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -122,9 +162,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake3"
@@ -182,6 +228,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +246,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -202,6 +256,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -244,16 +304,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -265,10 +360,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "daachorse"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db756b5eb7d81d31f31f660f4132f8cf5698de52fca144c143d0ae0cbb5f2e06"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
 
 [[package]]
 name = "displaydoc"
@@ -282,6 +479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,10 +494,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "fancy-regex"
@@ -308,10 +539,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fluent-uri"
@@ -323,6 +574,12 @@ dependencies = [
  "ref-cast",
  "serde",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -350,14 +607,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -404,6 +702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,10 +718,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "icu_collections"
@@ -502,6 +887,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,12 +942,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -583,6 +1040,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kanaria"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +1067,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
+name = "lindera"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74cda79d7161e99b414e4d292ff673cc3f8d22f070d8be3b6185c033363a9216"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "kanaria",
+ "lindera-dictionary",
+ "lindera-ipadic",
+ "log",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "strum",
+ "strum_macros",
+ "unicode-blocks",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "url",
+]
+
+[[package]]
+name = "lindera-dictionary"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2385456ca9fe87c29072c5f156b52fdd5e28d5b5738ddfb3979501dbd736530"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "derive_builder",
+ "encoding_rs",
+ "encoding_rs_io",
+ "flate2",
+ "glob",
+ "log",
+ "md5",
+ "memmap2",
+ "num_cpus",
+ "once_cell",
+ "rand 0.10.1",
+ "regex",
+ "reqwest",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "tar",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ipadic"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130c598519a40bbfb762c4c06d6ad29315331eb4c154fcb2d1d6b46776cee7d9"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,9 +1164,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markdown"
@@ -631,16 +1184,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "micromap"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "munge"
@@ -742,6 +1331,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +1351,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "outref"
@@ -789,12 +1394,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -827,6 +1447,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,12 +1527,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -935,6 +1655,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,13 +1710,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
+ "bytes",
  "hashbrown 0.17.1",
+ "indexmap",
  "munge",
  "ptr_meta",
  "rancor",
  "rend",
  "rkyv_derive",
  "tinyvec",
+ "uuid",
 ]
 
 [[package]]
@@ -976,11 +1734,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -991,13 +1778,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1005,6 +1832,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1032,10 +1860,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1081,10 +1956,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -1093,10 +1997,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1109,6 +2029,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1128,10 +2069,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1162,6 +2143,112 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
@@ -1221,6 +2308,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tzlint_morphology_native"
+version = "0.0.0"
+dependencies = [
+ "lindera",
+ "tzlint_ast",
+ "tzlint_pdk",
+]
+
+[[package]]
 name = "tzlint_pdk"
 version = "0.0.0"
 dependencies = [
@@ -1236,6 +2332,12 @@ dependencies = [
  "tzlint_core",
  "tzlint_pdk",
 ]
+
+[[package]]
+name = "unicode-blocks"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
 
 [[package]]
 name = "unicode-general-category"
@@ -1254,6 +2356,27 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -1320,6 +2443,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "uuid-simd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +2473,25 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1367,6 +2519,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1402,12 +2564,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1422,7 +2622,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1440,14 +2649,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1457,10 +2683,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1469,10 +2707,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1481,10 +2731,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1493,10 +2755,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1509,6 +2783,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yaml_serde"
@@ -1525,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/tzlint_abi",
     "crates/tzlint_cli",
     "crates/tzlint_lsp",
+    "crates/tzlint_morphology_native",
 ]
 
 [workspace.package]

--- a/crates/tzlint_morphology_native/Cargo.toml
+++ b/crates/tzlint_morphology_native/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "tzlint_morphology_native"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Native (lindera) morphology backend for TsuzuLint. Native-only: never part of the wasm build."
+
+[lints]
+workspace = true
+
+[dependencies]
+# The frozen MorphologyV1 data model the provider fills (MorphologyBuilder, Token, FeatureKey,
+# Tagset, Lang) and Span/NodeId. `no_std`, ABI-frozen — shared with the wasm-facing crates.
+tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+# The `MorphologyProvider` trait this crate implements (and `MorphologyError`).
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
+# The morphological analyzer. NATIVE-ONLY by construction: this crate has no dependency edge from
+# the wasm-facing crates (ast/pdk/core), so cargo never resolves lindera for the `wasm32` build,
+# and the crate's `lib.rs` is `#![cfg(not(target_arch = "wasm32"))]` as a second guard. MIT.
+lindera = "3.0.7"
+
+[features]
+# Compile a dictionary INTO the binary so the provider can be exercised OFFLINE (no downloaded
+# dictionary directory, no committed fixture). Default-off and intended for tests only — the
+# production path loads a pre-built dictionary directory from a filesystem path. Enabling it pulls
+# the full IPADIC into the (test) binary, so it is never on by default.
+embed-ipadic = ["lindera/embed-ipadic"]

--- a/crates/tzlint_morphology_native/src/lib.rs
+++ b/crates/tzlint_morphology_native/src/lib.rs
@@ -1,0 +1,441 @@
+//! Native morphology backend: a [`MorphologyProvider`](tzlint_pdk::MorphologyProvider) backed by
+//! the [`lindera`] analyzer.
+//!
+//! **Native-only.** The whole crate is `#![cfg(not(target_arch = "wasm32"))]`, and — more
+//! importantly — no wasm-facing crate (`tzlint_ast`/`tzlint_pdk`/`tzlint_core`) depends on it, so
+//! `lindera` is structurally unreachable from the `wasm32` build graph. The engine reaches a real
+//! backend only through the `Box<dyn MorphologyProvider>` trait object in
+//! `tzlint_core::MorphologyRegistry`, which names no `lindera` type.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+
+use lindera::dictionary::load_dictionary;
+use lindera::mode::Mode;
+use lindera::segmenter::Segmenter;
+use lindera::tokenizer::Tokenizer;
+use tzlint_ast::morphology::{
+    FeatureKey, Lang, MorphologyBuilder, MorphologyV1, Tagset, Token, TokenAttrs,
+};
+use tzlint_ast::{NodeId, Span};
+use tzlint_pdk::{MorphologyError, MorphologyProvider};
+
+/// A Japanese [`MorphologyProvider`] backed by lindera + an IPADIC dictionary.
+///
+/// Construct it over a pre-built dictionary directory with [`new`](LinderaProvider::new), or — for
+/// tests — over a dictionary compiled into the binary with
+/// [`with_embedded_ipadic`](LinderaProvider::with_embedded_ipadic) (the `embed-ipadic` feature).
+/// Both converge on one [`Tokenizer`], so the embedded-dictionary tests exercise the exact
+/// production [`analyze`](LinderaProvider::analyze) path.
+pub struct LinderaProvider {
+    tokenizer: Tokenizer,
+}
+
+impl core::fmt::Debug for LinderaProvider {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // The lindera tokenizer holds the whole dictionary; it is neither small nor meaningfully
+        // printable, so the provider prints opaquely (matching `MorphologyRegistry`'s manual Debug).
+        f.debug_struct("LinderaProvider").finish_non_exhaustive()
+    }
+}
+
+impl LinderaProvider {
+    /// Build a provider over the pre-built dictionary **directory** at `dict_dir` (the layout
+    /// lindera produces / ships in its releases). A path that does not load — missing, not a
+    /// dictionary, non-UTF-8 — is a [`MorphologyError::Backend`], never a panic.
+    pub fn new(dict_dir: &Path) -> Result<Self, MorphologyError> {
+        let uri = dict_dir.to_str().ok_or_else(|| {
+            MorphologyError::Backend(format!(
+                "dictionary path is not valid UTF-8: {}",
+                dict_dir.display()
+            ))
+        })?;
+        Self::build(uri)
+    }
+
+    /// Build a provider over lindera's **embedded** IPADIC (compiled into the binary by the
+    /// `embed-ipadic` feature). Test-only in practice: it pulls the whole dictionary into the
+    /// binary, so production uses [`new`](LinderaProvider::new) over a directory instead.
+    #[cfg(feature = "embed-ipadic")]
+    pub fn with_embedded_ipadic() -> Result<Self, MorphologyError> {
+        Self::build("embedded://ipadic")
+    }
+
+    /// Shared constructor tail: load the dictionary `uri`, wrap it in a normal-mode segmenter, and
+    /// build the immutable tokenizer. Every lindera error becomes a [`MorphologyError::Backend`].
+    fn build(uri: &str) -> Result<Self, MorphologyError> {
+        let dictionary =
+            load_dictionary(uri).map_err(|e| MorphologyError::Backend(e.to_string()))?;
+        let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+        Ok(LinderaProvider {
+            tokenizer: Tokenizer::new(segmenter),
+        })
+    }
+}
+
+/// The lindera/IPADIC `details()` column index of each canonical [`FeatureKey`]. `base_form`
+/// (index 6) and `reading` (index 7) are absent here on purpose: they are promoted to dedicated
+/// [`Token`] fields rather than stored as features. Note the asymmetry — `details[8]` (発音) maps
+/// to [`FeatureKey::PRONUNCIATION`] (=6).
+const FEATURE_COLUMNS: &[(usize, FeatureKey)] = &[
+    (0, FeatureKey::POS),
+    (1, FeatureKey::POS_SUB_1),
+    (2, FeatureKey::POS_SUB_2),
+    (3, FeatureKey::POS_SUB_3),
+    (4, FeatureKey::CONJUGATION_TYPE),
+    (5, FeatureKey::CONJUGATION_FORM),
+    (8, FeatureKey::PRONUNCIATION),
+];
+
+const COLUMN_BASE_FORM: usize = 6;
+const COLUMN_READING: usize = 7;
+
+/// The IPADIC `details()` value at column `i`, or `None` when absent, empty, or the `*` placeholder
+/// (so an empty column is never interned as a feature / reading / base_form).
+fn column<'a>(details: &[&'a str], i: usize) -> Option<&'a str> {
+    details
+        .get(i)
+        .copied()
+        .filter(|value| !value.is_empty() && *value != "*")
+}
+
+impl MorphologyProvider for LinderaProvider {
+    fn lang(&self) -> Lang {
+        Lang::JA
+    }
+
+    fn analyze(
+        &self,
+        text: &str,
+        base_offset: u32,
+        node: NodeId,
+    ) -> Result<MorphologyV1, MorphologyError> {
+        // Guard the absolute-offset arithmetic up front (mirrors `WhitespaceProvider`): surfaces are
+        // `u32` `Span`s into `Ast::text`, so a node whose text would push past `u32::MAX` is an
+        // error, never a panic or an inverted span.
+        u32::try_from(text.len())
+            .ok()
+            .and_then(|n| base_offset.checked_add(n))
+            .ok_or_else(|| {
+                MorphologyError::Backend(format!(
+                    "node text at offset {base_offset} exceeds the u32 address space"
+                ))
+            })?;
+
+        let mut tokens = self
+            .tokenizer
+            .tokenize(text)
+            .map_err(|e| MorphologyError::Backend(e.to_string()))?;
+
+        let mut builder = MorphologyBuilder::new();
+        for token in tokens.iter_mut() {
+            // lindera byte offsets are relative to `text`; lift them to document coordinates. The
+            // up-front guard proved `base_offset + text.len()` fits, and every token range is within
+            // `text`, so these additions cannot overflow — but stay checked rather than asserting.
+            let surface = u32::try_from(token.byte_start)
+                .ok()
+                .and_then(|s| base_offset.checked_add(s))
+                .zip(
+                    u32::try_from(token.byte_end)
+                        .ok()
+                        .and_then(|e| base_offset.checked_add(e)),
+                )
+                .map(|(start, end)| Span::new(start, end))
+                .ok_or_else(|| {
+                    MorphologyError::Backend(format!(
+                        "token byte range {}..{} at offset {base_offset} exceeds the u32 address space",
+                        token.byte_start, token.byte_end
+                    ))
+                })?;
+
+            let flags = if token.word_id.is_unknown() {
+                Token::FLAG_UNKNOWN
+            } else {
+                0
+            };
+
+            let details = token.details();
+            let features: Vec<(FeatureKey, &str)> = FEATURE_COLUMNS
+                .iter()
+                .filter_map(|&(index, key)| column(&details, index).map(|value| (key, value)))
+                .collect();
+
+            builder.push_token(
+                TokenAttrs {
+                    node,
+                    surface,
+                    lang: Lang::JA,
+                    tagset: Tagset::IPADIC,
+                    flags,
+                },
+                column(&details, COLUMN_READING),
+                column(&details, COLUMN_BASE_FORM),
+                &features,
+            );
+        }
+        Ok(builder.finish())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    // `super::*` re-exports the production items plus `NodeId`/`FeatureKey`/`Lang`/`Tagset`/
+    // `Token`/`MorphologyError`/`MorphologyProvider` the tests use (a glob, so an item only the
+    // embedded-dictionary tests touch never warns when `embed-ipadic` is off).
+    use super::*;
+    // Archive round-trip helpers — needed only by the embedded-dictionary mapping tests.
+    #[cfg(feature = "embed-ipadic")]
+    use tzlint_ast::morphology::{access_morphology, to_archive_morphology};
+
+    /// Guards the `Box<dyn MorphologyProvider>` (Send + Sync) bound in the registry: a future
+    /// lindera type that lost `Send`/`Sync` would fail HERE at compile time, not at the use site.
+    #[test]
+    fn provider_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<LinderaProvider>();
+    }
+
+    /// The directory constructor's ERROR path needs no real dictionary: a non-existent directory
+    /// must be a clean `Err`, never a panic. (Its happy path — a real on-disk dictionary — is
+    /// deferred, as it needs a downloaded dictionary, out of the no-network test budget.)
+    #[test]
+    fn new_with_missing_directory_errors_not_panics() {
+        let err =
+            LinderaProvider::new(Path::new("/tzlint-nonexistent-dictionary-dir")).unwrap_err();
+        assert!(matches!(err, MorphologyError::Backend(_)), "{err}");
+    }
+
+    // The mapping tests need a real tokenizer; they run against lindera's embedded IPADIC, compiled
+    // into the test binary by the `embed-ipadic` feature (no network, no committed fixture).
+    #[cfg(feature = "embed-ipadic")]
+    fn ja() -> LinderaProvider {
+        LinderaProvider::with_embedded_ipadic().expect("embedded IPADIC loads")
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn provider_reports_japanese_and_prints_opaquely() {
+        let provider = ja();
+        assert_eq!(provider.lang(), Lang::JA);
+        // Debug omits the dictionary-bearing tokenizer (it just names the type).
+        assert!(format!("{provider:?}").contains("LinderaProvider"));
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn tokenizes_japanese_into_absolute_spans() {
+        let table = ja().analyze("東京", 0, NodeId(0)).unwrap();
+        assert!(!table.tokens.is_empty(), "IPADIC tokenizes 東京");
+        // "東京" is 6 bytes; every surface is an absolute byte span inside 0..6.
+        for t in &table.tokens {
+            assert_eq!(t.lang, Lang::JA);
+            assert_eq!(t.tagset, Tagset::IPADIC);
+            assert_eq!(t.node, NodeId(0));
+            assert!(t.surface.start < t.surface.end);
+            assert!(t.surface.end <= 6, "surface {:?} within 0..6", t.surface);
+        }
+        // A dictionary-backed token carries a POS feature.
+        let bytes = to_archive_morphology(&table).unwrap();
+        let archived = access_morphology(&bytes).unwrap();
+        let first = &archived.tokens()[0];
+        assert!(
+            first
+                .features(archived)
+                .any(|(k, v)| k == FeatureKey::POS && v.is_some()),
+            "first token has a POS feature"
+        );
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn base_offset_and_multibyte_shift_surfaces() {
+        // Every CJK char is 3 bytes; surfaces must be base_offset + lindera byte range.
+        let base = 10;
+        let table = ja().analyze("日本語の文", base, NodeId(3)).unwrap();
+        assert!(!table.tokens.is_empty());
+        for t in &table.tokens {
+            assert_eq!(t.node, NodeId(3));
+            assert!(t.surface.start >= base, "shifted by base_offset");
+            assert!(t.surface.end <= base + 15, "5 CJK chars = 15 bytes");
+        }
+        // Contiguous coverage: first starts at base, last ends at base+15.
+        assert_eq!(table.tokens.first().unwrap().surface.start, base);
+        assert_eq!(table.tokens.last().unwrap().surface.end, base + 15);
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn reading_and_base_form_are_promoted_to_distinct_fields() {
+        // details[6]=base_form and details[7]=reading become dedicated Token fields, never features —
+        // and they are DISTINCT, so a column swap is caught. 東京 (proper noun) is a clean probe:
+        // base_form 東京 (== surface) vs reading トウキョウ (katakana). Asserting the surface-equal
+        // base form is IPADIC-version-stable; the distinctness kills the details[6]<->[7] swap.
+        let table = ja().analyze("東京", 0, NodeId(0)).unwrap();
+        let bytes = to_archive_morphology(&table).unwrap();
+        let archived = access_morphology(&bytes).unwrap();
+        let noun = archived
+            .tokens()
+            .iter()
+            .find(|t| {
+                t.features(archived)
+                    .any(|(k, v)| k == FeatureKey::POS && v == Some("名詞"))
+            })
+            .expect("a 名詞 token for 東京");
+        assert_eq!(
+            noun.base_form(archived),
+            Some("東京"),
+            "base_form is details[6] (== surface for 東京), not the reading"
+        );
+        let reading = noun.reading(archived).expect("reading promoted");
+        assert_ne!(
+            Some(reading),
+            noun.base_form(archived),
+            "reading (details[7]) is distinct from base_form (details[6])"
+        );
+        // FeatureKey has no reading/base_form member, so every feature key is a known mapping key —
+        // i.e. neither column 6 nor 7 leaked into the feature store.
+        for (k, _) in noun.features(archived) {
+            assert!(
+                [
+                    FeatureKey::POS,
+                    FeatureKey::POS_SUB_1,
+                    FeatureKey::POS_SUB_2,
+                    FeatureKey::POS_SUB_3,
+                    FeatureKey::CONJUGATION_TYPE,
+                    FeatureKey::CONJUGATION_FORM,
+                    FeatureKey::PRONUNCIATION,
+                ]
+                .contains(&k),
+                "feature key {k:?} is a canonical IPADIC column"
+            );
+        }
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn pronunciation_maps_details_index8_not_index7() {
+        // The asymmetric mapping: details[8] (発音) -> FeatureKey::PRONUNCIATION (=6), NOT details[7]
+        // (読み). 東京 discriminates them: reading(7) トウキョウ vs 発音(8) トーキョー. If PRONUNCIATION
+        // were sourced from details[7], its value would equal the reading — so asserting they DIFFER
+        // kills the index-7/8 confusion (which 行う could not catch — its 読み == 発音).
+        let table = ja().analyze("東京", 0, NodeId(0)).unwrap();
+        let bytes = to_archive_morphology(&table).unwrap();
+        let archived = access_morphology(&bytes).unwrap();
+        let noun = archived
+            .tokens()
+            .iter()
+            .find(|t| {
+                t.features(archived)
+                    .any(|(k, v)| k == FeatureKey::POS && v == Some("名詞"))
+            })
+            .expect("a 名詞 token");
+        let pron = noun
+            .features(archived)
+            .find(|(k, _)| *k == FeatureKey::PRONUNCIATION)
+            .and_then(|(_, v)| v)
+            .expect("pronunciation present at FeatureKey 6");
+        assert_ne!(
+            Some(pron),
+            noun.reading(archived),
+            "PRONUNCIATION comes from details[8] (発音), distinct from the details[7] reading"
+        );
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn conjugation_columns_map_for_a_verb() {
+        // Pins the details[4]->CONJUGATION_TYPE and details[5]->CONJUGATION_FORM mapping with a
+        // conjugating verb (行う), whose 活用型/活用形 columns are populated (not '*').
+        let table = ja().analyze("行う", 0, NodeId(0)).unwrap();
+        let bytes = to_archive_morphology(&table).unwrap();
+        let archived = access_morphology(&bytes).unwrap();
+        let verb = archived
+            .tokens()
+            .iter()
+            .find(|t| {
+                t.features(archived)
+                    .any(|(k, v)| k == FeatureKey::POS && v == Some("動詞"))
+            })
+            .expect("a 動詞 token for 行う");
+        let conj_type = verb
+            .features(archived)
+            .find(|(k, _)| *k == FeatureKey::CONJUGATION_TYPE)
+            .and_then(|(_, v)| v);
+        let conj_form = verb
+            .features(archived)
+            .find(|(k, _)| *k == FeatureKey::CONJUGATION_FORM)
+            .and_then(|(_, v)| v);
+        assert_eq!(
+            conj_type,
+            Some("五段・ワ行促音便"),
+            "details[4] -> CONJUGATION_TYPE"
+        );
+        assert_eq!(conj_form, Some("基本形"), "details[5] -> CONJUGATION_FORM");
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn empty_and_blank_inputs_yield_no_tokens() {
+        // The up-front length guard and an empty tokenize result must produce a valid, empty table —
+        // no spurious token, no error (mirrors WhitespaceProvider's empty/blank test).
+        assert!(ja().analyze("", 0, NodeId(0)).unwrap().tokens.is_empty());
+        assert!(ja().analyze("   ", 0, NodeId(0)).unwrap().tokens.is_empty());
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn star_placeholder_columns_are_omitted() {
+        // 東京 is a proper noun: its 活用型/活用形 columns are "*", which must produce NO feature.
+        let table = ja().analyze("東京", 0, NodeId(0)).unwrap();
+        let bytes = to_archive_morphology(&table).unwrap();
+        let archived = access_morphology(&bytes).unwrap();
+        for t in archived.tokens() {
+            for (_, v) in t.features(archived) {
+                assert_ne!(v, Some("*"), "a '*' column must be dropped, never interned");
+            }
+            // A noun does not conjugate: no CONJUGATION_* feature survives the '*' omission.
+            assert!(
+                !t.features(archived)
+                    .any(|(k, _)| k == FeatureKey::CONJUGATION_TYPE
+                        || k == FeatureKey::CONJUGATION_FORM),
+                "noun has no conjugation columns"
+            );
+        }
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn unknown_words_set_flag_unknown() {
+        // A run lindera cannot find in IPADIC is marked unknown; the canonical OOV bit must be set.
+        let table = ja().analyze("qwzx", 0, NodeId(0)).unwrap();
+        assert!(
+            table
+                .tokens
+                .iter()
+                .any(|t| t.flags & Token::FLAG_UNKNOWN != 0),
+            "an out-of-dictionary run sets FLAG_UNKNOWN"
+        );
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn offset_overflow_is_a_backend_error_not_a_panic() {
+        let err = ja().analyze("あ", u32::MAX - 1, NodeId(0)).unwrap_err();
+        assert!(matches!(err, MorphologyError::Backend(_)), "{err}");
+    }
+
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn output_archives_and_reads_back() {
+        // The produced table is a valid frozen MorphologyV1: archive and read via the checked path.
+        let table = ja().analyze("日本語", 0, NodeId(7)).unwrap();
+        let bytes = to_archive_morphology(&table).unwrap();
+        let archived = access_morphology(&bytes).unwrap();
+        assert!(archived.tokens_of(NodeId(7)).count() >= 1);
+        let first = &archived.tokens()[0];
+        assert_eq!(first.surface().start, 0);
+        assert!(first.features(archived).count() >= 1);
+    }
+}

--- a/justfile
+++ b/justfile
@@ -16,6 +16,12 @@ test:
 test-doc:
     cargo test --workspace --doc
 
+# The native lindera backend's mapping tests against embedded IPADIC (the dictionary is compiled
+# into the test binary by `embed-ipadic`; no network at test time). Default-off, so the normal
+# `test` run skips the heavy embedded-dictionary build; CI runs this in a dedicated linux job.
+test-native:
+    cargo nextest run -p tzlint_morphology_native --features embed-ipadic
+
 fmt:
     cargo fmt --all
 


### PR DESCRIPTION
## M2j — native lindera morphology backend

The first real `MorphologyProvider`: a new **native-only** crate `tzlint_morphology_native` whose `LinderaProvider` maps lindera's IPADIC tokenization into the frozen `MorphologyV1`. (Design picked by a judge-panel — separate crate over a feature, thin provider that defers dict acquisition — and user-approved.)

### Mapping (verified field-by-field against real IPADIC)
- `surface` byte range + `base_offset` → absolute `Span` (checked u32 arithmetic; no panic, no inverted span — mirrors `WhitespaceProvider`)
- `token.word_id.is_unknown()` → `Token::FLAG_UNKNOWN`
- `details()` columns → `FeatureKey`: `0`→POS, `1..3`→POS_SUB_1..3, `4`→CONJUGATION_TYPE, `5`→CONJUGATION_FORM, **`8`→PRONUNCIATION (=6)** (the asymmetry)
- `6` 原形→`Token.base_form`, `7` 読み→`Token.reading` (promoted to fields, never features); `*`/empty columns omitted
- `Tagset::IPADIC`, `Lang::JA`

### wasm isolation (structural)
The crate is `#![cfg(not(target_arch = "wasm32"))]` and **no wasm-facing crate (ast/pdk/core) depends on it**, so lindera is unreachable from the wasm build graph. The engine sees it only through the existing `Box<dyn MorphologyProvider>`. Guards: a new io-guard CI grep rejects `lindera` in any other crate manifest; the wasm gate is untouched.

### Dependency gate (validated before committing)
- lindera **3.0.7 / MIT**; `cargo deny check` → licenses/advisories/bans/sources all ok
- base (production) build clean; **MSRV 1.94** build verified on a 1.94 toolchain
- `embed-ipadic` pulls reqwest/tokio only as **build-deps of the test dictionary** — never the production tree

### Scope / deferred
- `new(dict_dir)` loads a pre-built dictionary **directory**. The dict.rs single-blob→directory bridge + CLI wiring are follow-ups, so this PR is **internal-only** (the CLI stays on `None`; no-doubled-joshi fires once wiring lands).
- JA/IPADIC only; ko/zh and UniDic deferred. A non-IPADIC directory would be mislabeled JA/IPADIC (operator error; out of scope for the JA-only slice).

### Tests & CI
- **13 tests** against lindera's **embedded IPADIC** (default-off `embed-ipadic` feature → no network at test time, no committed fixture) in a dedicated linux `morphology-native` job (`just test-native`); coverage accumulates that run.
- TDD (RED via compile-fail → GREEN). 3 mutation-resistance guards added after an adversarial review (16 agents → **0 production bugs**, 3 test-coverage gaps): reading↔base_form swap, PRONUNCIATION details[7]-vs-[8] confusion (discriminated with 東京, whose 読み≠発音), and empty input — the first two mutant kills **verified empirically**.

### Verification
`just check` ✅, `just wasm` ✅, `just test-native` ✅ (13), clippy -D both feature configs ✅, io-guard greps ✅, cargo-deny ✅. **441 workspace + 13 native = 454 tests.** Native-crate coverage **94.5% line**; production fully covered (residual = non-UTF-8-path + unreachable-overflow defensive branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ネイティブ形態素解析バックエンド（Lindera + IPADIC辞書）を追加しました。バイナリに辞書を組み込むことで、外部ファイル依存なしに日本語解析が可能になります。

* **テスト**
  * ネイティブ形態素解析機能の専用テストスイートを追加しました。CI で包括的な検証を実施します。

* **Chores**
  * ネイティブ実装対応のCI ワークフロー構成を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->