### PR TITLE
feat(morphology): in-memory dictionary container + CLI wiring (M2j-wiring)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,6 +2279,7 @@ dependencies = [
  "serde_json",
  "tzlint_ast",
  "tzlint_core",
+ "tzlint_morphology_native",
  "tzlint_pdk",
  "tzlint_rules",
  "ureq",
@@ -2312,8 +2313,13 @@ name = "tzlint_morphology_native"
 version = "0.0.0"
 dependencies = [
  "lindera",
+ "lindera-dictionary",
+ "rkyv",
+ "serde_json",
  "tzlint_ast",
+ "tzlint_core",
  "tzlint_pdk",
+ "tzlint_rules",
 ]
 
 [[package]]

--- a/crates/tzlint_cli/Cargo.toml
+++ b/crates/tzlint_cli/Cargo.toml
@@ -26,6 +26,12 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # `to_archive`/`access` (the parse → archive → lint bridge for the no-cache path) and `Span`.
 tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+# The native morphology backend: `LinderaProvider`, wired into a `MorphologyRegistry` when the
+# config names a dictionary. This edge finally links a real tokenizer into the binary. It is
+# depended on by its capability name (`tzlint_morphology_native`), so the underlying backend
+# library stays an internal detail and the io-guard tripwire — which rejects the bare token in any
+# non-backend manifest — is satisfied here.
+tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0" }
 # Argument parsing (derive API).
 clap = { workspace = true }
 # Blocking HTTPS client for `CliHost::fetch` — the CLI's network-egress boundary for dictionary

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -19,10 +19,13 @@
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
+use tzlint_ast::morphology::Lang;
 use tzlint_core::io::{MAX_CONFIG, MAX_FILE};
 use tzlint_core::{
-    Config, ConfigFormat, DocumentCache, Host, Registry, discover, lint_cached, lint_document,
+    Config, ConfigFormat, DictId, DictSource, DocumentCache, Host, MorphologyRegistry, Registry,
+    discover, lint_cached, lint_document, provision_dictionary, provision_dictionary_from_url,
 };
+use tzlint_morphology_native::LinderaProvider;
 use tzlint_pdk::Diagnostic;
 
 use crate::cli::{Cli, Command, OutputFormat, RuleListFormat, RulesCommand};
@@ -98,6 +101,81 @@ pub fn run(cli: &Cli, host: &dyn Host, cwd: &Path, streams: &mut Streams) -> Exi
     }
 }
 
+/// Build the per-run morphology registry from `config.morphology`, or `None` when no dictionary is
+/// configured or no rule active in *this run* needs one.
+///
+/// Returns `None` — doing no network or disk work — unless BOTH hold: the config names a
+/// `morphology` source, AND some rule applying to an input actually being processed requires a
+/// Japanese morphology table. The second gate is keyed to the run's effective `inputs`, NOT to
+/// every configured format: a JA rule enabled only under `formats.csv…` must not provision — let
+/// alone fatally fail to provision — the dictionary on a run that lints no CSV. A configured-but-
+/// unused dictionary is never provisioned, and a run with no active morphology rule keeps a cache
+/// key byte-identical to a pre-morphology run (an empty registry folds to an empty fingerprint).
+/// When both hold, the compressed container is provisioned through the [`Host`] (and cached),
+/// verified against the pin, decompressed in memory, and bridged into a [`LinderaProvider`].
+///
+/// A provisioning or load failure is surfaced as the run's error rather than silently skipping the
+/// rule: a misconfigured or unreachable dictionary is an operator problem that should fail loudly.
+/// The `DictId` is the same pin the cache file is addressed by, so a dictionary upgrade changes both
+/// the cache file and the morphology fingerprint.
+fn build_morphology_registry(
+    host: &dyn Host,
+    cwd: &Path,
+    config: &Config,
+    inputs: &expand::Inputs,
+) -> Result<Option<MorphologyRegistry>, String> {
+    let Some(morphology) = &config.morphology else {
+        return Ok(None);
+    };
+    // The dictionary serves exactly one language — `morphology.lang`, which the config layer has
+    // already constrained to the supported set ("ja" today; `RawMorphology::resolve` rejects the
+    // rest with `UnsupportedMorphologyLang`). Resolve it to a `Lang` rather than assuming Japanese,
+    // so when ko/zh dictionaries become configurable this gate already targets the right language
+    // (ko/zh additionally need the bridge's `Tagset`/`Lang` and the rules — a separate milestone).
+    let dict_lang = match morphology.lang.as_str() {
+        "ja" => Lang::JA,
+        // Unreachable: config validation rejects any other language before we reach here. Skip
+        // provisioning rather than panic if that invariant ever changes upstream.
+        _ => return Ok(None),
+    };
+    // Provision only when a rule active for an input *in this run* needs that language. Each input
+    // is checked under the same region it is linted with: stdin (and any markdown file) under the
+    // base rules, every other file under its extension's rules — which fold in that format's column
+    // overlays (a column may re-enable a base-disabled rule). Keying on the run's inputs rather than
+    // `config.formats` avoids provisioning — and a fatal provision failure — for a morphology rule
+    // scoped to a format not present in the run.
+    let needs_dict = inputs
+        .stdin
+        .then_some(None)
+        .into_iter()
+        .chain(inputs.files.iter().map(|p| extension_of(p)))
+        .any(|ext| {
+            region_rules_for(config, ext)
+                .required_langs()
+                .contains(&dict_lang)
+        });
+    if !needs_dict {
+        return Ok(None);
+    }
+
+    let cache_dir = cwd.join(".tzlint").join("dict");
+    let bytes = match &morphology.source {
+        DictSource::Path(path) => {
+            provision_dictionary(host, &cache_dir, &cwd.join(path), &morphology.pin)
+        }
+        DictSource::Url(url) => {
+            provision_dictionary_from_url(host, &cache_dir, url, &morphology.pin)
+        }
+    }
+    .map_err(|e| format!("morphology dictionary: {e}"))?;
+
+    let provider = LinderaProvider::from_dictionary_bytes(&bytes)
+        .map_err(|e| format!("morphology dictionary: {e}"))?;
+    let mut registry = MorphologyRegistry::new();
+    registry.insert(Box::new(provider), DictId::from_pin(morphology.pin));
+    Ok(Some(registry))
+}
+
 /// `lint`: read, lint, and render each file; exit `Findings` if any diagnostics, `Error` if any
 /// file could not be read or linted.
 fn lint(
@@ -125,6 +203,11 @@ fn lint(
     let inputs = expand::expand(host, cwd, paths, &dir_exts);
     note_expansion(&inputs.notes, stderr);
 
+    // One morphology registry for the whole run, provisioned once — but only when configured AND a
+    // JA rule is active for the run's actual inputs (above). A provisioning failure aborts the run
+    // before any file is linted.
+    let morphology = build_morphology_registry(host, cwd, &config, &inputs)?;
+
     // Persistent cache: load the on-disk file (best-effort) so a repeat run on unchanged content
     // skips parse+lint, and write it back afterwards. `--no-cache` skips both ends. (stdin is
     // never cached — it has no stable path key — so it always takes the direct path below.)
@@ -135,7 +218,7 @@ fn lint(
     // stdin is reported first so the work order is fixed and the summary count is stable.
     if inputs.stdin {
         match read_stdin(stdin).and_then(|source| {
-            let diagnostics = lint_source(&registry, &config, None, &source)?;
+            let diagnostics = lint_source(&registry, &config, morphology.as_ref(), None, &source)?;
             Ok(FileReport {
                 path: PathBuf::from(STDIN_LABEL),
                 source,
@@ -151,7 +234,14 @@ fn lint(
     }
     for path in &inputs.files {
         note_unconfigured_format(&config, path, stderr);
-        match read_and_lint(&registry, host, cache.as_mut(), path, &config) {
+        match read_and_lint(
+            &registry,
+            host,
+            cache.as_mut(),
+            morphology.as_ref(),
+            path,
+            &config,
+        ) {
             Ok(report) => reports.push(report),
             Err(message) => {
                 let _ = writeln!(stderr, "error: {}: {message}", path.display());
@@ -203,6 +293,7 @@ fn read_and_lint(
     registry: &Registry,
     host: &dyn Host,
     cache: Option<&mut DocumentCache>,
+    morphology: Option<&MorphologyRegistry>,
     path: &Path,
     config: &Config,
 ) -> Result<FileReport, String> {
@@ -214,12 +305,15 @@ fn read_and_lint(
         Some(cache) => {
             let pcfg = processor_config_for(config, ext);
             let rr = region_rules_for(config, ext);
-            // No morphology providers are wired into the CLI yet (the native backend is M2j), so
-            // pass `None`: the cache key stays byte-identical to the pre-morphology key.
-            lint_cached(cache, ext, &source, config, registry, &pcfg, &rr, None)
-                .map_err(|e| e.to_string())?
+            // The morphology registry is `Some` only when a dictionary is configured AND an enabled
+            // rule needs it; otherwise it is `None` and the cache key stays byte-identical to the
+            // pre-morphology key (the registry folds an empty fingerprint).
+            lint_cached(
+                cache, ext, &source, config, registry, &pcfg, &rr, morphology,
+            )
+            .map_err(|e| e.to_string())?
         }
-        None => lint_source(registry, config, ext, &source)?,
+        None => lint_source(registry, config, morphology, ext, &source)?,
     };
     Ok(FileReport {
         path: path.to_path_buf(),
@@ -248,13 +342,13 @@ fn discovery_extensions(config: &Config) -> Vec<String> {
 fn lint_source(
     registry: &Registry,
     config: &Config,
+    morphology: Option<&MorphologyRegistry>,
     ext: Option<&str>,
     source: &str,
 ) -> Result<Vec<Diagnostic>, String> {
     let pcfg = processor_config_for(config, ext);
     let rr = region_rules_for(config, ext);
-    // No morphology providers are wired into the CLI yet (native backend is M2j); pass `None`.
-    lint_document(ext, source, registry, &pcfg, &rr, None).map_err(|e| e.to_string())
+    lint_document(ext, source, registry, &pcfg, &rr, morphology).map_err(|e| e.to_string())
 }
 
 /// `fix`: lint-and-fix each file to a fixpoint; write changed files in place (or just report
@@ -280,6 +374,11 @@ fn fix(
     let inputs = expand::expand(host, cwd, paths, &dir_exts);
     note_expansion(&inputs.notes, stderr);
 
+    // One morphology registry for the whole fix run, provisioned once — but only when configured AND
+    // a JA rule is active for the run's actual inputs (above); a provisioning failure aborts before
+    // any file is touched.
+    let morphology = build_morphology_registry(host, cwd, &config, &inputs)?;
+
     // When stdin is a target, stdout carries the fixed stdin document (a pass-through filter), so
     // ALL progress/summary moves to stderr to keep stdout pure data. Without stdin, progress and
     // the summary stay on stdout exactly as before.
@@ -294,7 +393,8 @@ fn fix(
             Ok(source) => {
                 let pcfg = processor_config_for(&config, None);
                 let rr = region_rules_for(&config, None);
-                let fixed = tzlint_core::fix(None, &source, &registry, &pcfg, &rr, None);
+                let fixed =
+                    tzlint_core::fix(None, &source, &registry, &pcfg, &rr, morphology.as_ref());
                 let did_change = fixed != source;
                 if dry_run {
                     if did_change {
@@ -340,7 +440,7 @@ fn fix(
         let ext = extension_of(path);
         let pcfg = processor_config_for(&config, ext);
         let rr = region_rules_for(&config, ext);
-        let fixed = tzlint_core::fix(ext, &source, &registry, &pcfg, &rr, None);
+        let fixed = tzlint_core::fix(ext, &source, &registry, &pcfg, &rr, morphology.as_ref());
         if fixed == source {
             continue;
         }
@@ -1575,5 +1675,110 @@ mod tests {
         assert_eq!(status, ExitStatus::Error);
         assert!(err.contains("error: <stdin>"), "{err}");
         assert!(out.is_empty(), "no document should be emitted: {out:?}");
+    }
+
+    // --- morphology wiring (M2j) ---
+
+    /// A 64-hex pin (all zeros) for the morphology gate tests; the dictionary is never actually
+    /// provisioned here (the in-memory host cannot read it), so the bytes behind the pin don't
+    /// matter — these tests exercise the gate and its error surfacing, not a real dictionary.
+    const PIN64: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    #[test]
+    fn morphology_provision_failure_aborts_the_run() {
+        // A configured dictionary that cannot be provisioned (the in-memory host has no such file)
+        // fails the whole run loudly — a misconfigured dictionary must not be silently skipped. The
+        // default rule set leaves no-doubled-joshi enabled, so the JA gate is active and provisions.
+        let host = MockHost::new();
+        host.put("a.md", "私は彼は来た。\n");
+        host.put(
+            "c.json",
+            &format!(r#"{{ "morphology": {{ "path": "ja.dict.zst", "pin": "{PIN64}" }} }}"#),
+        );
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, _out, err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("morphology dictionary"), "{err}");
+    }
+
+    #[test]
+    fn morphology_is_not_provisioned_when_no_ja_rule_is_active() {
+        // The same unprovisionable dictionary, but no-doubled-joshi (the only JA-requiring rule) is
+        // disabled — so the gate never provisions, the run succeeds, and the dictionary is never
+        // touched (proving the gate avoids work, and keeps the pre-morphology cache key).
+        let host = MockHost::new();
+        host.put("a.md", "ふつうの文。\n");
+        host.put(
+            "c.json",
+            &format!(
+                r#"{{ "morphology": {{ "path": "ja.dict.zst", "pin": "{PIN64}" }}, "rules": {{ "no-doubled-joshi": false }} }}"#
+            ),
+        );
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, _out, _err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Clean);
+    }
+
+    #[test]
+    fn morphology_is_provisioned_for_a_column_overlay_ja_rule() {
+        // The gate must consider per-format column overlays, not just the base rule set:
+        // no-doubled-joshi is disabled in the base but RE-ENABLED under a csv column, so a dictionary
+        // IS needed and the gate provisions it (failing loudly here since it is unprovisionable).
+        // Without the overlay check this run would be a silent false-clean over the csv column.
+        let host = MockHost::new();
+        host.put("a.csv", "私は彼は来た。\n");
+        host.put(
+            "c.json",
+            &format!(
+                r#"{{ "morphology": {{ "path": "ja.dict.zst", "pin": "{PIN64}" }}, "rules": {{ "no-doubled-joshi": false }}, "formats": {{ "csv": {{ "columns": {{ "1": {{ "rules": {{ "no-doubled-joshi": true }} }} }} }} }} }}"#
+            ),
+        );
+        let mut c = lint_cli("a.csv", OutputFormat::Text);
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, _out, err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("morphology dictionary"), "{err}");
+    }
+
+    #[test]
+    fn morphology_is_not_provisioned_when_the_ja_format_is_absent_from_the_run() {
+        // The mirror of the overlay test: no-doubled-joshi is enabled ONLY under a csv column, but
+        // this run lints just markdown — no csv input — so no JA rule can fire. The gate keys on the
+        // run's actual inputs, NOT `config.formats`, so it must neither provision nor fatally fail on
+        // the unprovisionable dictionary. (Under the old `config.formats`-based gate this aborted.)
+        let host = MockHost::new();
+        host.put("a.md", "ふつうの文。\n");
+        host.put(
+            "c.json",
+            &format!(
+                r#"{{ "morphology": {{ "path": "ja.dict.zst", "pin": "{PIN64}" }}, "rules": {{ "no-doubled-joshi": false }}, "formats": {{ "csv": {{ "columns": {{ "1": {{ "rules": {{ "no-doubled-joshi": true }} }} }} }} }} }}"#
+            ),
+        );
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, _out, _err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Clean);
+    }
+
+    #[test]
+    fn morphology_url_source_provision_failure_aborts_the_run() {
+        // The `url` source takes the fetch path (the URL passes the SSRF guard, then the in-memory
+        // host has no network), so provisioning fails and the run aborts — the same loud-failure
+        // contract as the local-path source, exercising the `DictSource::Url` branch.
+        let host = MockHost::new();
+        host.put("a.md", "私は彼は来た。\n");
+        host.put(
+            "c.json",
+            &format!(
+                r#"{{ "morphology": {{ "url": "https://dict.example.com/ja.dict.zst", "pin": "{PIN64}" }} }}"#
+            ),
+        );
+        let mut c = lint_cli("a.md", OutputFormat::Text);
+        c.config = Some(PathBuf::from("c.json"));
+        let (status, _out, err) = run_capture(&c, &host);
+        assert_eq!(status, ExitStatus::Error);
+        assert!(err.contains("morphology dictionary"), "{err}");
     }
 }

--- a/crates/tzlint_core/src/config/config.schema.json
+++ b/crates/tzlint_core/src/config/config.schema.json
@@ -27,6 +27,9 @@
     },
     "formats": {
       "$ref": "#/$defs/formats"
+    },
+    "morphology": {
+      "$ref": "#/$defs/morphology"
     }
   },
   "$defs": {
@@ -34,6 +37,33 @@
       "description": "A built-in preset id.",
       "type": "string",
       "enum": ["ja-basic", "ja-technical-writing"]
+    },
+    "morphology": {
+      "description": "Optional morphology-dictionary source for morphology-dependent rules (e.g. no-doubled-joshi). The compressed container is provisioned at runtime, verified against `pin`, and decompressed in memory. Exactly one of `path`/`url` must be set.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pin"],
+      "oneOf": [{ "required": ["path"] }, { "required": ["url"] }],
+      "properties": {
+        "path": {
+          "description": "Local path to the compressed `.dict.zst` container (resolved relative to the working directory).",
+          "type": "string"
+        },
+        "url": {
+          "description": "https URL to fetch the compressed container from on a cache miss (SSRF-guarded).",
+          "type": "string"
+        },
+        "pin": {
+          "description": "BLAKE3 pin over the COMPRESSED container, 64 hexadecimal characters.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "lang": {
+          "description": "The language the dictionary serves. Only \"ja\" is supported today.",
+          "type": "string",
+          "enum": ["ja"]
+        }
+      }
     },
     "rules": {
       "description": "Map of rule id to its setting. Rule ids are arbitrary strings; they are not validated against a known-rule set yet (that arrives with the rules crate).",

--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -53,6 +53,36 @@ pub struct Config {
     pub rules: BTreeMap<RuleId, RuleSetting>,
     /// Per-format settings (e.g. `formats.csv`), keyed by format id. Empty by default.
     pub formats: BTreeMap<String, FormatConfig>,
+    /// Optional morphology-dictionary source. `None` (the default) means no tokenizer is wired and
+    /// morphology-dependent rules stay inert — and the document cache key is byte-identical to a
+    /// pre-morphology run. `Some` makes the CLI provision a hash-pinned dictionary and register a
+    /// provider (see [`MorphologyConfig`]).
+    pub morphology: Option<MorphologyConfig>,
+}
+
+/// A resolved morphology-dictionary source (the validated form of the config `morphology` block).
+///
+/// The CLI provisions the compressed container from [`source`](MorphologyConfig::source), verifies
+/// it against [`pin`](MorphologyConfig::pin), decompresses it in memory, and registers a provider
+/// for [`lang`](MorphologyConfig::lang).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MorphologyConfig {
+    /// Where the compressed dictionary container is obtained from.
+    pub source: DictSource,
+    /// The BLAKE3 pin over the **compressed** container — the value `provision_dictionary` verifies
+    /// and the dictionary's cache identity ([`DictId`](crate::DictId)).
+    pub pin: [u8; 32],
+    /// The language the dictionary serves (currently only `"ja"`).
+    pub lang: String,
+}
+
+/// Where a dictionary container is obtained: a local file or an https URL. Exactly one is set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DictSource {
+    /// A local path to the compressed `.dict.zst` container (resolved relative to the working dir).
+    Path(String),
+    /// An https URL to fetch the container from on a cache miss (SSRF-guarded, then pinned).
+    Url(String),
 }
 
 impl Config {
@@ -96,6 +126,12 @@ pub enum ConfigError {
         /// The offending delimiter character.
         delimiter: char,
     },
+    /// The `morphology` section did not set exactly one of `path` / `url`.
+    MorphologySource,
+    /// The `morphology.pin` is not 64 hexadecimal characters.
+    InvalidDictPin(String),
+    /// The `morphology.lang` names a language with no supported backend (only `ja` today).
+    UnsupportedMorphologyLang(String),
 }
 
 impl fmt::Display for ConfigError {
@@ -124,6 +160,21 @@ impl fmt::Display for ConfigError {
                 write!(
                     f,
                     "delimiter '{delimiter}' in format '{format}' is not ASCII (only single-byte delimiters are supported)"
+                )
+            }
+            ConfigError::MorphologySource => {
+                write!(f, "`morphology` requires exactly one of `path` or `url`")
+            }
+            ConfigError::InvalidDictPin(pin) => {
+                write!(
+                    f,
+                    "`morphology.pin` must be 64 hexadecimal characters: `{pin}`"
+                )
+            }
+            ConfigError::UnsupportedMorphologyLang(lang) => {
+                write!(
+                    f,
+                    "unsupported `morphology.lang` `{lang}` (only `ja` is supported)"
                 )
             }
         }

--- a/crates/tzlint_core/src/config/model.rs
+++ b/crates/tzlint_core/src/config/model.rs
@@ -14,7 +14,7 @@ use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde_json::Value;
 use tzlint_pdk::{RuleId, Severity};
 
-use super::{Config, ConfigError};
+use super::{Config, ConfigError, DictSource, MorphologyConfig};
 
 /// The on-disk config shape. Kebab-case keys, no unknown keys.
 #[derive(Debug, Deserialize)]
@@ -38,6 +38,77 @@ pub(super) struct RawConfig {
     /// under `header: false` is rejected in [`into_config`](RawConfig::into_config).
     #[serde(default)]
     formats: std::collections::BTreeMap<String, RawFormat>,
+    /// Optional morphology-dictionary source for morphology-dependent rules (e.g.
+    /// `no-doubled-joshi`). Absent (the default) means no tokenizer is wired and those rules stay
+    /// inert. Resolved + validated into [`Config::morphology`](super::Config::morphology).
+    #[serde(default)]
+    morphology: Option<RawMorphology>,
+}
+
+/// The on-disk shape of the `morphology` section. Exactly one of `path`/`url` must be set, and
+/// `pin` is the 64-hex BLAKE3 over the COMPRESSED container; both are validated in
+/// [`resolve`](RawMorphology::resolve).
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+struct RawMorphology {
+    /// A local path to the compressed `.dict.zst` container.
+    #[serde(default)]
+    path: Option<String>,
+    /// An https URL to fetch the compressed container from (SSRF-guarded).
+    #[serde(default)]
+    url: Option<String>,
+    /// 64 hex characters: the BLAKE3 pin over the compressed container.
+    pin: String,
+    /// The language this dictionary serves; defaults to `"ja"` (the only one supported today).
+    #[serde(default)]
+    lang: Option<String>,
+}
+
+impl RawMorphology {
+    /// Validate the raw section into a resolved [`MorphologyConfig`](super::MorphologyConfig):
+    /// exactly one source, a 64-hex pin decoded to 32 bytes, and a supported language.
+    fn resolve(self) -> Result<MorphologyConfig, ConfigError> {
+        let source = match (self.path, self.url) {
+            (Some(path), None) => DictSource::Path(path),
+            (None, Some(url)) => DictSource::Url(url),
+            _ => return Err(ConfigError::MorphologySource),
+        };
+        let pin = decode_pin(&self.pin)?;
+        let lang = self.lang.unwrap_or_else(|| "ja".to_string());
+        if lang != "ja" {
+            return Err(ConfigError::UnsupportedMorphologyLang(lang));
+        }
+        Ok(MorphologyConfig { source, pin, lang })
+    }
+}
+
+/// Decode a 64-character hex string into a 32-byte pin, panic-free. A wrong length or a non-hex
+/// character is a [`ConfigError::InvalidDictPin`].
+fn decode_pin(hex: &str) -> Result<[u8; 32], ConfigError> {
+    let bytes = hex.as_bytes();
+    if bytes.len() != 64 {
+        return Err(ConfigError::InvalidDictPin(hex.to_string()));
+    }
+    let mut out = [0u8; 32];
+    for (i, slot) in out.iter_mut().enumerate() {
+        // `bytes.len() == 64` and `i < 32`, so `i*2 + 1 <= 63` — both indexes are in bounds.
+        let hi =
+            hex_nibble(bytes[i * 2]).ok_or_else(|| ConfigError::InvalidDictPin(hex.to_string()))?;
+        let lo = hex_nibble(bytes[i * 2 + 1])
+            .ok_or_else(|| ConfigError::InvalidDictPin(hex.to_string()))?;
+        *slot = (hi << 4) | lo;
+    }
+    Ok(out)
+}
+
+/// The numeric value of one hex digit (`0-9`, `a-f`, `A-F`), or `None`.
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
 }
 
 /// The on-disk shape of one `formats.<id>` section.
@@ -183,6 +254,9 @@ impl RawConfig {
             .fold(user, |acc, preset| super::resolve(Some(preset), acc));
         // Attach the resolved formats to the FINAL folded config (formats are not preset-layered).
         result.formats = formats;
+        // Likewise the morphology source: it is this file's own setting (presets never supply one),
+        // validated here (exactly one source, a well-formed pin, a supported language).
+        result.morphology = self.morphology.map(RawMorphology::resolve).transpose()?;
         Ok(result)
     }
 }
@@ -458,6 +532,124 @@ mod tests {
             config.rules.get(&RuleId::from("sentence-length")),
             Some(&RuleSetting::Off)
         );
+    }
+
+    /// A 64-character hex pin used across the morphology tests; decodes to bytes `01 23 45 … ef`.
+    const PIN: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn morphology(json: &str) -> Result<Config, ConfigError> {
+        serde_json::from_str::<RawConfig>(json)
+            .expect("valid JSON shape")
+            .into_config()
+    }
+
+    #[test]
+    fn morphology_parses_a_local_path_and_decodes_the_pin() {
+        let m = morphology(&format!(
+            r#"{{ "morphology": {{ "path": "dict/ja.dict.zst", "pin": "{PIN}" }} }}"#
+        ))
+        .unwrap()
+        .morphology
+        .expect("morphology present");
+        assert_eq!(m.source, DictSource::Path("dict/ja.dict.zst".to_string()));
+        assert_eq!(m.lang, "ja"); // defaults to ja
+        assert_eq!(m.pin[0], 0x01);
+        assert_eq!(m.pin[31], 0xef);
+    }
+
+    #[test]
+    fn morphology_parses_a_url_source() {
+        let m = morphology(&format!(
+            r#"{{ "morphology": {{ "url": "https://example.com/ja.dict.zst", "pin": "{PIN}", "lang": "ja" }} }}"#
+        ))
+        .unwrap()
+        .morphology
+        .expect("morphology present");
+        assert_eq!(
+            m.source,
+            DictSource::Url("https://example.com/ja.dict.zst".to_string())
+        );
+    }
+
+    #[test]
+    fn morphology_rejects_an_ill_formed_pin() {
+        // Too short.
+        let err = morphology(r#"{ "morphology": { "path": "d.zst", "pin": "abc" } }"#).unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidDictPin(_)), "{err}");
+        // Right length, non-hex character ('g').
+        let bad = format!("g{}", &PIN[1..]);
+        let err = morphology(&format!(
+            r#"{{ "morphology": {{ "path": "d.zst", "pin": "{bad}" }} }}"#
+        ))
+        .unwrap_err();
+        assert!(matches!(err, ConfigError::InvalidDictPin(_)), "{err}");
+    }
+
+    #[test]
+    fn morphology_rejects_both_or_neither_source() {
+        let both = morphology(&format!(
+            r#"{{ "morphology": {{ "path": "d.zst", "url": "https://x/d.zst", "pin": "{PIN}" }} }}"#
+        ))
+        .unwrap_err();
+        assert!(matches!(both, ConfigError::MorphologySource), "{both}");
+        let neither =
+            morphology(&format!(r#"{{ "morphology": {{ "pin": "{PIN}" }} }}"#)).unwrap_err();
+        assert!(
+            matches!(neither, ConfigError::MorphologySource),
+            "{neither}"
+        );
+    }
+
+    #[test]
+    fn morphology_rejects_an_unsupported_language() {
+        let err = morphology(&format!(
+            r#"{{ "morphology": {{ "path": "d.zst", "pin": "{PIN}", "lang": "ko" }} }}"#
+        ))
+        .unwrap_err();
+        assert!(
+            matches!(err, ConfigError::UnsupportedMorphologyLang(ref l) if l == "ko"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn config_without_morphology_resolves_to_none() {
+        // The load-bearing invariant: no `morphology` key ⇒ `None` ⇒ an empty registry ⇒ a
+        // byte-identical pre-morphology cache key.
+        assert!(
+            morphology(r#"{ "rules": {} }"#)
+                .unwrap()
+                .morphology
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn morphology_config_errors_render_their_messages() {
+        assert!(
+            ConfigError::MorphologySource
+                .to_string()
+                .contains("exactly one")
+        );
+        assert!(
+            ConfigError::InvalidDictPin("abc".to_string())
+                .to_string()
+                .contains("64 hexadecimal")
+        );
+        assert!(
+            ConfigError::UnsupportedMorphologyLang("ko".to_string())
+                .to_string()
+                .contains("ko")
+        );
+    }
+
+    #[test]
+    fn morphology_rejects_unknown_keys() {
+        // `deny_unknown_fields` guards the section against typos.
+        let err = serde_json::from_str::<RawConfig>(&format!(
+            r#"{{ "morphology": {{ "path": "d.zst", "pin": "{PIN}", "compress": true }} }}"#
+        ));
+        assert!(err.is_err(), "unknown morphology key must be rejected");
     }
 
     #[test]

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -107,6 +107,8 @@ pub fn resolve(preset: Option<Preset>, user: Config) -> Config {
         rules: merge(base, user.rules),
         // Formats are not preset-layered; layering preserves the user's resolved formats.
         formats: user.formats,
+        // Morphology is likewise the user's own setting; presets never supply one.
+        morphology: user.morphology,
     }
 }
 

--- a/crates/tzlint_core/src/dict.rs
+++ b/crates/tzlint_core/src/dict.rs
@@ -16,6 +16,10 @@
 //! property the dictionary-version tests rely on); an old pre-M2m cache that stored *decompressed*
 //! bytes simply fails the pin re-check and is transparently re-provisioned once.
 
+/// The in-memory dictionary container codec: split a decompressed dictionary blob into its
+/// component byte ranges (backend-agnostic, `wasm32`-clean, panic-free on untrusted bytes).
+pub mod container;
+
 use std::io::Read;
 use std::path::Path;
 

--- a/crates/tzlint_core/src/dict/container.rs
+++ b/crates/tzlint_core/src/dict/container.rs
@@ -1,0 +1,478 @@
+//! A tiny, self-describing container that bundles a morphology dictionary's component files into
+//! one byte blob — the *content* of the decompressed `.dict.zst` that
+//! [`provision_dictionary`](crate::provision_dictionary) returns.
+//!
+//! A native tokenizer backend (lindera, in `tzlint_morphology_native`) needs several separate
+//! component files (a prefix-dictionary trie, a connection-cost matrix, character/unknown-word
+//! tables, metadata). Rather than ship a directory or a tar — neither of which a browser/wasm
+//! embedder can use — those components are concatenated here into a single blob with a fixed
+//! header, so the whole dictionary travels as one hash-pinned, compressed artifact and is split
+//! back apart **in memory** at load time. This module is therefore deliberately backend-agnostic:
+//! it knows *byte ranges*, not lindera; it names no tokenizer type and touches neither
+//! [`Host`](crate::Host) nor the network, so it compiles for `wasm32` and a future browser backend
+//! reuses the exact same split.
+//!
+//! # Format (all integers little-endian)
+//!
+//! ```text
+//! offset  size  field
+//! 0       8     magic = b"TZDICTC1"   (the trailing digit is the format version; a bump is a new magic)
+//! 8       2     version: u16 = 1      (must equal 1)
+//! 10      2     member_count: u16 = 8 (must equal 8 — the canonical component set)
+//! 12      64    member table: 8 × { offset: u32, len: u32 }
+//! 76      …     payload: the 8 member byte ranges
+//! ```
+//!
+//! Members are **positional** (identified by table index, not by an embedded name string), which
+//! removes all name-decoding surface. The canonical order matches a lindera dictionary's component
+//! load order; see [`Member`].
+//!
+//! # Untrusted bytes
+//!
+//! The pin authenticates the *compressed* artifact, but [`parse`] still treats its input as
+//! untrusted and is **panic-free on any byte string**: every field is read through bounds-checked
+//! slicing, every member range is validated with checked arithmetic against the blob length, and a
+//! hostile length never drives an allocation (members are returned as borrowed slices, so the
+//! parser allocates nothing). Member *content* validity (a malformed trie or archive) is the
+//! backend loader's contract, not this codec's.
+
+use core::fmt;
+
+/// The 8-byte magic. The trailing `1` is the format version; a future incompatible layout uses a
+/// new magic (and `version`), so the two can never be confused.
+const MAGIC: &[u8; 8] = b"TZDICTC1";
+
+/// The only supported [`MAGIC`]-companion version.
+const VERSION: u16 = 1;
+
+/// The fixed component set: exactly this many members, in this order.
+pub const MEMBER_COUNT: usize = 8;
+
+/// Bytes before the payload: magic (8) + version (2) + count (2) + table (`MEMBER_COUNT` × 8).
+const HEADER_LEN: usize = 8 + 2 + 2 + MEMBER_COUNT * 8;
+
+/// The canonical members, in table order. The discriminant is the table index, and the order
+/// matches the component load order of a lindera IPADIC dictionary (`metadata` first, then the
+/// prefix-dictionary quartet, the connection matrix, and the two character tables).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(usize)]
+pub enum Member {
+    /// `metadata.json` — dictionary metadata (JSON).
+    Metadata = 0,
+    /// `dict.da` — prefix-dictionary double-array trie.
+    PrefixDa = 1,
+    /// `dict.vals` — prefix-dictionary value blob.
+    PrefixVals = 2,
+    /// `dict.wordsidx` — prefix-dictionary word-index blob.
+    PrefixWordsIdx = 3,
+    /// `dict.words` — prefix-dictionary word-detail blob.
+    PrefixWords = 4,
+    /// `matrix.mtx` — connection-cost matrix.
+    ConnectionMatrix = 5,
+    /// `char_def.bin` — character-definition table.
+    CharDef = 6,
+    /// `unk.bin` — unknown-word dictionary.
+    Unknown = 7,
+}
+
+/// A failure to parse or build a [`DictContainer`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContainerError {
+    /// The blob is shorter than a member needs (header or a member range runs past the end).
+    Truncated {
+        /// The byte length the read required.
+        need: usize,
+        /// The byte length actually available.
+        got: usize,
+    },
+    /// The leading 8 bytes are not the container magic.
+    BadMagic,
+    /// The version field is not a supported value.
+    UnsupportedVersion(u16),
+    /// The member count is not the canonical [`MEMBER_COUNT`].
+    BadMemberCount(u16),
+    /// A member's `offset + len` overflows past the addressable range.
+    MemberRangeOverflow {
+        /// The offending member index.
+        index: usize,
+    },
+    /// Building a container whose total size would exceed `u32` member offsets.
+    EncodeOverflow,
+}
+
+impl fmt::Display for ContainerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ContainerError::Truncated { need, got } => {
+                write!(
+                    f,
+                    "dictionary container truncated: need {need} bytes, got {got}"
+                )
+            }
+            ContainerError::BadMagic => write!(f, "not a dictionary container (bad magic)"),
+            ContainerError::UnsupportedVersion(v) => {
+                write!(f, "unsupported dictionary container version {v}")
+            }
+            ContainerError::BadMemberCount(n) => {
+                write!(
+                    f,
+                    "dictionary container must have {MEMBER_COUNT} members, found {n}"
+                )
+            }
+            ContainerError::MemberRangeOverflow { index } => {
+                write!(f, "dictionary container member {index} range overflows")
+            }
+            ContainerError::EncodeOverflow => {
+                write!(
+                    f,
+                    "dictionary container too large to encode (member offset exceeds u32)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for ContainerError {}
+
+/// A parsed container: borrowed byte slices for each of the [`MEMBER_COUNT`] members.
+///
+/// Built by [`parse`]; the slices borrow the input blob (zero-copy). Access members by their
+/// [`Member`] role via [`DictContainer::member`] or the named accessors.
+#[derive(Debug, Clone, Copy)]
+pub struct DictContainer<'a> {
+    members: [&'a [u8]; MEMBER_COUNT],
+}
+
+impl<'a> DictContainer<'a> {
+    /// The bytes of `member`.
+    #[must_use]
+    pub fn member(&self, member: Member) -> &'a [u8] {
+        // `member as usize` is always in `0..MEMBER_COUNT` (the enum has exactly that many
+        // variants), so this index never panics.
+        self.members[member as usize]
+    }
+
+    /// `metadata.json` bytes.
+    #[must_use]
+    pub fn metadata(&self) -> &'a [u8] {
+        self.member(Member::Metadata)
+    }
+    /// `dict.da` (prefix-dictionary trie) bytes.
+    #[must_use]
+    pub fn prefix_da(&self) -> &'a [u8] {
+        self.member(Member::PrefixDa)
+    }
+    /// `dict.vals` bytes.
+    #[must_use]
+    pub fn prefix_vals(&self) -> &'a [u8] {
+        self.member(Member::PrefixVals)
+    }
+    /// `dict.wordsidx` bytes.
+    #[must_use]
+    pub fn prefix_words_idx(&self) -> &'a [u8] {
+        self.member(Member::PrefixWordsIdx)
+    }
+    /// `dict.words` bytes.
+    #[must_use]
+    pub fn prefix_words(&self) -> &'a [u8] {
+        self.member(Member::PrefixWords)
+    }
+    /// `matrix.mtx` (connection-cost matrix) bytes.
+    #[must_use]
+    pub fn connection_matrix(&self) -> &'a [u8] {
+        self.member(Member::ConnectionMatrix)
+    }
+    /// `char_def.bin` bytes.
+    #[must_use]
+    pub fn char_def(&self) -> &'a [u8] {
+        self.member(Member::CharDef)
+    }
+    /// `unk.bin` (unknown-word dictionary) bytes.
+    #[must_use]
+    pub fn unknown(&self) -> &'a [u8] {
+        self.member(Member::Unknown)
+    }
+}
+
+/// Read a little-endian `u16` at `off`, or `None` if it runs past `data`.
+fn read_u16(data: &[u8], off: usize) -> Option<u16> {
+    let bytes = data.get(off..off.checked_add(2)?)?;
+    Some(u16::from_le_bytes([bytes[0], bytes[1]]))
+}
+
+/// Read a little-endian `u32` at `off`, or `None` if it runs past `data`.
+fn read_u32(data: &[u8], off: usize) -> Option<u32> {
+    let bytes = data.get(off..off.checked_add(4)?)?;
+    Some(u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+}
+
+/// Parse `data` as a [`DictContainer`], borrowing its member ranges.
+///
+/// Panic-free on arbitrary input: every read is bounds-checked and every member range is validated
+/// with checked arithmetic, so a truncated or hostile blob yields a [`ContainerError`], never a
+/// panic or an attacker-sized allocation.
+///
+/// # Errors
+///
+/// Returns [`ContainerError`] for a short blob, wrong magic/version, a member count other than
+/// [`MEMBER_COUNT`], or a member range that overflows or runs past the end of `data`.
+pub fn parse(data: &[u8]) -> Result<DictContainer<'_>, ContainerError> {
+    if data.len() < HEADER_LEN {
+        return Err(ContainerError::Truncated {
+            need: HEADER_LEN,
+            got: data.len(),
+        });
+    }
+    // The length check above guarantees the whole header (offsets 0..HEADER_LEN) is present, so the
+    // header reads below cannot return `None`; they stay `get`-based regardless, to keep the parser
+    // uniformly panic-free.
+    if data.get(0..8) != Some(MAGIC.as_slice()) {
+        return Err(ContainerError::BadMagic);
+    }
+    let truncated = || ContainerError::Truncated {
+        need: HEADER_LEN,
+        got: data.len(),
+    };
+    let version = read_u16(data, 8).ok_or_else(truncated)?;
+    if version != VERSION {
+        return Err(ContainerError::UnsupportedVersion(version));
+    }
+    let count = read_u16(data, 10).ok_or_else(truncated)?;
+    if count as usize != MEMBER_COUNT {
+        return Err(ContainerError::BadMemberCount(count));
+    }
+
+    let mut members: [&[u8]; MEMBER_COUNT] = [&[]; MEMBER_COUNT];
+    for (i, slot) in members.iter_mut().enumerate() {
+        // Each table entry is 8 bytes (u32 offset + u32 len) starting at offset 12.
+        let entry = 12 + i * 8;
+        let offset = read_u32(data, entry).ok_or_else(truncated)? as usize;
+        let len = read_u32(data, entry + 4).ok_or_else(truncated)? as usize;
+        let end = offset
+            .checked_add(len)
+            .ok_or(ContainerError::MemberRangeOverflow { index: i })?;
+        *slot = data.get(offset..end).ok_or(ContainerError::Truncated {
+            need: end,
+            got: data.len(),
+        })?;
+    }
+    Ok(DictContainer { members })
+}
+
+/// Build a container blob from the [`MEMBER_COUNT`] member byte ranges, in [`Member`] order.
+///
+/// The inverse of [`parse`]: `parse(&encode(m)?)` yields a container whose members equal `m`.
+///
+/// # Errors
+///
+/// Returns [`ContainerError::EncodeOverflow`] if the members are collectively large enough that a
+/// member's start offset would not fit in a `u32` (the container then could not be parsed back).
+pub fn encode(members: &[&[u8]; MEMBER_COUNT]) -> Result<Vec<u8>, ContainerError> {
+    let payload_len: usize = members.iter().map(|m| m.len()).sum();
+    let mut out = Vec::with_capacity(HEADER_LEN + payload_len);
+    out.extend_from_slice(MAGIC);
+    out.extend_from_slice(&VERSION.to_le_bytes());
+    // `MEMBER_COUNT` is 8, well within u16.
+    out.extend_from_slice(&(MEMBER_COUNT as u16).to_le_bytes());
+
+    let mut offset = u32::try_from(HEADER_LEN).map_err(|_| ContainerError::EncodeOverflow)?;
+    for m in members {
+        let len = u32::try_from(m.len()).map_err(|_| ContainerError::EncodeOverflow)?;
+        out.extend_from_slice(&offset.to_le_bytes());
+        out.extend_from_slice(&len.to_le_bytes());
+        offset = offset
+            .checked_add(len)
+            .ok_or(ContainerError::EncodeOverflow)?;
+    }
+    for m in members {
+        out.extend_from_slice(m);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Eight distinguishable dummy members (different bytes + lengths, including an empty one).
+    fn sample() -> [Vec<u8>; MEMBER_COUNT] {
+        [
+            b"{\"metadata\":1}".to_vec(),
+            vec![0xDA; 5],
+            vec![0x01, 0x02, 0x03],
+            vec![0x10, 0x11],
+            vec![0x20],
+            vec![0x00, 0xFF, 0x00, 0xFF], // matrix: even length on purpose
+            vec![0xC0; 7],
+            Vec::new(), // an empty member must round-trip
+        ]
+    }
+
+    fn refs(members: &[Vec<u8>; MEMBER_COUNT]) -> [&[u8]; MEMBER_COUNT] {
+        std::array::from_fn(|i| members[i].as_slice())
+    }
+
+    #[test]
+    fn encode_then_parse_round_trips_every_member() {
+        let members = sample();
+        let blob = encode(&refs(&members)).unwrap();
+        let parsed = parse(&blob).unwrap();
+        for (i, expected) in members.iter().enumerate() {
+            assert_eq!(
+                parsed.members[i], *expected,
+                "member {i} did not round-trip"
+            );
+        }
+        // The named accessors agree with positional order.
+        assert_eq!(parsed.metadata(), members[0]);
+        assert_eq!(parsed.prefix_da(), members[1]);
+        assert_eq!(parsed.unknown(), members[7]);
+        assert_eq!(parsed.connection_matrix(), members[5]);
+    }
+
+    #[test]
+    fn parse_rejects_a_short_blob_without_panicking() {
+        let members = sample();
+        let blob = encode(&refs(&members)).unwrap();
+        // Every truncation of a valid blob is an Err, never a panic.
+        for n in 0..blob.len() {
+            let err = parse(&blob[..n]).unwrap_err();
+            // A prefix shorter than the header is Truncated; once the header is present but a
+            // member range points past the (now shorter) end, it is Truncated too.
+            assert!(
+                matches!(
+                    err,
+                    ContainerError::Truncated { .. } | ContainerError::BadMagic
+                ),
+                "n={n} gave {err:?}"
+            );
+        }
+        // The empty blob specifically.
+        assert!(matches!(
+            parse(&[]).unwrap_err(),
+            ContainerError::Truncated { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_bad_magic() {
+        let members = sample();
+        let mut blob = encode(&refs(&members)).unwrap();
+        blob[0] ^= 0xFF;
+        assert_eq!(parse(&blob).unwrap_err(), ContainerError::BadMagic);
+    }
+
+    #[test]
+    fn parse_rejects_unsupported_version() {
+        let members = sample();
+        let mut blob = encode(&refs(&members)).unwrap();
+        blob[8] = 2; // version low byte
+        blob[9] = 0;
+        assert_eq!(
+            parse(&blob).unwrap_err(),
+            ContainerError::UnsupportedVersion(2)
+        );
+    }
+
+    #[test]
+    fn parse_rejects_a_wrong_member_count() {
+        let members = sample();
+        for bad in [0u16, 7, 9, 65535] {
+            let mut blob = encode(&refs(&members)).unwrap();
+            blob[10] = (bad & 0xFF) as u8;
+            blob[11] = (bad >> 8) as u8;
+            assert_eq!(
+                parse(&blob).unwrap_err(),
+                ContainerError::BadMemberCount(bad),
+                "count={bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_rejects_a_member_offset_len_overflow() {
+        let members = sample();
+        let mut blob = encode(&refs(&members)).unwrap();
+        // Member 0's table entry is at offset 12: set offset=u32::MAX, len=2 so offset+len overflows
+        // usize on 32-bit and, on 64-bit, lands far past the end → either MemberRangeOverflow or
+        // Truncated, and crucially NOT a panic or a giant allocation.
+        blob[12..16].copy_from_slice(&u32::MAX.to_le_bytes());
+        blob[16..20].copy_from_slice(&2u32.to_le_bytes());
+        let err = parse(&blob).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ContainerError::MemberRangeOverflow { index: 0 } | ContainerError::Truncated { .. }
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_a_member_pointing_past_the_end() {
+        let members = sample();
+        let mut blob = encode(&refs(&members)).unwrap();
+        // Member 7 (last): make its len reach one past the blob end.
+        let entry = 12 + 7 * 8;
+        let offset = u32::from_le_bytes(blob[entry..entry + 4].try_into().unwrap());
+        let too_long = (blob.len() as u32 - offset) + 1;
+        blob[entry + 4..entry + 8].copy_from_slice(&too_long.to_le_bytes());
+        assert!(matches!(
+            parse(&blob).unwrap_err(),
+            ContainerError::Truncated { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_never_panics_on_mutated_bytes() {
+        // Defense-in-depth fuzz-lite: walk a valid blob, flip each byte through several patterns and
+        // also truncate, asserting parse returns Ok or Err but never panics. Deterministic (no rng).
+        let members = sample();
+        let blob = encode(&refs(&members)).unwrap();
+        for i in 0..blob.len() {
+            for pat in [0x00u8, 0x01, 0x7F, 0x80, 0xFF] {
+                let mut m = blob.clone();
+                m[i] ^= pat;
+                let _ = parse(&m); // must not panic
+                let _ = parse(&m[..i]); // truncations too
+            }
+        }
+    }
+
+    #[test]
+    fn empty_member_round_trips_as_an_empty_slice() {
+        let members = sample();
+        let blob = encode(&refs(&members)).unwrap();
+        let parsed = parse(&blob).unwrap();
+        assert!(
+            parsed.unknown().is_empty(),
+            "member 7 is empty by construction"
+        );
+    }
+
+    #[test]
+    fn each_error_variant_renders_a_distinct_message() {
+        assert!(
+            ContainerError::Truncated { need: 76, got: 3 }
+                .to_string()
+                .contains("truncated")
+        );
+        assert!(ContainerError::BadMagic.to_string().contains("magic"));
+        assert!(
+            ContainerError::UnsupportedVersion(2)
+                .to_string()
+                .contains("version 2")
+        );
+        assert!(ContainerError::BadMemberCount(7).to_string().contains('7'));
+        assert!(
+            ContainerError::MemberRangeOverflow { index: 3 }
+                .to_string()
+                .contains("member 3")
+        );
+        assert!(
+            ContainerError::EncodeOverflow
+                .to_string()
+                .contains("too large")
+        );
+    }
+}

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -35,9 +35,10 @@ pub use cache::{
     CacheError, CacheKey, CacheKeyInput, DocumentCache, document_cache_key, lint_cached,
 };
 pub use config::{
-    CONFIG_SCHEMA, ColumnConfig, Config, ConfigError, ConfigFormat, DiscoveredConfig, FormatConfig,
-    Preset, RuleSetting, ShadowedCandidate, discover, resolve,
+    CONFIG_SCHEMA, ColumnConfig, Config, ConfigError, ConfigFormat, DictSource, DiscoveredConfig,
+    FormatConfig, MorphologyConfig, Preset, RuleSetting, ShadowedCandidate, discover, resolve,
 };
+pub use dict::container::{ContainerError, DictContainer, Member};
 pub use dict::{DictError, provision_dictionary, provision_dictionary_from_url};
 pub use engine::Engine;
 pub use fix::{FixPass, MAX_FIX_PASSES, apply_fixes, fix};

--- a/crates/tzlint_core/tests/config_schema.rs
+++ b/crates/tzlint_core/tests/config_schema.rs
@@ -266,6 +266,55 @@ const CORPUS: &[(&str, &str, Mode)] = &[
         r#"{"formats":{"csv":{"header":true,"columns":{"body":{"rules":{"r":{"severity":"fatal"}}}}}}}"#,
         Mode::Reject,
     ),
+    // `morphology`: a hash-pinned dictionary source. All validations here are schema-expressible
+    // (the pin pattern, the exactly-one-of-path/url `oneOf`, the lang enum, required pin,
+    // additionalProperties:false), so every fixture is strict schema⇔loader parity. A 64-zero pin
+    // is valid hex.
+    (
+        "morphology path source",
+        r#"{"morphology":{"path":"dict/ja.dict.zst","pin":"0000000000000000000000000000000000000000000000000000000000000000"}}"#,
+        Mode::Accept,
+    ),
+    (
+        "morphology url source with explicit ja",
+        r#"{"morphology":{"url":"https://example.com/ja.dict.zst","pin":"0000000000000000000000000000000000000000000000000000000000000000","lang":"ja"}}"#,
+        Mode::Accept,
+    ),
+    (
+        "morphology pin too short",
+        r#"{"morphology":{"path":"d.zst","pin":"abc"}}"#,
+        Mode::Reject,
+    ),
+    (
+        "morphology pin non-hex",
+        r#"{"morphology":{"path":"d.zst","pin":"g000000000000000000000000000000000000000000000000000000000000000"}}"#,
+        Mode::Reject,
+    ),
+    (
+        "morphology both path and url",
+        r#"{"morphology":{"path":"d.zst","url":"https://x/d.zst","pin":"0000000000000000000000000000000000000000000000000000000000000000"}}"#,
+        Mode::Reject,
+    ),
+    (
+        "morphology neither path nor url",
+        r#"{"morphology":{"pin":"0000000000000000000000000000000000000000000000000000000000000000"}}"#,
+        Mode::Reject,
+    ),
+    (
+        "morphology missing pin",
+        r#"{"morphology":{"path":"d.zst"}}"#,
+        Mode::Reject,
+    ),
+    (
+        "morphology unsupported lang",
+        r#"{"morphology":{"path":"d.zst","pin":"0000000000000000000000000000000000000000000000000000000000000000","lang":"ko"}}"#,
+        Mode::Reject,
+    ),
+    (
+        "morphology unknown key",
+        r#"{"morphology":{"path":"d.zst","pin":"0000000000000000000000000000000000000000000000000000000000000000","zstd":true}}"#,
+        Mode::Reject,
+    ),
 ];
 
 fn validator() -> Validator {

--- a/crates/tzlint_morphology_native/Cargo.toml
+++ b/crates/tzlint_morphology_native/Cargo.toml
@@ -21,10 +21,45 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 # the wasm-facing crates (ast/pdk/core), so cargo never resolves lindera for the `wasm32` build,
 # and the crate's `lib.rs` is `#![cfg(not(target_arch = "wasm32"))]` as a second guard. MIT.
 lindera = "3.0.7"
+# The dictionary component types + their byte-`load()`s (PrefixDictionary, ConnectionCostMatrix,
+# CharacterDefinition, UnknownDictionary, Metadata, and the `Dictionary` struct), which the
+# `lindera` meta-crate does not re-export. Needed to assemble a `Dictionary` in memory from the
+# container's component byte ranges (`from_dictionary_bytes`). Already in the graph as a transitive
+# dependency of `lindera` at this exact version; MIT.
+lindera-dictionary = "3.0.7"
+# The wasm-clean, lindera-free dictionary-container codec (`tzlint_core::dict::container`) used to
+# split the decompressed blob into component byte ranges. A native-only edge (core never depends on
+# this crate, so there is no cycle and the wasm graph is untouched).
+tzlint_core = { path = "../tzlint_core", version = "0.0.0" }
+# Packaging-only (behind the `package` feature): re-serialize a loaded dictionary's components back
+# to their on-disk byte forms when BUILDING a distributable container. `serde_json` re-emits
+# `metadata.json`; `rkyv` re-emits the `char_def.bin`/`unk.bin` archives. Both are already in the
+# graph via lindera at these versions; optional so the production provider never pulls them.
+serde_json = { version = "1", optional = true }
+rkyv = { version = "0.8", optional = true }
 
 [features]
 # Compile a dictionary INTO the binary so the provider can be exercised OFFLINE (no downloaded
 # dictionary directory, no committed fixture). Default-off and intended for tests only — the
 # production path loads a pre-built dictionary directory from a filesystem path. Enabling it pulls
-# the full IPADIC into the (test) binary, so it is never on by default.
-embed-ipadic = ["lindera/embed-ipadic"]
+# the full IPADIC into the (test) binary, so it is never on by default. It also enables `package`
+# so the round-trip tests can build a container from the embedded dictionary.
+embed-ipadic = ["lindera/embed-ipadic", "package"]
+# The dictionary-container PACKAGING side: `extract_components` (split a loaded `Dictionary` back
+# into the 8 component byte arrays) + the `pack_ipadic` example. Dev/maintainer-only; pulls the
+# re-serialization deps above. Never needed by the runtime provider (which only ever LOADS a
+# container via `from_dictionary_bytes`).
+package = ["dep:serde_json", "dep:rkyv"]
+
+# The maintainer packaging tool (build a `.dict` container from embedded IPADIC). Needs the
+# dictionary (`embed-ipadic`) and the extractor (`package`); never built by the default workspace,
+# so it stays out of default `cargo build`/clippy and the wasm graph.
+[[example]]
+name = "pack_ipadic"
+required-features = ["embed-ipadic"]
+
+[dev-dependencies]
+# The morphology rule under test (`NoDoubledJoshi`) for the end-to-end firing test: a real lindera
+# provider, wired through `tzlint_core::lint_document`, must make the rule fire. Test-only — there is
+# no production edge from this backend crate to the rules crate.
+tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }

--- a/crates/tzlint_morphology_native/examples/pack_ipadic.rs
+++ b/crates/tzlint_morphology_native/examples/pack_ipadic.rs
@@ -1,0 +1,45 @@
+//! Build a distributable dictionary container from lindera's embedded IPADIC.
+//!
+//! A **maintainer tool**, never shipped: it produces the *uncompressed* `.dict` container that
+//! [`LinderaProvider::from_dictionary_bytes`](tzlint_morphology_native::LinderaProvider::from_dictionary_bytes)
+//! consumes. Compress and pin it out of band (the in-tree `ruzstd` decoder is decode-only, so
+//! packaging shells out to the `zstd` CLI):
+//!
+//! ```sh
+//! cargo run -p tzlint_morphology_native --example pack_ipadic --features embed-ipadic -- ipadic.dict
+//! zstd -q -19 ipadic.dict -o ipadic.dict.zst   # compress (any zstd level)
+//! b3sum ipadic.dict.zst                         # the BLAKE3 pin for `.tzlintrc` morphology.pin
+//! ```
+//!
+//! The config `pin` is BLAKE3 over the **compressed** `ipadic.dict.zst` (the value
+//! `provision_dictionary` verifies). Re-pack and re-pin on any lindera-dictionary version bump:
+//! the container embeds version-coupled rkyv/daachorse blobs.
+
+use std::error::Error;
+use std::path::Path;
+
+use lindera::dictionary::load_dictionary;
+use tzlint_core::dict::container;
+use tzlint_core::io::{Host, NativeHost};
+use tzlint_morphology_native::extract_components;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let out = std::env::args()
+        .nth(1)
+        .ok_or("usage: pack_ipadic <out.dict>")?;
+
+    let dictionary = load_dictionary("embedded://ipadic").map_err(|e| e.to_string())?;
+    let components = extract_components(&dictionary).map_err(|e| e.to_string())?;
+    let refs: [&[u8]; container::MEMBER_COUNT] = std::array::from_fn(|i| components[i].as_slice());
+    let blob = container::encode(&refs).map_err(|e| e.to_string())?;
+
+    // Write through the centralized Host boundary (atomic temp-then-rename), the same way the
+    // linter does all of its I/O — so an interrupted pack never leaves a half-written `.dict`.
+    NativeHost
+        .write_atomic(Path::new(&out), &blob)
+        .map_err(|e| e.to_string())?;
+
+    println!("wrote {out} ({} bytes, uncompressed container)", blob.len());
+    println!("next: `zstd -q -19 {out} -o {out}.zst` then `b3sum {out}.zst` for the config pin");
+    Ok(())
+}

--- a/crates/tzlint_morphology_native/src/lib.rs
+++ b/crates/tzlint_morphology_native/src/lib.rs
@@ -14,10 +14,17 @@ use lindera::dictionary::load_dictionary;
 use lindera::mode::Mode;
 use lindera::segmenter::Segmenter;
 use lindera::tokenizer::Tokenizer;
+use lindera_dictionary::dictionary::Dictionary;
+use lindera_dictionary::dictionary::character_definition::CharacterDefinition;
+use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix;
+use lindera_dictionary::dictionary::metadata::Metadata;
+use lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary;
+use lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary;
 use tzlint_ast::morphology::{
     FeatureKey, Lang, MorphologyBuilder, MorphologyV1, Tagset, Token, TokenAttrs,
 };
 use tzlint_ast::{NodeId, Span};
+use tzlint_core::dict::container;
 use tzlint_pdk::{MorphologyError, MorphologyProvider};
 
 /// A Japanese [`MorphologyProvider`] backed by lindera + an IPADIC dictionary.
@@ -61,16 +68,161 @@ impl LinderaProvider {
         Self::build("embedded://ipadic")
     }
 
-    /// Shared constructor tail: load the dictionary `uri`, wrap it in a normal-mode segmenter, and
-    /// build the immutable tokenizer. Every lindera error becomes a [`MorphologyError::Backend`].
+    /// Build a provider from a single in-memory dictionary **container** blob — the decompressed
+    /// content of the `.dict.zst` that
+    /// [`provision_dictionary`](tzlint_core::provision_dictionary) returns.
+    ///
+    /// The blob carries the dictionary's component files bundled by
+    /// [`tzlint_core::dict::container`]; this splits them back apart **in memory** (no filesystem,
+    /// no temp directory) and assembles a lindera [`Dictionary`] from the component byte ranges —
+    /// the same shape lindera's own embedded loader uses. It is the representation a host without a
+    /// filesystem (a browser/wasm embedder) can also produce, which `new` (a directory path) can
+    /// not.
+    ///
+    /// The container is treated as untrusted: a malformed blob — bad framing, or a connection-cost
+    /// matrix whose byte length would make lindera's loader panic — is a [`MorphologyError::Backend`],
+    /// never a panic.
+    pub fn from_dictionary_bytes(container: &[u8]) -> Result<Self, MorphologyError> {
+        let c = container::parse(container)
+            .map_err(|e| MorphologyError::Backend(format!("dictionary container: {e}")))?;
+
+        // Guard the connection-cost matrix BEFORE handing it to lindera. `ConnectionCostMatrix::load`
+        // computes `len/2 - 3` `i16`s and feeds `&data[6..]` to `byteorder::read_i16_into`, which
+        // PANICS unless `src.len() == 2 * dst.len()` — i.e. it panics on an odd-length matrix — and
+        // its old-format branch indexes by attacker-declared sizes. Our packaging always emits the
+        // "new" transposed format (leading `i16 == -1`, so bytes `FF FF`) with an even length, which
+        // takes the panic-free new-format path; require exactly that shape and reject anything else
+        // as a corrupt container rather than risk an abort.
+        let matrix = c.connection_matrix();
+        let new_format_matrix = matrix.len() >= 6
+            && matrix.len() % 2 == 0
+            && matrix.first() == Some(&0xFF)
+            && matrix.get(1) == Some(&0xFF);
+        if !new_format_matrix {
+            return Err(MorphologyError::Backend(
+                "dictionary container: connection matrix is not a valid new-format matrix.mtx"
+                    .to_string(),
+            ));
+        }
+
+        // Assemble the Dictionary exactly as lindera's embedded loader does (component load order,
+        // `is_system = true` for a system dictionary). The four prefix-dictionary blobs need owned
+        // `Vec<u8>` (lindera's `Data` has no `From<&[u8]>` for a borrowed slice); the rkyv/JSON
+        // members take a borrowed `&[u8]` and copy internally.
+        let metadata = Metadata::load(c.metadata())
+            .map_err(|e| MorphologyError::Backend(format!("dictionary metadata: {e}")))?;
+        let prefix_dictionary = PrefixDictionary::load(
+            c.prefix_da().to_vec(),
+            c.prefix_vals().to_vec(),
+            c.prefix_words_idx().to_vec(),
+            c.prefix_words().to_vec(),
+            // `is_system = true`: a system dictionary. `false` is for user dictionaries and would
+            // silently corrupt the value (offset, count) bit-packing.
+            true,
+        )
+        .map_err(|e| MorphologyError::Backend(format!("prefix dictionary: {e}")))?;
+        let connection_cost_matrix = ConnectionCostMatrix::load(matrix.to_vec())
+            .map_err(|e| MorphologyError::Backend(format!("connection matrix: {e}")))?;
+        let character_definition = CharacterDefinition::load(c.char_def())
+            .map_err(|e| MorphologyError::Backend(format!("character definition: {e}")))?;
+        let unknown_dictionary = UnknownDictionary::load(c.unknown())
+            .map_err(|e| MorphologyError::Backend(format!("unknown dictionary: {e}")))?;
+
+        let dictionary = Dictionary {
+            prefix_dictionary,
+            connection_cost_matrix,
+            character_definition,
+            unknown_dictionary,
+            metadata,
+        };
+        Ok(Self::from_dictionary(dictionary))
+    }
+
+    /// Shared constructor tail: load the dictionary `uri`, then hand off to
+    /// [`from_dictionary`](Self::from_dictionary). Every lindera error becomes a
+    /// [`MorphologyError::Backend`].
     fn build(uri: &str) -> Result<Self, MorphologyError> {
         let dictionary =
             load_dictionary(uri).map_err(|e| MorphologyError::Backend(e.to_string()))?;
-        let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
-        Ok(LinderaProvider {
-            tokenizer: Tokenizer::new(segmenter),
-        })
+        Ok(Self::from_dictionary(dictionary))
     }
+
+    /// Wrap an already-loaded lindera [`Dictionary`] in a normal-mode segmenter and the immutable
+    /// tokenizer. The single convergence point for every constructor — a directory
+    /// ([`new`](Self::new)), the embedded IPADIC
+    /// ([`with_embedded_ipadic`](Self::with_embedded_ipadic)), and an in-memory container
+    /// ([`from_dictionary_bytes`](Self::from_dictionary_bytes)) — so [`analyze`](Self::analyze)
+    /// behaves identically no matter how the dictionary was obtained.
+    fn from_dictionary(dictionary: Dictionary) -> Self {
+        let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+        LinderaProvider {
+            tokenizer: Tokenizer::new(segmenter),
+        }
+    }
+}
+
+/// Split a loaded lindera [`Dictionary`] back into the 8 component byte arrays, in
+/// [`container::Member`] order — the inverse of the assembly in
+/// [`from_dictionary_bytes`](LinderaProvider::from_dictionary_bytes).
+///
+/// This is the **packaging** side: feed the result to [`container::encode`] to build a
+/// distributable container blob (then zstd-compress + hash-pin it). Dev/maintainer-only (behind the
+/// `package` feature); the runtime provider never re-serializes a dictionary.
+///
+/// `dict.vals`/`dict.wordsidx`/`dict.words` round-trip verbatim and `dict.da` is re-`serialize()`d
+/// byte-faithfully by daachorse. The two rkyv archives (`char_def.bin`/`unk.bin`) and
+/// `metadata.json` are re-serialized to value-equal bytes, and the connection matrix — which lindera
+/// keeps only as a parsed `i16` grid — is re-encoded into the "new" `matrix.mtx` format. A
+/// load → extract → load round-trip is therefore **value-exact** (proven by the `embed-ipadic`
+/// round-trip test), even where the bytes are not identical to the original files.
+///
+/// # Errors
+///
+/// [`MorphologyError::Backend`] if re-serializing `metadata.json` or an rkyv archive fails.
+#[cfg(feature = "package")]
+pub fn extract_components(
+    dict: &Dictionary,
+) -> Result<[Vec<u8>; container::MEMBER_COUNT], MorphologyError> {
+    let metadata = serde_json::to_vec(&dict.metadata)
+        .map_err(|e| MorphologyError::Backend(format!("packaging metadata.json: {e}")))?;
+    let da = dict.prefix_dictionary.da.serialize();
+    let vals = (*dict.prefix_dictionary.vals_data).to_vec();
+    let words_idx = (*dict.prefix_dictionary.words_idx_data).to_vec();
+    let words = (*dict.prefix_dictionary.words_data).to_vec();
+    let matrix = encode_connection_matrix(&dict.connection_cost_matrix);
+    let char_def = rkyv::to_bytes::<rkyv::rancor::Error>(&dict.character_definition)
+        .map_err(|e| MorphologyError::Backend(format!("packaging char_def.bin: {e}")))?
+        .to_vec();
+    let unk = rkyv::to_bytes::<rkyv::rancor::Error>(&dict.unknown_dictionary)
+        .map_err(|e| MorphologyError::Backend(format!("packaging unk.bin: {e}")))?
+        .to_vec();
+
+    let mut out: [Vec<u8>; container::MEMBER_COUNT] = std::array::from_fn(|_| Vec::new());
+    out[container::Member::Metadata as usize] = metadata;
+    out[container::Member::PrefixDa as usize] = da;
+    out[container::Member::PrefixVals as usize] = vals;
+    out[container::Member::PrefixWordsIdx as usize] = words_idx;
+    out[container::Member::PrefixWords as usize] = words;
+    out[container::Member::ConnectionMatrix as usize] = matrix;
+    out[container::Member::CharDef as usize] = char_def;
+    out[container::Member::Unknown as usize] = unk;
+    Ok(out)
+}
+
+/// Re-encode lindera's parsed connection-cost grid into a "new"-format `matrix.mtx` byte blob:
+/// little-endian `i16` `[-1, forward_size, backward_size]` followed by the cost grid. Always an even
+/// length beginning `FF FF` — the shape
+/// [`from_dictionary_bytes`](LinderaProvider::from_dictionary_bytes) requires.
+#[cfg(feature = "package")]
+fn encode_connection_matrix(matrix: &ConnectionCostMatrix) -> Vec<u8> {
+    let mut out = Vec::with_capacity(6 + matrix.costs_data.len() * 2);
+    out.extend_from_slice(&(-1i16).to_le_bytes());
+    out.extend_from_slice(&(matrix.forward_size as i16).to_le_bytes());
+    out.extend_from_slice(&(matrix.backward_size as i16).to_le_bytes());
+    for &cost in &matrix.costs_data {
+        out.extend_from_slice(&cost.to_le_bytes());
+    }
+    out
 }
 
 /// The lindera/IPADIC `details()` column index of each canonical [`FeatureKey`]. `base_form`
@@ -207,11 +359,139 @@ mod tests {
         assert!(matches!(err, MorphologyError::Backend(_)), "{err}");
     }
 
+    /// Arbitrary bytes are not a dictionary container: a clean `Backend` error, never a panic. (No
+    /// real dictionary needed — this fails at the container parse, before any lindera load.)
+    #[test]
+    fn from_dictionary_bytes_rejects_non_container_bytes() {
+        let err = LinderaProvider::from_dictionary_bytes(b"definitely not a dictionary container")
+            .unwrap_err();
+        assert!(matches!(err, MorphologyError::Backend(_)), "{err}");
+    }
+
+    /// A structurally valid container whose connection-matrix member has an odd length — the exact
+    /// shape that makes lindera's `ConnectionCostMatrix::load` panic via `read_i16_into`. The
+    /// bridge's matrix guard must turn it into a clean `Backend` error, never an abort. The guard
+    /// runs before any lindera load, so the other members can be empty placeholders.
+    #[test]
+    fn from_dictionary_bytes_rejects_a_bad_matrix_without_panicking() {
+        let members: [Vec<u8>; container::MEMBER_COUNT] = std::array::from_fn(|i| {
+            if i == container::Member::ConnectionMatrix as usize {
+                vec![0xFF, 0xFF, 0x00] // odd length: would panic read_i16_into without the guard
+            } else {
+                Vec::new()
+            }
+        });
+        let refs: [&[u8]; container::MEMBER_COUNT] = std::array::from_fn(|i| members[i].as_slice());
+        let blob = container::encode(&refs).expect("encodes");
+        let err = LinderaProvider::from_dictionary_bytes(&blob).unwrap_err();
+        assert!(matches!(err, MorphologyError::Backend(_)), "{err}");
+        assert!(err.to_string().contains("connection matrix"), "{err}");
+    }
+
     // The mapping tests need a real tokenizer; they run against lindera's embedded IPADIC, compiled
     // into the test binary by the `embed-ipadic` feature (no network, no committed fixture).
     #[cfg(feature = "embed-ipadic")]
     fn ja() -> LinderaProvider {
         LinderaProvider::with_embedded_ipadic().expect("embedded IPADIC loads")
+    }
+
+    /// The headline proof that the in-memory container bridge WORKS on a real dictionary: pack the
+    /// embedded IPADIC into a container, rehydrate a provider from it via `from_dictionary_bytes`,
+    /// and assert it tokenizes real Japanese **byte-for-byte identically** to the embedded reference.
+    /// Equal token streams (surfaces, features, readings) prove the round-trip is value-exact —
+    /// including the re-encoded connection-cost matrix and the `is_system = true` bit-packing, the
+    /// two places a packaging bug would silently corrupt segmentation.
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn from_dictionary_bytes_round_trips_embedded_ipadic_and_tokenizes_identically() {
+        let dict = load_dictionary("embedded://ipadic").expect("embedded IPADIC loads");
+        let components = extract_components(&dict).expect("extract components");
+        let refs: [&[u8]; container::MEMBER_COUNT] =
+            std::array::from_fn(|i| components[i].as_slice());
+        let blob = container::encode(&refs).expect("encode container");
+
+        let rehydrated =
+            LinderaProvider::from_dictionary_bytes(&blob).expect("rehydrate from container");
+        let reference = ja();
+
+        for text in [
+            "関西国際空港限定トートバッグ",
+            "すもももももももものうち",
+            "本を読む",
+            "私は彼は来た",
+        ] {
+            let from_container = rehydrated
+                .analyze(text, 0, NodeId(0))
+                .expect("rehydrated analyze");
+            let from_embedded = reference
+                .analyze(text, 0, NodeId(0))
+                .expect("reference analyze");
+            assert!(!from_container.tokens.is_empty(), "no tokens for {text:?}");
+            // Byte-for-byte equality of the whole MorphologyV1 (tokens + features + interned
+            // strings) — the strongest equivalence, and it localizes any matrix/packing regression.
+            let a = to_archive_morphology(&from_container).expect("archive rehydrated");
+            let b = to_archive_morphology(&from_embedded).expect("archive reference");
+            // `AlignedVec` has no `PartialEq`; compare the archived bytes directly (Deref to [u8]).
+            assert_eq!(&a[..], &b[..], "token streams differ for {text:?}");
+        }
+    }
+
+    /// The matrix guard's panic-prevention, on a REAL dictionary: valid metadata/prefix members but
+    /// a connection-matrix member truncated to an odd length — the exact shape that makes lindera's
+    /// `ConnectionCostMatrix::load` panic in `read_i16_into`. The guard must turn it into a clean
+    /// `Backend` error. (Removing the guard makes this test abort instead of asserting, so it pins
+    /// the guard's necessity against the real loader.)
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn from_dictionary_bytes_rejects_a_corrupt_real_matrix_without_panicking() {
+        let dict = load_dictionary("embedded://ipadic").expect("embedded IPADIC loads");
+        let mut components = extract_components(&dict).expect("extract components");
+        components[container::Member::ConnectionMatrix as usize].pop(); // → odd length
+        let refs: [&[u8]; container::MEMBER_COUNT] =
+            std::array::from_fn(|i| components[i].as_slice());
+        let blob = container::encode(&refs).expect("encode container");
+        let err = LinderaProvider::from_dictionary_bytes(&blob).unwrap_err();
+        assert!(matches!(err, MorphologyError::Backend(_)), "{err}");
+        assert!(err.to_string().contains("connection matrix"), "{err}");
+    }
+
+    /// The end-to-end firing proof through the engine: a REAL lindera provider, wired into a
+    /// [`MorphologyRegistry`] and run through `tzlint_core::lint_document`, makes the
+    /// `no-doubled-joshi` morphology rule FIRE on real Japanese — and a run with no provider leaves
+    /// it inert. This closes the loop the rest of the suite proves piecewise (the bridge tokenizes;
+    /// the analysis pass builds the table; the rule reads it).
+    #[cfg(feature = "embed-ipadic")]
+    #[test]
+    fn no_doubled_joshi_fires_through_lint_document_with_a_real_provider() {
+        use tzlint_core::{
+            DictId, MorphologyRegistry, ProcessorConfig, RegionRules, Registry, lint_document,
+        };
+        use tzlint_rules::NoDoubledJoshi;
+
+        // A paragraph repeating the particle は in one sentence — the canonical doubled-joshi case.
+        let source = "私は彼は本を読む。\n";
+        let rules = RegionRules::base_only(vec![Box::new(NoDoubledJoshi::default())]);
+        let fires = |morphology: Option<&MorphologyRegistry>| {
+            lint_document(
+                Some("md"),
+                source,
+                &Registry::with_builtins(),
+                &ProcessorConfig::default(),
+                &rules,
+                morphology,
+            )
+            .expect("lint_document")
+            .iter()
+            .any(|d| d.rule_id.as_str() == "no-doubled-joshi")
+        };
+
+        let mut reg = MorphologyRegistry::new();
+        reg.insert(Box::new(ja()), DictId::from_pin([7; 32]));
+        assert!(fires(Some(&reg)), "rule must fire with a real JA provider");
+        assert!(
+            !fires(None),
+            "rule must stay inert without a morphology provider"
+        );
     }
 
     #[cfg(feature = "embed-ipadic")]

--- a/docs/design/dictionary-container-and-cli-wiring.md
+++ b/docs/design/dictionary-container-and-cli-wiring.md
@@ -1,0 +1,123 @@
+# Dictionary container & CLI morphology wiring (M2j-wiring)
+
+This is the slice that finally makes the morphology-dependent rules (today,
+[`no-doubled-joshi`](../../crates/tzlint_rules/src/rules/no_doubled_joshi.rs)) **fire on real
+Japanese text**. The frozen `MorphologyV1` model, the provider trait, the registry/fingerprint, the
+analysis pass, the dictionary provisioning (verify → decompress → cache), and the native
+[lindera](https://github.com/lindera-morphology/lindera) backend all already existed; what was
+missing was the connection between *a provisioned dictionary blob* and *a working tokenizer*, and
+between *that tokenizer* and *the CLI*.
+
+## The problem
+
+`provision_dictionary` returns the dictionary as a single in-memory `Vec<u8>` — the one
+representation every host can produce, including a browser/wasm embedder with no filesystem. lindera,
+however, builds a `Dictionary` from **several component files** (a prefix-dictionary trie, a
+connection-cost matrix, character/unknown-word tables, and JSON metadata). lindera's public
+filesystem loader wants a *directory* of those files; neither a directory nor a tar is something a
+wasm host can hand it.
+
+Crucially, lindera 3.0.7 also exposes an **in-memory** path: the `Dictionary` struct's fields are
+public and each component has a public `load(bytes)` constructor (this is exactly how lindera's own
+`embedded://` dictionaries are assembled from `include_bytes!` blobs). So no filesystem, no temp
+directory, and **no tar dependency** are required — only a way to carry the component byte arrays
+inside the single provisioned blob and split them back apart in memory.
+
+## The container
+
+`tzlint_core::dict::container` defines a tiny, positional, length-prefixed container that bundles the
+eight component byte arrays into one blob — the *content* of the decompressed `.dict.zst`:
+
+```text
+offset  size  field
+0       8     magic = b"TZDICTC1"      (trailing digit = format version; a bump is a new magic)
+8       2     version: u16 = 1
+10      2     member_count: u16 = 8
+12      64    member table: 8 × { offset: u32, len: u32 }   (little-endian)
+76      …     payload: the 8 member byte ranges
+```
+
+Members are **positional** (index → role; see `Member`), so there are no embedded name strings to
+decode — one less untrusted-input surface. The module is deliberately **backend-agnostic**: it names
+no lindera type and touches neither `Host` nor the network, so it compiles for `wasm32` and a future
+browser backend reuses the exact same split.
+
+`parse` is **panic-free on any byte string**: every field is read through bounds-checked slicing,
+every member range is validated with checked arithmetic against the blob length, and members are
+returned as borrowed slices, so a hostile length never drives an allocation. (The pin already
+authenticates the compressed artifact and `provision_dictionary` caps the decompressed size at
+`MAX_DICT`; the codec's own panic-safety is defense-in-depth for any future unpinned path.) Member
+*content* validity — a malformed trie or archive — is the backend loader's contract, not the codec's.
+
+## The bridge
+
+`LinderaProvider::from_dictionary_bytes(&[u8])` (in the native-only `tzlint_morphology_native` crate)
+parses the container and assembles a lindera `Dictionary` from the eight members via the five public
+component loaders, mirroring lindera's embedded loader exactly (component order, `is_system = true`
+for a system dictionary). It then converges on the same `Segmenter`/`Tokenizer` tail as the
+directory and embedded constructors, so `analyze` is byte-for-byte identical no matter how the
+dictionary was obtained.
+
+One loader needs guarding: `ConnectionCostMatrix::load` reads `i16`s with `byteorder::read_i16_into`,
+which **panics** on an odd-length matrix (and its old-format branch indexes by attacker-declared
+sizes). The bridge therefore validates the matrix member up front — it must be the even-length
+"new" format (leading `i16 == -1`) — and rejects anything else as a `MorphologyError::Backend`
+rather than risk an abort. All other loaders (daachorse `deserialize`, rkyv checked `from_bytes`,
+`serde_json`) already return `Result`, so every failure surfaces as `Backend`, never a panic.
+
+### Packaging
+
+`extract_components` (behind the dev-only `package` feature) is the inverse: it splits a *loaded*
+`Dictionary` back into the eight component byte arrays — four verbatim, the two rkyv archives and the
+metadata re-serialized value-exact, and the connection matrix re-encoded into the new `matrix.mtx`
+format (the one component lindera keeps only as a parsed grid). The `pack_ipadic` example uses it to
+build a `.dict` container from lindera's embedded IPADIC; compress it (`zstd`) and hash it (`b3sum`)
+out of band to produce the distributable `.dict.zst` and its pin. The `embed-ipadic` round-trip test
+packs the embedded IPADIC, rehydrates a provider through the bridge, and asserts its token stream is
+**byte-identical** to the embedded reference — proving the round-trip (including the lossy matrix
+re-encode and the `is_system` bit) is value-exact.
+
+> **Build coupling.** `char_def.bin`/`unk.bin` are rkyv-0.8 archives and `dict.da` is a
+> daachorse-2.1.1 blob, both tied to the exact `lindera-dictionary` 3.0.7 build. A container is only
+> loadable by the same build; **re-pack and re-pin on any lindera bump.** The `embed-ipadic`
+> round-trip test rebuilds the container in-process, so it trips the moment the pin must move.
+
+## CLI wiring
+
+A new, additive `morphology` config block names the source and pin:
+
+```jsonc
+{
+  "morphology": {
+    "path": "ipadic.dict.zst",   // OR "url": "https://…/ipadic.dict.zst"
+    "pin": "<64 hex chars>",      // BLAKE3 over the COMPRESSED container
+    "lang": "ja"                  // optional; only "ja" today
+  }
+}
+```
+
+It is validated at parse time (exactly one of `path`/`url`, a 64-hex pin decoded to 32 bytes, a
+supported language) and resolved into `Config::morphology`. Absent (the default) it is `None`, so the
+document cache key stays byte-identical to a pre-morphology run.
+
+`app::build_morphology_registry` runs once per `lint`/`fix` and returns `Some(registry)` only when
+**both** a source is configured **and** an enabled rule requires Japanese morphology (so a configured
+but unused dictionary is never provisioned). When both hold it provisions the compressed container
+through the `Host` (cached, verified against the pin), decompresses it, bridges it into a
+`LinderaProvider`, and inserts it into a `MorphologyRegistry` keyed by `DictId::from_pin(pin)` — the
+same pin the cache file is addressed by, so a dictionary upgrade changes both the cache file and the
+morphology fingerprint. The registry is threaded into the three `lint_cached` / `lint_document` /
+`fix` call sites that previously passed `None`. A provisioning or load failure aborts the run loudly;
+a misconfigured or unreachable dictionary is an operator problem, not a silently-skipped rule.
+
+`tzlint_morphology_native` becomes a dependency of the native CLI here — the first time lindera is
+linked into a shipped binary. It can never enter the `wasm32` graph (the CLI is native-only, the
+backend crate is `#![cfg(not(target_arch = "wasm32"))]`, and the io-guard tripwire keeps `lindera`
+out of every other manifest).
+
+## Out of scope
+
+User-facing dictionary docs, per-dictionary licenses, a hosted IPADIC artifact, a "lite" preset, and
+the browser/IndexedDB provider are deliberately left to later slices (M2k, M2n). This slice delivers
+the codec, the bridge, the packaging building blocks, and the CLI wiring — and proves, end to end,
+that `no-doubled-joshi` fires on real Japanese.


### PR DESCRIPTION
## M2j-wiring — connect the lindera backend to the CLI so `no-doubled-joshi` fires on real text

Builds on #51 (the native lindera backend). Provisions a hash-pinned, compressed dictionary, bridges it into a `LinderaProvider` **in memory**, and threads a `MorphologyRegistry` through the CLI lint/fix paths — so the morphology rule actually fires on real input.

### What's here
- **`tzlint_core::dict::container`** — a positional 8-member codec (`TZDICTC1`) that bundles a dictionary's component files into the single byte blob a hash-pinned `.dict.zst` decompresses to. `parse` is **panic-free on any byte string** (every field bounds-checked, member ranges validated with checked arithmetic, no allocation driven by a hostile length); wasm-clean and it names no tokenizer type.
- **`LinderaProvider::from_dictionary_bytes(&[u8])`** — the in-memory bridge: parse the container → guard the connection-cost matrix parity (lindera's loader panics on odd-length) → assemble a `Dictionary` from the 8 members via the public component loaders. Plus a `pack_ipadic` example that builds a container from embedded IPADIC.
- **Config `morphology { source: path|url, pin: <64 hex>, lang }`** → `Config.morphology: Option<MorphologyConfig>`, JSON schema + corpus fixtures. Absent ⇒ `None` ⇒ byte-identical cache key (no behaviour change for non-morphology runs).
- **CLI wiring** — `build_morphology_registry`: when morphology is configured **and** a JA rule is active (checked over the base rules **and all per-format column overlays**), provision → bridge → `insert` (`DictId::from_pin`), then thread the registry through `lint_cached` / `lint_document` / `fix`.

### Verification
- **Firing proven**: native test `no_doubled_joshi_fires_through_lint_document_with_a_real_provider` (`"私は彼は本を読む。"`), and the container round-trips byte-identical to embedded IPADIC.
- All gates green: fmt / workspace clippy / wasm32 (×2 targets) / io-guard / cargo-deny / **496 workspace + 18 native (`embed-ipadic`)** tests + doctests.

Design doc: `docs/design/dictionary-container-and-cli-wiring.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 形態素解析設定を追加。辞書ソース（path/url）とpinを指定でき、設定時に自動でプロビジョニング・検証・読み込みされます。キャッシュの指紋に形態素構成が反映されます。

* **Bug Fixes**
  * 辞書プロビジョン失敗時は明示的に処理を中断するように変更（無言スキップを排除）。

* **Documentation**
  * 辞書コンテナ形式とCLI接続の設計・運用手順を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->