### PR TITLE
feat(wasm): browser linter with opt-in morphology backend (M2k)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
 
   wasm:
-    name: wasm32 build
+    name: wasm32 build + test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -88,6 +88,15 @@ jobs:
       # lean build above is what the seam-purity check guarantees stays lindera-free.
       - run: cargo build -p tzlint_wasm --target wasm32-unknown-unknown
       - run: cargo build -p tzlint_wasm --target wasm32-unknown-unknown --features morphology
+      # Building only proves the `#[wasm_bindgen]` layer type-checks; it is never executed by the
+      # native unit tests (the `bindings` module is `cfg(target_arch = "wasm32")`). Actually RUN it in
+      # a real wasm runtime (node) with wasm-bindgen-test, exercising the string/byte marshaling and
+      # the `JsError` mapping across the JS boundary. Both artifacts: lean (no tokenizer) and full
+      # (`--features morphology`, the dictionary-registration boundary). wasm-pack fetches the
+      # wasm-bindgen version matching the dependency, sidestepping runner/dep version skew.
+      - uses: taiki-e/install-action@wasm-pack
+      - run: wasm-pack test --node crates/tzlint_wasm
+      - run: wasm-pack test --node crates/tzlint_wasm --features morphology
 
   morphology-native:
     name: morphology-native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,13 @@ jobs:
             fi
           done
       # The wasm bindings crate (M2k): build BOTH artifacts the embedder chooses between — lean
-      # (default, tokenizer-free, tiny) and full (`--features lindera`, the Japanese backend bundled
-      # in). lindera-in-wasm is strictly opt-in: the lean build above is what the seam-purity check
-      # guarantees stays lindera-free.
+      # (default, tokenizer-free, tiny) and full (`--features morphology`, the morphology backend
+      # bundled in). ONE capability feature, not one per language: the backend is a single
+      # language-neutral engine and the dictionary (hence the language: ja today, ko/zh later) loads
+      # at runtime, so there is no compile-time language axis. Bundling it is strictly opt-in: the
+      # lean build above is what the seam-purity check guarantees stays lindera-free.
       - run: cargo build -p tzlint_wasm --target wasm32-unknown-unknown
-      - run: cargo build -p tzlint_wasm --target wasm32-unknown-unknown --features lindera
+      - run: cargo build -p tzlint_wasm --target wasm32-unknown-unknown --features morphology
 
   morphology-native:
     name: morphology-native
@@ -123,13 +125,17 @@ jobs:
             ':!crates/tzlint_cli/src/host.rs' || (echo "network egress (ureq) must go through CliHost::fetch in host.rs"; exit 1)
       # The lindera tokenizer backend must stay confined to the dedicated backend crate(s) and out
       # of the morphology SEAM (`tzlint_ast`/`tzlint_pdk`/`tzlint_core`). It lives in
-      # `tzlint_morphology_native` (the CLI/LSP backend); the wasm `seam stays lindera-free` check in
-      # the `wasm` job enforces seam-purity at the dependency-tree level. Reject `lindera` in any
-      # other crate manifest — a fast, explicit tripwire that catches a stray dependency edge.
+      # `tzlint_morphology_native`; every consumer (the CLI, the wasm `morphology` build) depends on THAT
+      # crate by its capability name, never on `lindera` directly — so the bare token `lindera` must
+      # appear in no other crate manifest. The wasm `seam stays lindera-free` check enforces the same
+      # at the dependency-tree level. NOTE: the pattern is a plain (un-anchored) `lindera`, NOT
+      # `\blindera\b` — git's default grep is POSIX ERE, which does not support `\b`, so the anchored
+      # form silently matched nothing (a dead tripwire). It is case-sensitive, so the CamelCase
+      # `LinderaProvider` type the CLI tool body legitimately names is not a manifest concern.
       - name: reject lindera outside the dedicated backend crate
         run: |
-          ! git grep -nE '\blindera\b' -- 'crates/*/Cargo.toml' \
-            ':!crates/tzlint_morphology_native/Cargo.toml' || (echo "lindera must stay in the dedicated backend crate(s); the seam must stay lindera-free"; exit 1)
+          ! git grep -nE 'lindera' -- 'crates/*/Cargo.toml' \
+            ':!crates/tzlint_morphology_native/Cargo.toml' || (echo "lindera must stay in the dedicated backend crate(s); depend on tzlint_morphology_native by name instead"; exit 1)
       # blake3 must stay pure-Rust: without `features = ["pure"]` it builds a SIMD backend via a
       # C compiler, breaking the uniform/reproducible build and wasm32. Guard the manifest.
       - name: blake3 must keep features = ["pure"]
@@ -177,13 +183,13 @@ jobs:
       # (`cargo llvm-cov --doctests`) and is intentionally omitted here.
       # Accumulate runs into one report: the default workspace tests, then the native backend's
       # mapping tests behind `embed-ipadic` (otherwise `LinderaProvider::analyze` reads as uncovered,
-      # since the default run only exercises its error paths), then the wasm bindings' `lindera`
+      # since the default run only exercises its error paths), then the wasm bindings' `morphology`
       # feature (so `register_dictionary` / pin decoding are measured, not just the lean path).
       - name: Generate coverage (lcov)
         run: |
           cargo llvm-cov nextest --workspace --no-tests=warn --no-report
           cargo llvm-cov nextest -p tzlint_morphology_native --features embed-ipadic --no-report
-          cargo llvm-cov nextest -p tzlint_wasm --features lindera --no-report
+          cargo llvm-cov nextest -p tzlint_wasm --features morphology --no-report
           cargo llvm-cov report --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,25 @@ jobs:
         with:
           targets: wasm32-unknown-unknown, wasm32-wasip1
       - uses: Swatinem/rust-cache@v2
-      # The morphology seam must stay wasm-clean with NO native backend (M2i): the frozen model
+      # The morphology seam must stay wasm-clean with NO tokenizer backend: the frozen model
       # (`tzlint_ast`), the injected-provider trait (`tzlint_pdk`), and the engine + provider
       # registry + cache fingerprint (`tzlint_core`) are dictionary-free by default — embedders
-      # inject providers Host-style. Build all three wasm-facing crates for both wasm targets. When
-      # the native morphology backend lands (M2j, lindera) it MUST be cfg/feature-gated so it can
-      # never enter this build; a regression here is the tripwire.
+      # inject providers Host-style. Build all three wasm-facing crates for both wasm targets.
       - run: cargo build -p tzlint_ast -p tzlint_pdk -p tzlint_core --target wasm32-unknown-unknown
       - run: cargo build -p tzlint_ast -p tzlint_pdk -p tzlint_core --target wasm32-wasip1
+      # Seam-purity tripwire (replaces the backend crate's former `#![cfg(not(wasm32))]` gate). The
+      # lindera backend is now target-agnostic — it compiles for wasm so the M2k browser provider
+      # can reuse it — so a successful seam build no longer proves lindera is absent. Assert it via
+      # the dependency tree instead: lindera must NOT be reachable from any seam crate on wasm. If a
+      # seam crate ever gains a path to lindera (a stray dependency edge), this fails loudly.
+      - name: morphology seam stays lindera-free on wasm
+        run: |
+          for c in tzlint_ast tzlint_pdk tzlint_core; do
+            if cargo tree -p "$c" --target wasm32-unknown-unknown -e normal -f '{p}' | grep -qi lindera; then
+              echo "lindera is reachable from $c on wasm32 — the morphology seam must stay lindera-free"
+              exit 1
+            fi
+          done
 
   morphology-native:
     name: morphology-native
@@ -104,14 +115,15 @@ jobs:
         run: |
           ! git grep -nE '\bureq\b' -- 'crates/*/src/**.rs' \
             ':!crates/tzlint_cli/src/host.rs' || (echo "network egress (ureq) must go through CliHost::fetch in host.rs"; exit 1)
-      # The native morphology backend (lindera) must stay native-only: it lives ONLY in
-      # `tzlint_morphology_native` (cfg(not(wasm32)), depended on only by the native CLI/LSP), so it
-      # can never enter the wasm build graph. Reject `lindera` in any other crate manifest — a
-      # fast, explicit tripwire next to the (slow) wasm build that would also catch the regression.
-      - name: reject lindera outside the native morphology crate
+      # The lindera tokenizer backend must stay confined to the dedicated backend crate(s) and out
+      # of the morphology SEAM (`tzlint_ast`/`tzlint_pdk`/`tzlint_core`). It lives in
+      # `tzlint_morphology_native` (the CLI/LSP backend); the wasm `seam stays lindera-free` check in
+      # the `wasm` job enforces seam-purity at the dependency-tree level. Reject `lindera` in any
+      # other crate manifest — a fast, explicit tripwire that catches a stray dependency edge.
+      - name: reject lindera outside the dedicated backend crate
         run: |
           ! git grep -nE '\blindera\b' -- 'crates/*/Cargo.toml' \
-            ':!crates/tzlint_morphology_native/Cargo.toml' || (echo "lindera must stay in tzlint_morphology_native (native-only; never in the wasm graph)"; exit 1)
+            ':!crates/tzlint_morphology_native/Cargo.toml' || (echo "lindera must stay in the dedicated backend crate(s); the seam must stay lindera-free"; exit 1)
       # blake3 must stay pure-Rust: without `features = ["pure"]` it builds a SIMD backend via a
       # C compiler, breaking the uniform/reproducible build and wasm32. Guard the manifest.
       - name: blake3 must keep features = ["pure"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,12 @@ jobs:
               exit 1
             fi
           done
+      # The wasm bindings crate (M2k): build BOTH artifacts the embedder chooses between — lean
+      # (default, tokenizer-free, tiny) and full (`--features lindera`, the Japanese backend bundled
+      # in). lindera-in-wasm is strictly opt-in: the lean build above is what the seam-purity check
+      # guarantees stays lindera-free.
+      - run: cargo build -p tzlint_wasm --target wasm32-unknown-unknown
+      - run: cargo build -p tzlint_wasm --target wasm32-unknown-unknown --features lindera
 
   morphology-native:
     name: morphology-native
@@ -169,13 +175,15 @@ jobs:
       # Coverage is measured over the nextest-run tests (stable toolchain). Doctests are
       # exercised for pass/fail in the `test` job; doctest *line* coverage requires nightly
       # (`cargo llvm-cov --doctests`) and is intentionally omitted here.
-      # Accumulate two runs into one report: the default workspace tests, then the native backend's
-      # mapping tests behind `embed-ipadic` (otherwise `LinderaProvider::analyze` would read as
-      # uncovered, since the default run only exercises its error paths).
+      # Accumulate runs into one report: the default workspace tests, then the native backend's
+      # mapping tests behind `embed-ipadic` (otherwise `LinderaProvider::analyze` reads as uncovered,
+      # since the default run only exercises its error paths), then the wasm bindings' `lindera`
+      # feature (so `register_dictionary` / pin decoding are measured, not just the lean path).
       - name: Generate coverage (lcov)
         run: |
           cargo llvm-cov nextest --workspace --no-tests=warn --no-report
           cargo llvm-cov nextest -p tzlint_morphology_native --features embed-ipadic --no-report
+          cargo llvm-cov nextest -p tzlint_wasm --features lindera --no-report
           cargo llvm-cov report --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +249,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -1071,6 +1088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libyaml-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,6 +1292,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1338,6 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1361,6 +1404,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -2360,6 +2409,7 @@ dependencies = [
  "tzlint_pdk",
  "tzlint_rules",
  "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -2591,6 +2641,45 @@ checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fde991ccdc895cb7fbaa14b137d62af74d9011be67b71c694bfc40edd3119c"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925354648d2a4d1bf205412e36d520a800280622eef4719678d268e5d40e978"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2347,19 @@ dependencies = [
  "tzlint_ast",
  "tzlint_core",
  "tzlint_pdk",
+]
+
+[[package]]
+name = "tzlint_wasm"
+version = "0.0.0"
+dependencies = [
+ "console_error_panic_hook",
+ "serde_json",
+ "tzlint_core",
+ "tzlint_morphology_native",
+ "tzlint_pdk",
+ "tzlint_rules",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/tzlint_cli",
     "crates/tzlint_lsp",
     "crates/tzlint_morphology_native",
+    "crates/tzlint_wasm",
 ]
 
 [workspace.package]

--- a/crates/tzlint_ast/src/morphology.rs
+++ b/crates/tzlint_ast/src/morphology.rs
@@ -126,8 +126,8 @@ impl Tagset {
 
 /// An open-enum feature key, a bare `u32` like [`NodeKind`](crate::NodeKind).
 ///
-/// Morphological features are stored as open `(key, value)` pairs (à la lindera's
-/// `token.details()`), sidestepping a closed, per-tagset enum so adding a feature never forces a
+/// Morphological features are stored as open `(key, value)` pairs (the per-token named columns a
+/// dictionary tokenizer emits), sidestepping a closed, per-tagset enum so adding a feature never forces a
 /// `V1 → V2` bump. The known keys cover the common positional fields of dictionaries like IPADIC;
 /// `reading` and `base_form` are promoted to dedicated [`Token`] fields and are **not** repeated
 /// here. A backend may emit any additional key as an opaque value `>= COUNT`.
@@ -254,7 +254,7 @@ pub struct Token {
 
 impl Token {
     /// `flags` bit: the token is **unknown** to the dictionary — an out-of-vocabulary run the
-    /// analyzer guessed rather than looked up (lindera's `is_unknown`). Rules that should not
+    /// analyzer guessed rather than looked up (the analyzer's unknown-word flag). Rules that should not
     /// trust the features of guessed tokens test this bit.
     pub const FLAG_UNKNOWN: u32 = 1 << 0;
 }

--- a/crates/tzlint_core/src/dict.rs
+++ b/crates/tzlint_core/src/dict.rs
@@ -193,10 +193,14 @@ fn try_cache_hit(
         Err(IoError::NotFound) => return Ok(None), // vanished/cold → miss
         Err(other) => return Err(DictError::Io(other)), // genuine fault → surface
     };
-    if blake3::hash(&compressed).as_bytes() != pinned_hash {
-        return Ok(None); // benign corruption → self-heal as a miss
+    match decompress_dictionary(&compressed, pinned_hash) {
+        Ok(decompressed) => Ok(Some(decompressed)),
+        // Benign corruption (the bytes no longer hash to the pin) → self-heal as a miss.
+        Err(DictError::HashMismatch) => Ok(None),
+        // A genuine post-verify decompression fault is surfaced (a logical impossibility for a blob
+        // that hashed to the pin, but never silently downgraded to a miss).
+        Err(other) => Err(other),
     }
-    Ok(Some(zstd_decompress(&compressed, MAX_DICT)?))
 }
 
 /// Verify `compressed` against `pinned_hash`, decompress it (bounded by [`MAX_DICT`]), cache the
@@ -215,16 +219,33 @@ fn verify_decompress_and_cache(
     compressed: &[u8],
     pinned_hash: &[u8; 32],
 ) -> Result<Vec<u8>, DictError> {
-    // Verify before decompressing: never process the contents of an unverified blob.
-    if blake3::hash(compressed).as_bytes() != pinned_hash {
-        return Err(DictError::HashMismatch);
-    }
-    let decompressed = zstd_decompress(compressed, MAX_DICT)?;
+    // Verify-before-decompress, then cache the verified compressed blob (so a hit re-verifies).
+    let decompressed = decompress_dictionary(compressed, pinned_hash)?;
 
     host.create_dir_all(cache_dir)?;
     // Cache the verified COMPRESSED blob, not the decompressed bytes, so the pin re-verifies a hit.
     host.write_atomic(cache_path, compressed)?;
     Ok(decompressed)
+}
+
+/// Verify a hash-pinned **compressed** dictionary blob and decompress it in memory — the
+/// `Host`-free core of provisioning, for callers that already hold the compressed bytes and manage
+/// their own caching (a browser/wasm embedder hands the bytes in from JS and caches on the JS side,
+/// e.g. IndexedDB). `blake3(compressed) == pinned_hash` is checked **before** decompressing (zstd,
+/// bounded by [`MAX_DICT`]), so an unverified blob is never processed.
+///
+/// # Errors
+///
+/// [`DictError::HashMismatch`] if the blob does not match the pin; [`DictError::Decompress`] or
+/// [`DictError::TooLarge`] if the verified blob is not valid zstd or its output exceeds [`MAX_DICT`].
+pub fn decompress_dictionary(
+    compressed: &[u8],
+    pinned_hash: &[u8; 32],
+) -> Result<Vec<u8>, DictError> {
+    if blake3::hash(compressed).as_bytes() != pinned_hash {
+        return Err(DictError::HashMismatch);
+    }
+    zstd_decompress(compressed, MAX_DICT)
 }
 
 /// Decompress the zstd `compressed` blob, rejecting output larger than `limit` bytes.
@@ -428,6 +449,27 @@ mod tests {
             zstd_decompress(FIXTURE, MAX_DICT).unwrap(),
             PAYLOAD.as_bytes()
         );
+    }
+
+    #[test]
+    fn decompress_dictionary_verifies_the_pin_before_decompressing() {
+        let pinned = pin_of(FIXTURE);
+        // Correct pin → verified + decompressed.
+        assert_eq!(
+            decompress_dictionary(FIXTURE, &pinned).unwrap(),
+            PAYLOAD.as_bytes()
+        );
+        // Wrong pin → rejected before any decompression.
+        assert!(matches!(
+            decompress_dictionary(FIXTURE, &[0u8; 32]).unwrap_err(),
+            DictError::HashMismatch
+        ));
+        // Verified (its own pin) but not zstd → a decompression error, not a panic.
+        let garbage: &[u8] = b"verified but not a zstd frame";
+        assert!(matches!(
+            decompress_dictionary(garbage, &pin_of(garbage)).unwrap_err(),
+            DictError::Decompress(_)
+        ));
     }
 
     #[test]

--- a/crates/tzlint_core/src/dict/container.rs
+++ b/crates/tzlint_core/src/dict/container.rs
@@ -2,13 +2,13 @@
 //! one byte blob — the *content* of the decompressed `.dict.zst` that
 //! [`provision_dictionary`](crate::provision_dictionary) returns.
 //!
-//! A native tokenizer backend (lindera, in `tzlint_morphology_native`) needs several separate
+//! A native tokenizer backend (in `tzlint_morphology_native`) needs several separate
 //! component files (a prefix-dictionary trie, a connection-cost matrix, character/unknown-word
 //! tables, metadata). Rather than ship a directory or a tar — neither of which a browser/wasm
 //! embedder can use — those components are concatenated here into a single blob with a fixed
 //! header, so the whole dictionary travels as one hash-pinned, compressed artifact and is split
 //! back apart **in memory** at load time. This module is therefore deliberately backend-agnostic:
-//! it knows *byte ranges*, not lindera; it names no tokenizer type and touches neither
+//! it knows *byte ranges*, not any tokenizer; it names no tokenizer type and touches neither
 //! [`Host`](crate::Host) nor the network, so it compiles for `wasm32` and a future browser backend
 //! reuses the exact same split.
 //!
@@ -24,7 +24,7 @@
 //! ```
 //!
 //! Members are **positional** (identified by table index, not by an embedded name string), which
-//! removes all name-decoding surface. The canonical order matches a lindera dictionary's component
+//! removes all name-decoding surface. The canonical order matches the backend dictionary's component
 //! load order; see [`Member`].
 //!
 //! # Untrusted bytes
@@ -52,7 +52,7 @@ pub const MEMBER_COUNT: usize = 8;
 const HEADER_LEN: usize = 8 + 2 + 2 + MEMBER_COUNT * 8;
 
 /// The canonical members, in table order. The discriminant is the table index, and the order
-/// matches the component load order of a lindera IPADIC dictionary (`metadata` first, then the
+/// matches the component load order of the backend's IPADIC dictionary (`metadata` first, then the
 /// prefix-dictionary quartet, the connection matrix, and the two character tables).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(usize)]

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -39,7 +39,9 @@ pub use config::{
     FormatConfig, MorphologyConfig, Preset, RuleSetting, ShadowedCandidate, discover, resolve,
 };
 pub use dict::container::{ContainerError, DictContainer, Member};
-pub use dict::{DictError, provision_dictionary, provision_dictionary_from_url};
+pub use dict::{
+    DictError, decompress_dictionary, provision_dictionary, provision_dictionary_from_url,
+};
 pub use engine::Engine;
 pub use fix::{FixPass, MAX_FIX_PASSES, apply_fixes, fix};
 pub use io::{DirEntry, EntryKind, Host, IoError};

--- a/crates/tzlint_core/src/morphology.rs
+++ b/crates/tzlint_core/src/morphology.rs
@@ -12,7 +12,7 @@
 //! [`MorphologyRegistry::build_table`] runs the active providers over a document's archived AST and
 //! merges their tokens into one [`MorphologyV1`](tzlint_ast::morphology::MorphologyV1) for
 //! `Engine::lint` (wired in at `lint_document`), keyed to the nodes the morphology rules visit. A
-//! real tokenizing backend (lindera, M2j) and the rule that reads the tokens (`no-doubled-joshi`,
+//! real tokenizing backend (M2j) and the rule that reads the tokens (`no-doubled-joshi`,
 //! M2l) are still to come; the dictionary-free [`WhitespaceProvider`] exercises the seam
 //! end-to-end today. The registry never touches [`Host`](crate::Host), `dict`, or the network, so
 //! it stays `wasm32`-clean and dictionary-free by default.

--- a/crates/tzlint_core/src/parse.rs
+++ b/crates/tzlint_core/src/parse.rs
@@ -72,7 +72,11 @@ const MAX_SOURCE_LEN: usize = u32::MAX as usize;
 /// Reject a source whose length would overflow the `u32` span offsets. The message is
 /// derived from [`MAX_SOURCE_LEN`] so it can't drift from the actual bound.
 fn check_source_len(len: usize) -> Result<(), ParseError> {
-    if len > MAX_SOURCE_LEN {
+    // Expressed as a fallible `u32` conversion rather than `len > MAX_SOURCE_LEN`: on a 32-bit
+    // target (e.g. wasm32) `usize == u32`, so that comparison is `len > usize::MAX` — always false
+    // (`clippy::absurd_extreme_comparisons`) — whereas `u32::try_from` states the same bound (does
+    // the length fit a u32 span offset?) and lints clean on every target. Behaviour is identical.
+    if u32::try_from(len).is_err() {
         return Err(ParseError {
             message: format!(
                 "source is {len} bytes, over the {MAX_SOURCE_LEN}-byte limit (span offsets must fit in u32)"

--- a/crates/tzlint_morphology_native/Cargo.toml
+++ b/crates/tzlint_morphology_native/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "Native (lindera) morphology backend for TsuzuLint. Native-only: never part of the wasm build."
+description = "lindera-backed morphology backend for TsuzuLint (native CLI/LSP; the bridge also compiles for wasm so the browser provider can reuse it). Kept out of the wasm-clean morphology seam."
 
 [lints]
 workspace = true

--- a/crates/tzlint_morphology_native/src/lib.rs
+++ b/crates/tzlint_morphology_native/src/lib.rs
@@ -1,12 +1,12 @@
 //! Native morphology backend: a [`MorphologyProvider`](tzlint_pdk::MorphologyProvider) backed by
 //! the [`lindera`] analyzer.
 //!
-//! **Native-only.** The whole crate is `#![cfg(not(target_arch = "wasm32"))]`, and — more
-//! importantly — no wasm-facing crate (`tzlint_ast`/`tzlint_pdk`/`tzlint_core`) depends on it, so
-//! `lindera` is structurally unreachable from the `wasm32` build graph. The engine reaches a real
-//! backend only through the `Box<dyn MorphologyProvider>` trait object in
+//! The lindera-backed backend works on both native and `wasm32` (lindera and its dependencies are
+//! pure Rust). The wasm-clean morphology *seam* — `tzlint_ast`/`tzlint_pdk`/`tzlint_core` — never
+//! depends on this crate, so `lindera` stays out of that build graph (the M2i tripwire); the
+//! browser provider (M2k) is a separate crate that opts into lindera-on-wasm explicitly. The engine
+//! reaches a backend only through the `Box<dyn MorphologyProvider>` trait object in
 //! `tzlint_core::MorphologyRegistry`, which names no `lindera` type.
-#![cfg(not(target_arch = "wasm32"))]
 
 use std::path::Path;
 

--- a/crates/tzlint_pdk/src/morphology.rs
+++ b/crates/tzlint_pdk/src/morphology.rs
@@ -3,8 +3,8 @@
 //!
 //! A [`MorphologyProvider`] turns the text of a node into a frozen
 //! [`MorphologyV1`](tzlint_ast::morphology::MorphologyV1) table that rules read in place. The
-//! trait is `no_std`/alloc and backend-agnostic; heavy native backends (lindera, …) and
-//! dictionary provisioning live in `tzlint_core` behind this seam and are injected Host-style,
+//! trait is `no_std`/alloc and backend-agnostic; heavy native backends and dictionary provisioning
+//! live in `tzlint_core` behind this seam and are injected Host-style,
 //! so the core stays wasm-clean and dictionary-free by default. The deterministic
 //! [`WhitespaceProvider`] lets the model and the (later) engine wiring be tested without any
 //! dictionary.

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -35,6 +35,12 @@ tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"
 
+# Drives the `#[wasm_bindgen]` bindings under a real wasm runtime (node) — the only place the JS-facing
+# `TsuzuLint` is actually executed rather than just type-checked. wasm-target + dev only, so neither
+# native builds nor the shipped artifact pull it. The official test companion to `wasm-bindgen`.
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [features]
 # Bundle the morphology backend so morphology-dependent rules (e.g. no-doubled-joshi) fire with the
 # same analysis as the CLI. Off by default: the lean artifact is for embedders that need no

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-description = "WebAssembly bindings for TsuzuLint. Lean by default (the wasm-clean seam, no tokenizer); the optional `lindera` feature bundles the Japanese morphology backend for a full, CLI-consistent build."
+description = "WebAssembly bindings for TsuzuLint. Lean by default (the wasm-clean seam, no tokenizer); the optional `morphology` feature bundles the morphology backend (the language is chosen at runtime by the registered dictionary) for a full, CLI-consistent build."
 
 [lib]
 # `cdylib` for the wasm artifact; `rlib` so the pure-Rust `Linter` core is unit-testable on native.
@@ -25,8 +25,8 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
 serde_json = { workspace = true }
-# The lindera backend — pulled ONLY by the `lindera` feature, so the default (lean) wasm artifact is
-# tokenizer-free and tiny. lindera and its deps are pure Rust and build for wasm32.
+# The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
+# wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }
 
 # wasm-only glue: the `#[wasm_bindgen]` JS bindings + a panic→console.error hook. Native builds (the
@@ -36,8 +36,12 @@ wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"
 
 [features]
-# Bundle the lindera Japanese morphology backend so morphology-dependent rules (e.g.
-# no-doubled-joshi) fire with the same analysis as the CLI. Off by default: the lean artifact is for
-# embedders whose languages need no tokenizer. Loading a dictionary is then done from JS via
-# `registerDictionary(lang, compressedBytes, pinHex)`.
-lindera = ["dep:tzlint_morphology_native"]
+# Bundle the morphology backend so morphology-dependent rules (e.g. no-doubled-joshi) fire with the
+# same analysis as the CLI. Off by default: the lean artifact is for embedders that need no
+# morphological analysis. A single capability feature, NOT one per language: the backend is one
+# language-neutral engine (the same native tokenizer serves ja/ko/zh) and the dictionary — and thus
+# the language — is loaded at runtime from JS via `registerDictionary(lang, compressedBytes, pinHex)`,
+# so there is no compile-time language axis to split on. Japanese is the language wired today; ko/zh
+# reuse this same build once their dictionaries and rules land. Named for the capability, so a
+# consumer opts in by whether it needs morphology, not by a backend or a language.
+morphology = ["dep:tzlint_morphology_native"]

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "tzlint_wasm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "WebAssembly bindings for TsuzuLint. Lean by default (the wasm-clean seam, no tokenizer); the optional `lindera` feature bundles the Japanese morphology backend for a full, CLI-consistent build."
+
+[lib]
+# `cdylib` for the wasm artifact; `rlib` so the pure-Rust `Linter` core is unit-testable on native.
+crate-type = ["cdylib", "rlib"]
+
+[lints]
+workspace = true
+
+[dependencies]
+# The lint pipeline (parser/engine/config/`lint_document`), the morphology registry seam, and the
+# `Host`-free `decompress_dictionary` the full build uses to verify a JS-supplied dictionary blob.
+tzlint_core = { path = "../tzlint_core", version = "0.0.0" }
+# Diagnostics, the `Rule` trait, severities.
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
+# The built-in rules (`RULE_IDS`/`build_rule`) the linter resolves the active set from.
+tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
+# Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
+serde_json = { workspace = true }
+# The lindera backend — pulled ONLY by the `lindera` feature, so the default (lean) wasm artifact is
+# tokenizer-free and tiny. lindera and its deps are pure Rust and build for wasm32.
+tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }
+
+# wasm-only glue: the `#[wasm_bindgen]` JS bindings + a panic→console.error hook. Native builds (the
+# unit tests of the `Linter` core) never pull these.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+console_error_panic_hook = "0.1"
+
+[features]
+# Bundle the lindera Japanese morphology backend so morphology-dependent rules (e.g.
+# no-doubled-joshi) fire with the same analysis as the CLI. Off by default: the lean artifact is for
+# embedders whose languages need no tokenizer. Loading a dictionary is then done from JS via
+# `registerDictionary(lang, compressedBytes, pinHex)`.
+lindera = ["dep:tzlint_morphology_native"]

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -238,9 +238,61 @@ mod bindings {
                 .map_err(|e| JsError::new(&e))
         }
     }
+
+    // Run in a real wasm runtime (node) via `wasm-bindgen-test-runner` — the only place the JS-facing
+    // `TsuzuLint` is executed rather than just type-checked, so the `#[wasm_bindgen]` string/byte
+    // marshaling and the `JsError` mapping are exercised (the native `Linter` tests below never enter
+    // this `cfg(target_arch = "wasm32")` module).
+    #[cfg(test)]
+    mod tests {
+        use wasm_bindgen_test::wasm_bindgen_test;
+
+        use super::TsuzuLint;
+
+        #[wasm_bindgen_test]
+        fn new_then_lint_returns_diagnostics_json() {
+            let linter = TsuzuLint::new("").ok().unwrap();
+            // Half-width kana trips `no-hankaku-kana` under the default (all-on) rule set.
+            let json = linter.lint("ﾊﾛｰ\n").ok().unwrap();
+            assert!(json.contains("no-hankaku-kana"), "{json}");
+            assert!(json.contains("\"start\""), "{json}");
+        }
+
+        #[wasm_bindgen_test]
+        fn a_disabled_rule_does_not_fire() {
+            let linter = TsuzuLint::new(r#"{ "rules": { "no-hankaku-kana": false } }"#)
+                .ok()
+                .unwrap();
+            assert_eq!(linter.lint("ﾊﾛｰ\n").ok().unwrap(), "[]");
+        }
+
+        #[wasm_bindgen_test]
+        fn an_invalid_config_surfaces_an_error() {
+            assert!(TsuzuLint::new("{ not json").is_err());
+        }
+
+        // With the morphology backend bundled in, the dictionary-registration boundary must surface
+        // bad input as a JS error through the wasm marshaling, never panic.
+        #[cfg(feature = "morphology")]
+        #[wasm_bindgen_test]
+        fn register_dictionary_surfaces_errors_without_panicking() {
+            let mut linter = TsuzuLint::new("").ok().unwrap();
+            assert!(
+                linter
+                    .register_dictionary("ko", b"x", &"0".repeat(64))
+                    .is_err()
+            );
+            assert!(linter.register_dictionary("ja", b"x", "abc").is_err());
+            assert!(
+                linter
+                    .register_dictionary("ja", b"not a real dictionary", &"0".repeat(64))
+                    .is_err()
+            );
+        }
+    }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
 

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -5,7 +5,7 @@
 //! - **Lean** (default): the wasm-clean lint pipeline with no tokenizer backend. Tiny. Morphology-
 //!   dependent rules simply stay inert. For embedders whose languages need no morphological
 //!   analysis.
-//! - **Full** (`--features lindera`): bundles the lindera Japanese backend, so morphology rules
+//! - **Full** (`--features morphology`): bundles the Japanese morphology backend, so morphology rules
 //!   (e.g. `no-doubled-joshi`) fire with the same analysis as the native CLI. The embedder loads a
 //!   hash-pinned, compressed dictionary from JS via `registerDictionary`.
 //!
@@ -23,12 +23,12 @@ use tzlint_pdk::{Diagnostic, Rule, RuleId, Severity};
 use tzlint_rules::{RULE_IDS, build_rule};
 
 /// The linter core: a resolved [`Config`] plus the built-in rule/processor registries (and, in the
-/// `lindera` build, an injected morphology registry). Pure Rust — no `wasm-bindgen` — so it is
+/// `morphology` build, an injected morphology registry). Pure Rust — no `wasm-bindgen` — so it is
 /// unit-tested on native; the `#[wasm_bindgen]` bindings below are a thin wrapper over it.
 pub struct Linter {
     config: Config,
     registry: Registry,
-    #[cfg(feature = "lindera")]
+    #[cfg(feature = "morphology")]
     morphology: MorphologyRegistry,
 }
 
@@ -48,7 +48,7 @@ impl Linter {
         Ok(Linter {
             config,
             registry: Registry::with_builtins(),
-            #[cfg(feature = "lindera")]
+            #[cfg(feature = "morphology")]
             morphology: MorphologyRegistry::new(),
         })
     }
@@ -77,14 +77,14 @@ impl Linter {
         .map_err(|e| e.to_string())
     }
 
-    #[cfg(feature = "lindera")]
+    #[cfg(feature = "morphology")]
     fn morphology_ref(&self) -> Option<&MorphologyRegistry> {
         // An empty registry behaves as `None` (no active provider → no morphology table), so this
         // is safe to pass unconditionally before any dictionary is registered.
         Some(&self.morphology)
     }
 
-    #[cfg(not(feature = "lindera"))]
+    #[cfg(not(feature = "morphology"))]
     #[allow(clippy::unused_self)]
     fn morphology_ref(&self) -> Option<&MorphologyRegistry> {
         None
@@ -92,7 +92,7 @@ impl Linter {
 
     /// Register a Japanese dictionary from its hash-pinned, **compressed** container bytes (handed
     /// in by the JS host, which owns fetching and caching), so morphology-dependent rules fire.
-    /// Available in the `lindera` build only.
+    /// Available in the `morphology` build only.
     ///
     /// The bytes are verified against `pin_hex` and decompressed in wasm (the same pipeline as the
     /// CLI) before being bridged into a provider — a wrong pin, malformed pin, or undecodable
@@ -101,7 +101,7 @@ impl Linter {
     /// # Errors
     ///
     /// An unsupported language, a malformed/mismatched pin, or an undecodable dictionary.
-    #[cfg(feature = "lindera")]
+    #[cfg(feature = "morphology")]
     pub fn register_dictionary(
         &mut self,
         lang: &str,
@@ -167,7 +167,7 @@ fn severity_str(severity: Severity) -> &'static str {
 }
 
 /// Decode 64 hex characters into a 32-byte pin, panic-free.
-#[cfg(feature = "lindera")]
+#[cfg(feature = "morphology")]
 fn decode_pin(hex: &str) -> Result<[u8; 32], String> {
     let bytes = hex.as_bytes();
     if bytes.len() != 64 {
@@ -183,7 +183,7 @@ fn decode_pin(hex: &str) -> Result<[u8; 32], String> {
 }
 
 /// The value of one hex digit (`0-9`, `a-f`, `A-F`), or `None`.
-#[cfg(feature = "lindera")]
+#[cfg(feature = "morphology")]
 fn hex_nibble(b: u8) -> Option<u8> {
     match b {
         b'0'..=b'9' => Some(b - b'0'),
@@ -223,9 +223,9 @@ mod bindings {
         }
 
         /// Register a hash-pinned, compressed Japanese dictionary so morphology rules fire (the
-        /// `lindera` build only). `compressed` is the `.dict.zst` bytes; `pin_hex` is the 64-char
+        /// `morphology` build only). `compressed` is the `.dict.zst` bytes; `pin_hex` is the 64-char
         /// BLAKE3 pin over them.
-        #[cfg(feature = "lindera")]
+        #[cfg(feature = "morphology")]
         #[wasm_bindgen(js_name = registerDictionary)]
         pub fn register_dictionary(
             &mut self,
@@ -299,7 +299,7 @@ mod tests {
         assert_eq!(severity_str(Severity::Hint), "hint");
     }
 
-    #[cfg(feature = "lindera")]
+    #[cfg(feature = "morphology")]
     #[test]
     fn register_dictionary_rejects_bad_lang_and_pin() {
         let mut linter = Linter::from_config_json("").unwrap();

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -1,0 +1,325 @@
+//! WebAssembly bindings for TsuzuLint.
+//!
+//! Two artifacts, chosen by the embedder at build time:
+//!
+//! - **Lean** (default): the wasm-clean lint pipeline with no tokenizer backend. Tiny. Morphology-
+//!   dependent rules simply stay inert. For embedders whose languages need no morphological
+//!   analysis.
+//! - **Full** (`--features lindera`): bundles the lindera Japanese backend, so morphology rules
+//!   (e.g. `no-doubled-joshi`) fire with the same analysis as the native CLI. The embedder loads a
+//!   hash-pinned, compressed dictionary from JS via `registerDictionary`.
+//!
+//! The pure-Rust [`Linter`] core carries the logic and is unit-tested on native; the
+//! `#[wasm_bindgen]` layer is a thin wrapper compiled only for `wasm32`. The dictionary fetch and
+//! its caching (IndexedDB/OPFS) live on the JS side — wasm only verifies the pin and decompresses
+//! the bytes it is handed (reusing the same container/pin pipeline as the CLI).
+
+use serde_json::Value;
+use tzlint_core::{
+    Config, ConfigFormat, MorphologyRegistry, ProcessorConfig, RegionRules, Registry, RuleSetting,
+    lint_document,
+};
+use tzlint_pdk::{Diagnostic, Rule, RuleId, Severity};
+use tzlint_rules::{RULE_IDS, build_rule};
+
+/// The linter core: a resolved [`Config`] plus the built-in rule/processor registries (and, in the
+/// `lindera` build, an injected morphology registry). Pure Rust — no `wasm-bindgen` — so it is
+/// unit-tested on native; the `#[wasm_bindgen]` bindings below are a thin wrapper over it.
+pub struct Linter {
+    config: Config,
+    registry: Registry,
+    #[cfg(feature = "lindera")]
+    morphology: MorphologyRegistry,
+}
+
+impl Linter {
+    /// Build a linter from a JSON config string. An empty or whitespace-only string is the default
+    /// config (every built-in rule on).
+    ///
+    /// # Errors
+    ///
+    /// The config's parse/validation error message, as a string for the JS boundary.
+    pub fn from_config_json(config_json: &str) -> Result<Self, String> {
+        let config = if config_json.trim().is_empty() {
+            Config::default()
+        } else {
+            Config::parse(config_json, ConfigFormat::Json).map_err(|e| e.to_string())?
+        };
+        Ok(Linter {
+            config,
+            registry: Registry::with_builtins(),
+            #[cfg(feature = "lindera")]
+            morphology: MorphologyRegistry::new(),
+        })
+    }
+
+    /// Lint a Markdown document, returning the diagnostics as a JSON array string.
+    ///
+    /// # Errors
+    ///
+    /// A processing-error message (e.g. an internal failure in the pipeline).
+    pub fn lint_to_json(&self, text: &str) -> Result<String, String> {
+        let diagnostics = self.lint(text)?;
+        Ok(diagnostics_to_json(&diagnostics))
+    }
+
+    fn lint(&self, text: &str) -> Result<Vec<Diagnostic>, String> {
+        let rr = RegionRules::base_only(resolve_rules(&self.config));
+        let pcfg = ProcessorConfig::default();
+        lint_document(
+            Some("md"),
+            text,
+            &self.registry,
+            &pcfg,
+            &rr,
+            self.morphology_ref(),
+        )
+        .map_err(|e| e.to_string())
+    }
+
+    #[cfg(feature = "lindera")]
+    fn morphology_ref(&self) -> Option<&MorphologyRegistry> {
+        // An empty registry behaves as `None` (no active provider → no morphology table), so this
+        // is safe to pass unconditionally before any dictionary is registered.
+        Some(&self.morphology)
+    }
+
+    #[cfg(not(feature = "lindera"))]
+    #[allow(clippy::unused_self)]
+    fn morphology_ref(&self) -> Option<&MorphologyRegistry> {
+        None
+    }
+
+    /// Register a Japanese dictionary from its hash-pinned, **compressed** container bytes (handed
+    /// in by the JS host, which owns fetching and caching), so morphology-dependent rules fire.
+    /// Available in the `lindera` build only.
+    ///
+    /// The bytes are verified against `pin_hex` and decompressed in wasm (the same pipeline as the
+    /// CLI) before being bridged into a provider — a wrong pin, malformed pin, or undecodable
+    /// dictionary is an error, never a panic.
+    ///
+    /// # Errors
+    ///
+    /// An unsupported language, a malformed/mismatched pin, or an undecodable dictionary.
+    #[cfg(feature = "lindera")]
+    pub fn register_dictionary(
+        &mut self,
+        lang: &str,
+        compressed: &[u8],
+        pin_hex: &str,
+    ) -> Result<(), String> {
+        use tzlint_core::DictId;
+        if lang != "ja" {
+            return Err(format!(
+                "unsupported morphology language '{lang}' (only 'ja')"
+            ));
+        }
+        let pin = decode_pin(pin_hex)?;
+        let bytes =
+            tzlint_core::decompress_dictionary(compressed, &pin).map_err(|e| e.to_string())?;
+        let provider = tzlint_morphology_native::LinderaProvider::from_dictionary_bytes(&bytes)
+            .map_err(|e| e.to_string())?;
+        self.morphology
+            .insert(Box::new(provider), DictId::from_pin(pin));
+        Ok(())
+    }
+}
+
+/// Resolve the active built-in rule set for `config`: every rule on by default, minus those a
+/// `config.rules` entry turns off, each with its configured options/severity. (Column overlays —
+/// a CLI/CSV concern — are not modeled here; the browser lints Markdown/text.)
+fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
+    RULE_IDS
+        .iter()
+        .filter_map(|id| match config.rules.get(&RuleId::from(*id)) {
+            Some(RuleSetting::Off) => None,
+            Some(RuleSetting::On { severity, options }) => build_rule(id, options, *severity),
+            None => build_rule(id, &Value::Null, None),
+        })
+        .collect()
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    let items: Vec<Value> = diagnostics
+        .iter()
+        .map(|d| {
+            serde_json::json!({
+                "ruleId": d.rule_id.as_str(),
+                "severity": severity_str(d.severity),
+                "message": d.message,
+                "start": d.span.start,
+                "end": d.span.end,
+            })
+        })
+        .collect();
+    Value::Array(items).to_string()
+}
+
+/// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).
+fn severity_str(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
+        Severity::Info => "info",
+        Severity::Hint => "hint",
+    }
+}
+
+/// Decode 64 hex characters into a 32-byte pin, panic-free.
+#[cfg(feature = "lindera")]
+fn decode_pin(hex: &str) -> Result<[u8; 32], String> {
+    let bytes = hex.as_bytes();
+    if bytes.len() != 64 {
+        return Err("dictionary pin must be 64 hexadecimal characters".to_string());
+    }
+    let mut out = [0u8; 32];
+    for (i, slot) in out.iter_mut().enumerate() {
+        let hi = hex_nibble(bytes[i * 2]).ok_or("dictionary pin has a non-hex character")?;
+        let lo = hex_nibble(bytes[i * 2 + 1]).ok_or("dictionary pin has a non-hex character")?;
+        *slot = (hi << 4) | lo;
+    }
+    Ok(out)
+}
+
+/// The value of one hex digit (`0-9`, `a-f`, `A-F`), or `None`.
+#[cfg(feature = "lindera")]
+fn hex_nibble(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// The `#[wasm_bindgen]` JS bindings — a thin wrapper over [`Linter`], compiled only for `wasm32`.
+#[cfg(target_arch = "wasm32")]
+mod bindings {
+    use wasm_bindgen::prelude::*;
+
+    use super::Linter;
+
+    /// The JS-facing linter handle.
+    #[wasm_bindgen]
+    pub struct TsuzuLint {
+        inner: Linter,
+    }
+
+    #[wasm_bindgen]
+    impl TsuzuLint {
+        /// Construct a linter from a JSON config string (empty ⇒ the default config).
+        #[wasm_bindgen(constructor)]
+        pub fn new(config_json: &str) -> Result<TsuzuLint, JsError> {
+            console_error_panic_hook::set_once();
+            let inner = Linter::from_config_json(config_json).map_err(|e| JsError::new(&e))?;
+            Ok(TsuzuLint { inner })
+        }
+
+        /// Lint a Markdown document; returns a JSON array of diagnostics
+        /// (`[{ ruleId, severity, message, start, end }]`).
+        pub fn lint(&self, text: &str) -> Result<String, JsError> {
+            self.inner.lint_to_json(text).map_err(|e| JsError::new(&e))
+        }
+
+        /// Register a hash-pinned, compressed Japanese dictionary so morphology rules fire (the
+        /// `lindera` build only). `compressed` is the `.dict.zst` bytes; `pin_hex` is the 64-char
+        /// BLAKE3 pin over them.
+        #[cfg(feature = "lindera")]
+        #[wasm_bindgen(js_name = registerDictionary)]
+        pub fn register_dictionary(
+            &mut self,
+            lang: &str,
+            compressed: &[u8],
+            pin_hex: &str,
+        ) -> Result<(), JsError> {
+            self.inner
+                .register_dictionary(lang, compressed, pin_hex)
+                .map_err(|e| JsError::new(&e))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lints_markdown_with_the_default_rule_set() {
+        let linter = Linter::from_config_json("").unwrap();
+        // Half-width kana triggers `no-hankaku-kana` under the default (all-on) set.
+        let json = linter.lint_to_json("ﾊﾛｰ\n").unwrap();
+        assert!(json.contains("no-hankaku-kana"), "{json}");
+        assert!(json.contains("\"severity\""), "{json}");
+        assert!(json.contains("\"start\""), "{json}");
+    }
+
+    #[test]
+    fn a_blank_config_is_the_default() {
+        assert!(Linter::from_config_json("   ").is_ok());
+    }
+
+    #[test]
+    fn a_rule_disabled_in_config_does_not_fire() {
+        let linter =
+            Linter::from_config_json(r#"{ "rules": { "no-hankaku-kana": false } }"#).unwrap();
+        let json = linter.lint_to_json("ﾊﾛｰ\n").unwrap();
+        assert_eq!(json, "[]", "disabled rule must not fire: {json}");
+    }
+
+    #[test]
+    fn an_invalid_config_is_an_error() {
+        assert!(Linter::from_config_json("{ not json").is_err());
+    }
+
+    #[test]
+    fn clean_text_yields_an_empty_array() {
+        let linter = Linter::from_config_json("").unwrap();
+        assert_eq!(linter.lint_to_json("ただのテキストです。\n").unwrap(), "[]");
+    }
+
+    #[test]
+    fn a_rule_with_options_and_a_severity_override_is_applied() {
+        // The object rule form exercises the `RuleSetting::On { options, severity }` path: max-ten
+        // with `max: 0` flags any comma, and the severity override surfaces as "error" in the JSON.
+        let linter = Linter::from_config_json(
+            r#"{ "rules": { "max-ten": { "severity": "error", "options": { "max": 0 } } } }"#,
+        )
+        .unwrap();
+        let json = linter.lint_to_json("あれ、これ、それ。\n").unwrap();
+        assert!(json.contains("max-ten"), "{json}");
+        assert!(json.contains("\"severity\":\"error\""), "{json}");
+    }
+
+    #[test]
+    fn severity_renders_every_variant() {
+        assert_eq!(severity_str(Severity::Error), "error");
+        assert_eq!(severity_str(Severity::Warning), "warning");
+        assert_eq!(severity_str(Severity::Info), "info");
+        assert_eq!(severity_str(Severity::Hint), "hint");
+    }
+
+    #[cfg(feature = "lindera")]
+    #[test]
+    fn register_dictionary_rejects_bad_lang_and_pin() {
+        let mut linter = Linter::from_config_json("").unwrap();
+        // Unsupported language (rejected before the pin is even decoded).
+        assert!(
+            linter
+                .register_dictionary("ko", b"x", &"0".repeat(64))
+                .is_err()
+        );
+        // Malformed pin (wrong length).
+        assert!(linter.register_dictionary("ja", b"x", "abc").is_err());
+        // 64-char but non-hex pin.
+        let bad = format!("g{}", "0".repeat(63));
+        assert!(linter.register_dictionary("ja", b"x", &bad).is_err());
+        // A WELL-FORMED pin but bytes that do not hash to it: the pin decodes, then the
+        // verify+decompress rejects the blob (a hash mismatch) — exercising the success path of
+        // pin decoding and the decompress call, without needing a real dictionary.
+        let err = linter
+            .register_dictionary("ja", b"not a real dictionary", &"0".repeat(64))
+            .unwrap_err();
+        assert!(!err.is_empty(), "a mismatched blob must surface an error");
+    }
+}

--- a/docs/morphology.md
+++ b/docs/morphology.md
@@ -3,9 +3,9 @@
 > Status: template (M0/M2).
 
 - **Provider abstraction:** `MorphologyProvider { lang(), analyze(text) -> TokenTable }`.
-  A backend may cover several languages (lindera: ja/ko/zh); other engines allowed.
+  A backend may cover several languages (e.g. ja/ko/zh from one engine); engines are pluggable.
 - **Language-neutral `MorphologyV1`:** `Token { surface, lang, features: Vec<(k,v)>,
-  reading: Option, base_form: Option }` — open features (à la lindera `token.details()`),
+  reading: Option, base_form: Option }` — open features (the tokenizer's per-token detail list),
   optional fields present only where meaningful. Avoids a forced `V1→V2` bump across tagsets.
 - **Dynamic dictionaries (not embedded):** fetched on demand from a hash-pinned,
   configurable source (local path / mirror allowed), cached (native FS / browser


### PR DESCRIPTION
## M2k — a `#[wasm_bindgen]` linter for the browser, with opt-in morphology

Builds on #56 (the in-memory dictionary bridge). Adds a WebAssembly build of TsuzuLint and makes the morphology backend an internal detail that rule authors and embedders never have to name.

### What's here

**1. `tzlint_wasm` — the wasm bindings (two artifacts the embedder chooses at build time)**
- **Lean** (default): the wasm-clean lint pipeline, no tokenizer — tiny. Morphology rules stay inert. For embedders whose languages need no morphological analysis.
- **Full** (`--features morphology`): bundles the Japanese morphology backend (which compiles for wasm), so morphology rules fire with the same analysis as the CLI. A hash-pinned, compressed dictionary is loaded from JS via `registerDictionary(lang, compressed, pinHex)` — the JS host owns fetch + IndexedDB/OPFS caching; wasm only verifies the pin and decompresses (reusing the CLI's container/pin pipeline via the Host-free `tzlint_core::decompress_dictionary`).

The pure-Rust `Linter` core (config → resolve rules → `lint_document` → diagnostics JSON) is unit-tested on native; the `#[wasm_bindgen]` layer is a thin wrapper compiled only for wasm32, so native builds never pull `wasm-bindgen`.

**2. The backend is named by capability, not by library.** Only the backend-integration layer (`tzlint_morphology_native` + the CLI/wasm tool body) may name `lindera`; rules and tool-consumers reason only about *whether morphological analysis is needed*. An audit (after #56) found the brand leaking, so:
- the wasm full-build feature is `morphology` (one capability feature, **not** per-language: the backend is one engine serving ja/ko/zh and the dictionary — hence the language — loads at runtime, so there is no compile-time language axis);
- the backend-agnostic seam docs (`tzlint_ast`/`tzlint_pdk`/`tzlint_core`, incl. the dictionary container) and `docs/morphology.md` describe the *capability*, not the engine.

**3. Run the bindings (not just build them).** `wasm-bindgen-test` exercises the `#[wasm_bindgen] TsuzuLint` in a real wasm runtime (node) — the string/byte marshaling and `JsError` mapping the native unit tests never reach. CI's `wasm` job runs both artifacts via `wasm-pack test --node`.

### Notable fixes found along the way
- **io-guard portability:** the "reject lindera outside the dedicated backend crate" tripwire used `git grep -E '\blindera\b'`; `\b` is a GNU grep extension BSD/macOS `grep -E` ignores, so it silently matched nothing locally on macOS while still firing on CI. Switched to an un-anchored, case-sensitive `lindera` that behaves identically everywhere.
- **`tzlint_core` on 32-bit/wasm:** `check_source_len` compared `len > u32::MAX as usize`, always-false on wasm32 (`usize == u32`) — `clippy::absurd_extreme_comparisons`. Expressed as `u32::try_from(len).is_err()` (identical behaviour, clippy-clean on every target).

### Verification
508 workspace + wasm(`morphology`) tests, both wasm artifacts build, seam-purity cargo-tree (ast/pdk/core stay lindera-free on wasm32), clippy (lean + full), fmt, io-guard, cargo-deny — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * WebAssemblyバインディング（ブラウザ環境でのテキスト検証）を追加
  * 形態素解析機能のWASM対応を実装
  * オンデマンド辞書登録機能を提供

* **Improvements**
  * ワークスペース構成を拡張
  * CI/CDにおけるWASMテストカバレッジを強化
  * 辞書処理のエラーハンドリングを改善

* **Documentation**
  * 複数言語対応の仕様説明を明確化
  * コメント・ドキュメント記述を最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->