### PR TITLE
docs(morphology): morphology docs flip — shipped reference + config surface (M2n)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -17,8 +17,8 @@
   configuration and enable alias-expansion ("billion laughs") memory-exhaustion that the
   config size cap cannot bound.
 - **Validation:** serde `deny_unknown_fields` — an unknown top-level key is an error. Accepted
-  top-level keys are: `language`, `message-language`, `rules`, `extends`, and `formats` (see
-  below). Keys in the dynamic `rules` map that are not built-in rule ids are not an error but
+  top-level keys are: `language`, `message-language`, `rules`, `extends`, `formats`, and
+  `morphology` (see below). Keys in the dynamic `rules` map that are not built-in rule ids are not an error but
   are **warned** by the CLI (`note: config references unknown rule '…'`), so a typo is surfaced
   rather than silently ignored.
 - **Activation model (opt-out):** every built-in rule is **on by default**. A bare
@@ -41,7 +41,9 @@
   Because activation is opt-out, a preset does **not** restrict *which* rules run — every
   built-in rule is already on, so a preset effectively supplies **options and severities** for
   the rules it names. To run a narrower set, disable the unwanted rules explicitly. Morphology
-  rules (e.g. `no-doubled-joshi`) are intentionally absent from the presets until M2.
+  rules (e.g. `no-doubled-joshi`) are intentionally absent from the presets: they are no-ops
+  until a [`morphology`](#morphology--dictionary-for-morphology-dependent-rules) dictionary is
+  configured, so a preset never silently requires one.
 - **Language:** `language` (e.g. `ja`) and `message-language` (the diagnostic locale,
   independent of the document language). Config keys are kebab-case (`message-language`).
 - **JSON Schema:** a Draft 2020-12 schema is published as `tzlint_core::CONFIG_SCHEMA`
@@ -54,8 +56,9 @@
   a persistent on-disk cache written to `.tzlintcache` in the working directory, so a repeat run
   over unchanged files skips parse+lint. `--no-cache` disables both. The cache key is
   `blake3(content)` + the full config + rule versions + parser/engine version + a morphology
-  dictionary fingerprint (a placeholder until M2), so any change that could alter diagnostics
-  invalidates the entry. A cache read/write failure only warns; results are unaffected.
+  dictionary fingerprint (the pins of the dictionaries active for the run), so any change that
+  could alter diagnostics — including a dictionary upgrade — invalidates the entry. A cache
+  read/write failure only warns; results are unaffected.
 
 ## `formats` — per-format options
 
@@ -127,6 +130,39 @@ formats:
       "2": { rules: { no-todo: true } }
       "5": { parse-mode: plain, rules: { max-ten: { options: { max: 0 } } } }
 ```
+
+## `morphology` — dictionary for morphology-dependent rules
+
+Some rules (e.g. `no-doubled-joshi`) need a tokenized, part-of-speech-tagged view of the text,
+which comes from a **dynamic, hash-pinned dictionary** — never embedded in the binary. The
+`morphology` key points at one. It is provisioned at runtime **only when a rule active for the
+run needs its language**, so configuring it is free for runs that don't exercise such a rule. See
+[`docs/morphology.md`](morphology.md) for the full model and per-dictionary licenses.
+
+- **`path`** / **`url`** (exactly one, required): the compressed container (`.dict.zst`). `path`
+  is resolved relative to the working directory; `url` must be `https` (SSRF-guarded, fetched on
+  a cache miss).
+- **`pin`** (required): a BLAKE3 hash over the **compressed** container, 64 hexadecimal
+  characters. The bytes are verified against it before decompression, and it is the cache key —
+  so a dictionary upgrade is simply a new pin.
+- **`lang`** (optional; default `"ja"`): the language the dictionary serves. **Only `"ja"` is
+  supported today**; any other value is a config error.
+
+```jsonc
+{
+  // `no-doubled-joshi` is on by default (opt-out); it stays inert until this is set.
+  "morphology": {
+    "url": "https://example.com/ipadic.dict.zst",
+    "pin": "0000000000000000000000000000000000000000000000000000000000000000",
+    "lang": "ja"
+  }
+}
+```
+
+The verified, decompressed dictionary is cached under `.tzlint/dict/` (native CLI). In the
+browser the wasm build receives the bytes via `registerDictionary(...)` and the JS host owns the
+cache. Absent a `morphology` key, morphology rules are inert and the cache key is byte-identical
+to a pre-morphology run.
 
 ## Planned
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -20,18 +20,21 @@ Three deliberate, semver'd surfaces:
 
 ## Dictionary distribution (web)
 
-> Status: design intent (M2/M4). The code-only wasm is light (~157 KiB brotli, measured);
-> the morphology dictionary (tens of MB for Japanese) is the only real bandwidth term and is
-> delivered separately. See [`morphology.md`](morphology.md) for the dictionary model.
+> Status: the runtime-fetch model below is **shipped** for Japanese (the wasm `morphology` build
+> plus `registerDictionary`); the opt-in bundled sidecar is still design intent. The code-only
+> wasm is light (~157 KiB brotli, measured); the morphology dictionary (tens of MB for Japanese)
+> is the only real bandwidth term and is delivered separately. See [`morphology.md`](morphology.md)
+> for the dictionary model.
 
 - **Default: dictionary fetched at runtime, never embedded.** Hash-pinned, compressed,
   IndexedDB-cached, per-enabled-language. The npm/wasm artifact ships code only, so a code
   update never re-downloads the dictionary and a dictionary update never re-downloads the
   code. Rule sets that need no morphology fetch no dictionary at all.
-- **`preloadDictionary(lang) -> Promise<void>` is part of the JS surface.** A first-class
-  warm-up hook so apps can fetch the dictionary during idle/splash time rather than on the
-  first lint. Pairs with `<link rel="prefetch">` and a Service Worker precache (recommended
-  patterns, not requirements).
+- **The JS host owns the fetch, via `registerDictionary(lang, compressedBytes, pinHex)`.** wasm
+  verifies the pin and decompresses the bytes it is handed; the host fetches and caches them.
+  Because the host owns the fetch, warming up is just loading + registering during idle/splash
+  time rather than on the first lint. Pairs with `<link rel="prefetch">` and a Service Worker
+  precache (recommended patterns, not requirements).
 - **Opt-in bundled variant** (e.g. a `@tsuzulint/dict-ja-*` sidecar package, or an
   all-in-one build) for offline / air-gapped / Electron / zero-config embedders. It is an
   explicit opt-in, never the default: bundling into the main artifact would force the

--- a/docs/morphology.md
+++ b/docs/morphology.md
@@ -1,43 +1,123 @@
-# Morphology (ja / ko / zh)
+# Morphology (Japanese; ko/zh planned)
 
-> Status: template (M0/M2).
+> Status: **shipped for Japanese (IPADIC)** — on the native CLI/LSP, and in the wasm build's
+> `morphology` feature. The model reserves Korean and Chinese, but they are not wired yet (see
+> [Languages](#languages)).
 
-- **Provider abstraction:** `MorphologyProvider { lang(), analyze(text) -> TokenTable }`.
-  A backend may cover several languages (e.g. ja/ko/zh from one engine); engines are pluggable.
-- **Language-neutral `MorphologyV1`:** `Token { surface, lang, features: Vec<(k,v)>,
-  reading: Option, base_form: Option }` — open features (the tokenizer's per-token detail list),
-  optional fields present only where meaningful. Avoids a forced `V1→V2` bump across tagsets.
-- **Dynamic dictionaries (not embedded):** fetched on demand from a hash-pinned,
-  configurable source (local path / mirror allowed), cached (native FS / browser
-  IndexedDB), compressed. Only languages required by enabled rules. Dictionary
-  identity/version is in the cache key.
-- **Licenses vary** per dictionary (IPADIC / UniDic / ko-dic / CC-CEDICT; CC-CEDICT is
-  share-alike) — documented here; not embedded in the binary.
+Morphology-dependent rules (e.g. [`no-doubled-joshi`](rule-development.md)) need a tokenized,
+part-of-speech-tagged view of the text. TsuzuLint produces that through a backend-agnostic
+**provider seam**, fed by a **dynamic, non-embedded dictionary**.
 
-## Web delivery & dictionary loading
+## The model
 
-> Status: design intent (M2/M4). Measured: the code-only wasm payload is ~157 KiB brotli
-> today (parser + config + engine); a Japanese dictionary is tens of MB. The dictionary —
-> not the code — dominates web traffic, so it stays a separately cached artifact and is
-> never embedded in the wasm.
+- **`MorphologyProvider`** (`tzlint_pdk`) — the seam a tokenizer backend implements:
+  `lang() -> Lang` and `analyze(text, base_offset, node) -> Result<MorphologyV1, _>`. It is
+  `no_std`/`alloc` and names no concrete tokenizer; backends are injected Host-style, so the
+  core stays dictionary-free and `wasm32`-clean by default.
+- **`MorphologyV1`** (`tzlint_ast`) — a frozen, additive table keyed by node. Each `Token`
+  carries `surface`, `lang`, `tagset`, optional `reading`/`base_form`, and **open `(key, value)`
+  feature pairs**. The open `FeatureKey` (a bare `u32`) is deliberate: a new dictionary scheme
+  emits its own columns without forcing a `V1 → V2` bump. An `is_unknown` flag marks
+  out-of-vocabulary runs the analyzer guessed rather than looked up.
+- **The lindera backend** (`tzlint_morphology_native`) is the shipped provider. It is
+  target-agnostic (native **and** `wasm32`) but lives outside the morphology seam, so the seam
+  crates (`tzlint_ast`/`tzlint_pdk`/`tzlint_core`) never depend on it — enforced by a CI
+  dependency-tree check. It maps IPADIC's `details()` columns to the canonical feature keys.
 
-- **Default stays non-embedded.** Bundling a dictionary into the wasm/npm artifact is
-  rejected as the default: it forces tens of MB on every visitor (including dictionary-free
-  rule sets), destroys cache granularity (a one-line code change would invalidate the whole
-  multi-MB blob), blocks independent dictionary updates, and would pull per-dictionary
-  licenses (e.g. share-alike CC-CEDICT) into the binary. A separate, hash-pinned,
-  IndexedDB-cached artifact avoids all four.
-- **Preload / warm-up is first-class.** The JS surface exposes an explicit
-  `preloadDictionary(lang) -> Promise<void>` so embedders can fetch ahead of the first lint
-  (during a splash screen or `requestIdleCallback`) instead of paying the latency inline.
-  Preloading changes *timing*, not architecture — the artifact and cache key are unchanged.
-- **Prefetch & offline hints.** Recommended patterns: `<link rel="prefetch">`
-  (will-need-soon) / `rel="preload"` (need-now) for the dictionary URL, and a Service Worker
-  precache for offline use. Second and later visits hit the IndexedDB cache and transfer zero
-  bytes.
+The analysis pass runs only the providers whose language an enabled rule actually requires, and
+folds the result into one `MorphologyV1` per document for the engine. The registry and the
+node-keyed table are described in
+[`design/morphology-registry-and-fingerprint.md`](design/morphology-registry-and-fingerprint.md).
+
+## Dictionaries (dynamic, not embedded)
+
+Dictionaries are **provisioned at runtime**, never compiled into the binary:
+
+- The source is a **hash-pinned, compressed container** (`.dict.zst`). On use it is verified
+  against `pin` — a BLAKE3 hash over the **compressed** bytes — **before** decompression, then
+  decompressed in memory and assembled into a lindera `Dictionary`. A wrong pin, malformed pin,
+  or undecodable container is an error, never a panic.
+- It is **cached** keyed by the pin: on the native CLI under `.tzlint/dict/` in the working
+  directory; in the browser the JS host owns the cache (IndexedDB/OPFS). The dictionary's
+  identity (its pin) is part of the document cache key, so a dictionary upgrade invalidates
+  stale cached diagnostics.
+- It is provisioned **only when a rule active for the current run needs that dictionary's
+  language** — a run that lints no Japanese-rule input does no network or disk work, and an
+  unconfigured run keeps a cache key byte-identical to a pre-morphology run.
+
+The container is a positional, self-describing blob (no per-member name strings); its format and
+the in-memory bridge are documented in
+[`design/dictionary-container-and-cli-wiring.md`](design/dictionary-container-and-cli-wiring.md).
+Maintainers build one from lindera's embedded IPADIC with the `pack_ipadic` example, compress it
+(`zstd`), and publish its `b3sum` as the config `pin`.
+
+### Configuration
+
+```jsonc
+{
+  "morphology": {
+    "path": "dict/ipadic.dict.zst",   // local container (or "url" for an https source)
+    "pin":  "<64 hex BLAKE3 over the compressed container>",
+    "lang": "ja"                       // only "ja" is supported today
+  }
+}
+```
+
+Exactly one of `path`/`url`; `url` is `https`-only and SSRF-guarded. See the
+[configuration reference](config-reference.md#morphology--dictionary-for-morphology-dependent-rules)
+for the full surface.
+
+## Web delivery & loading
+
+> The code-only wasm payload is small (~157 KiB brotli, measured: parser + config + engine); a
+> Japanese dictionary is tens of MB. The dictionary — not the code — dominates web traffic, so it
+> stays a separately cached artifact and is **never** embedded in the wasm.
+
+- **Two artifacts, chosen at build time.** The default **lean** build is tokenizer-free and tiny;
+  morphology rules stay inert. The **full** build (`--features morphology`) bundles the Japanese
+  backend so those rules fire with the same analysis as the CLI. The feature is named for the
+  capability, not the backend, and is language-neutral — the language is chosen at runtime by the
+  dictionary you register, not at compile time.
+- **`registerDictionary(lang, compressedBytes, pinHex)`** is the JS surface. The host owns the
+  fetch **and** the IndexedDB/OPFS cache; wasm only verifies the pin and decompresses the bytes it
+  is handed (the same container/pin pipeline as the CLI). This keeps fetch policy, caching, and
+  offline strategy in the embedder's hands.
+- **Warm up by fetching ahead of the first lint.** Because the host owns the fetch, an app can
+  load + `registerDictionary` during idle/splash time instead of paying the latency inline. Pairs
+  with `<link rel="prefetch">`/`rel="preload"` for the dictionary URL and a Service Worker
+  precache for offline use; second and later visits hit the cache and transfer zero bytes.
 - **Dictionary size levers** (independent of delivery): prefer a compact base dictionary over
-  expanded variants (plain IPADIC over NEologd; UniDic only when its precision is needed),
-  ship compressed (zstd/gzip, decompressed client-side), trim features to those the enabled
-  rules read, and offer a reduced "lite" dictionary preset for the playground.
-- **Opt-in bundled variant** for offline / air-gapped / Electron / zero-config use is a
-  sidecar package, never the default build — see [`embedding.md`](embedding.md).
+  expanded variants (plain IPADIC over NEologd; UniDic only when its precision is needed), ship
+  compressed, trim features to those the enabled rules read, and offer a reduced **"lite"
+  dictionary** for the playground.
+- **An opt-in bundled variant** (a sidecar package / all-in-one build) for offline / air-gapped /
+  Electron / zero-config use is never the default — see [`embedding.md`](embedding.md).
+
+## Languages
+
+- **Japanese (IPADIC)** ships today and powers `no-doubled-joshi`.
+- **Korean and Chinese are reserved, not yet wired.** The frozen model already carries
+  `Lang::{KO, ZH}` and `Tagset::{KO_DIC, CC_CEDICT}`, and features are open, so adding them is
+  **additive** (no ABI bump). lindera serves ja/ko/zh from one engine; what remains is a
+  per-scheme `analyze` column mapping (ko-dic / CC-CEDICT columns differ from IPADIC), deriving
+  the `Lang`/`Tagset` from the dictionary's metadata instead of the current IPADIC hard-coding,
+  relaxing the `"ja"`-only config/wasm guards, packing the dictionaries, and — the real work —
+  designing the Korean/Chinese rules that consume the tokens.
+- **UniDic** (`Tagset::UNIDIC`) is reserved but unexercised; Japanese ships on IPADIC.
+
+## Licenses
+
+The tokenizer **engine** (lindera, **MIT**) is the only morphology code in the binary/wasm.
+**Dictionaries are not embedded** — each is fetched or packed separately under its own license,
+so a share-alike dictionary (CC-CEDICT) never attaches its terms to the artifact:
+
+| Dictionary | Language | License (summary) |
+| --- | --- | --- |
+| IPADIC | ja | BSD-style (IPADIC license) |
+| UniDic | ja | tri-license (GPL / LGPL / BSD) |
+| mecab-ko-dic | ko | Apache-2.0 |
+| CC-CEDICT | zh | CC BY-SA (share-alike) |
+
+These are summaries; consult each dictionary's upstream for exact terms before redistributing a
+packed container. Because the dictionary travels as a separate artifact, redistributing one is a
+decision the operator makes explicitly, with that dictionary's license in view.


### PR DESCRIPTION
## M2n — morphology docs flip

The final M2 step. Now that morphology ships for Japanese (CLI wiring #56, wasm browser build #58), the morphology docs move from design-intent template to shipped reference. **Docs only.**

- **`docs/morphology.md`** rewritten to the shipped system: the `MorphologyProvider` seam + frozen `MorphologyV1`, the dynamic hash-pinned **non-embedded** dictionary (provision → pin-verify → decompress → cache, provisioned only when a rule active for the run needs that language), the `morphology` config block, the two wasm artifacts + `registerDictionary(lang, compressedBytes, pinHex)`, dictionary size/delivery levers (incl. the "lite" playground dictionary), the reserved-but-unwired ko/zh + UniDic, and a **per-dictionary license** table (IPADIC BSD / UniDic tri / mecab-ko-dic Apache-2.0 / CC-CEDICT CC BY-SA; engine lindera MIT — dictionaries are never embedded, so share-alike terms never attach to the artifact).
- **`docs/config-reference.md`**: `morphology` added to the accepted top-level keys + a section documenting `path|url` / `pin` / `lang`; two now-stale "until M2" notes corrected (presets omit morphology rules because they are no-ops without a dictionary; the cache-key fingerprint is the active dictionaries' pins, no longer a placeholder).
- **`docs/embedding.md`**: the web dictionary-distribution section reconciled to the shipped `registerDictionary` (the JS host owns fetch + cache; wasm verifies the pin + decompresses) instead of the old design-intent `preloadDictionary(lang)`.

Every factual claim was cross-checked against the code (provider trait, `MorphologyV1`/`Token` fields, config schema + `RawMorphology::resolve`, the `.tzlint/dict/` cache path, the provisioning gate, the wasm API + `morphology` feature, the seam-purity CI check, frozen `Lang`/`Tagset` + open `FeatureKey`).

Completes M2. ko/zh remain a future **additive** milestone — reserved in the frozen model, no ABI bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 設定リファレンスに `morphology` キーを追加
  * 形態素解析機能の仕様をドキュメント化
  * 辞書の取得・キャッシュ処理に関する新しいAPI仕様と推奨パターンを明記
  * 日本語形態素辞書（IPADIC）の配布モデルを「配布済み」として更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->