### PR TITLE
⚡ Bolt: Use Arc<str> for RuleId to avoid cloning

### DIFF
--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -1,6 +1,7 @@
 //! The diagnostic model rules emit and the engine aggregates.
 
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use tzlint_ast::Span;
@@ -11,12 +12,13 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
     pub fn new(id: impl Into<String>) -> Self {
-        RuleId(id.into())
+        let s: String = id.into();
+        RuleId(s.into())
     }
     /// The id as a string slice.
     pub fn as_str(&self) -> &str {
@@ -38,7 +40,7 @@ impl From<&str> for RuleId {
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(s.into())
     }
 }
 


### PR DESCRIPTION
💡 What: Replaced the underlying `String` of `RuleId` with `Arc<str>`.
🎯 Why: `RuleId`s are frequently cloned and stored across multiple structures (`Diagnostic`s, `HashMap`s, caches). A `String` clone is a heap allocation (O(n)). An `Arc<str>` clone is a cheap atomic increment (O(1)).
📊 Impact: Reduces heap allocations and reduces the memory footprint for stored diagnostics, slightly accelerating linting operations and cache construction.
🔬 Measurement: Verify using memory profiling/benchmarks; tests have successfully executed confirming no functional regression.

---
*PR created automatically by Jules for task [12952456024689002514](https://jules.google.com/task/12952456024689002514) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 内部の最適化により、メモリ効率が改善されました。公開APIに変更はなく、既存機能は引き続き利用可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->