### PR TITLE
feat(0.1.0): foundations — rule applicability, language scoping, UTF-16 column, JSON contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+While the project is in `0.x`, the public API and rule behavior may change between
+minor releases.
+
+## [0.1.0] - Unreleased
+
+The first public release: a fast, embeddable Japanese prose linter — the Rust
+counterpart to `textlint`. The release date is set when 0.1.0 is cut; entries below
+accumulate as the release is built.
+
+### Added
+
+- **Lean core (`tzlint_core`).** A `markdown-rs` parser with an mdast → index-AST
+  transform over the frozen `AstCoreV1` (rkyv) layout, a single-traversal lint engine
+  with a stable `(span.start, span.end, rule_id, message)` diagnostic order, a
+  document-level in-memory cache keyed by every input that can change a result, a
+  multi-format configuration loader (TOML / JSON / YAML) with presets, a byte-offset →
+  line/column position mapper, and an `io` / `Host` boundary that routes all filesystem
+  and network access through a single abstraction.
+- **Diagnostic and fix model.** A `Diagnostic` / `Fix` model with a convergent
+  autofix engine.
+- **Starter rules (`tzlint_rules`).** Eleven rules: `no-hankaku-kana`,
+  `no-mixed-zenkaku-hankaku-alphabet`, `no-nfd`, `no-zero-width-spaces`,
+  `ja-no-mixed-period`, `no-exclamation-question-mark`, `no-todo`, `sentence-length`,
+  `max-ten`, `max-kanji-continuous-len`, and the morphology-backed `no-doubled-joshi`.
+- **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
+  subcommands with `text`, `json`, and `sarif` output formats.
+- **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the
+  frozen `MorphologyV1` token table, a Japanese backend (native, feature-gated), and a
+  dynamic, non-embedded dictionary pipeline — hash-pinned provisioning, verification,
+  decompression, and caching — folded into the cache key as a morphology fingerprint.
+- **WebAssembly bindings (`tzlint_wasm`).** A `TsuzuLint` binding exposing `lint`, plus
+  `registerDictionary` for host-supplied morphology dictionaries, shipped as lean
+  (no tokenizer) and full (`morphology` feature) artifacts.
+- **Frozen ABIs.** `AstCoreV1` and `MorphologyV1` are frozen and extended only via
+  additive tables.
+
+[0.1.0]: https://github.com/simorgh3196/tsuzulint/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ $ printf 'これはﾊﾛｰという文です。\n' | tzlint lint -
 1 file(s) checked, 1 issue(s) found
 ```
 
-See [`docs/config-reference.md`](docs/config-reference.md) for configuration and
+See [`docs/config-reference.md`](docs/config-reference.md) for configuration,
+[`docs/json-output.md`](docs/json-output.md) for the `--format json` contract, and
 [`docs/processors.md`](docs/processors.md) for CSV/TSV column linting.
 
 ## Workspace layout

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -798,6 +798,15 @@ mod tests {
         })
     }
 
+    /// A [`MockHost`] holding `path` plus a discovered `{ "language": "ja" }` config at the test
+    /// cwd, so JA-only rules are in scope. (R6 runs only the language-neutral rules when the
+    /// document language is unset, so a test that exercises a JA rule must declare the language.)
+    fn ja_host(path: &str, contents: &str) -> MockHost {
+        let host = MockHost::with(path, contents);
+        host.put("/work/.tzlintrc.json", "{ \"language\": \"ja\" }");
+        host
+    }
+
     fn rules_list_cli(format: RuleListFormat) -> Cli {
         cli(Command::Rules {
             command: RulesCommand::List { format },
@@ -918,7 +927,7 @@ mod tests {
     fn lint_sarif_output_is_a_valid_log_with_results() {
         // `--format sarif` emits a SARIF 2.1.0 log; the half-width kana triggers `no-hankaku-kana`,
         // which surfaces as one result referencing that rule.
-        let host = MockHost::with("a.md", "ﾊﾛｰ\n");
+        let host = ja_host("a.md", "ﾊﾛｰ\n");
         let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Sarif), &host);
         assert_eq!(status, ExitStatus::Findings);
         let value: serde_json::Value = serde_json::from_str(&out).unwrap();
@@ -947,7 +956,7 @@ mod tests {
         // Both code paths (cached vs. direct bridge) must produce identical output, including when
         // rules emit diagnostics — half-width kana triggers `no-hankaku-kana` under the default
         // (all-on) rule set.
-        let host = MockHost::with("a.md", "ﾊﾛｰ\n");
+        let host = ja_host("a.md", "ﾊﾛｰ\n");
         let (_s1, cached_out, _e1) = run_capture(&lint_cli("a.md", OutputFormat::Json), &host);
         let mut direct = lint_cli("a.md", OutputFormat::Json);
         direct.no_cache = true;
@@ -1003,7 +1012,7 @@ mod tests {
     fn lint_reports_a_violation_and_exits_findings() {
         // Half-width kana triggers `no-hankaku-kana` under the default (all-on) rule set, so the
         // command path reaches `Findings` and renders a real diagnostic.
-        let host = MockHost::with("a.md", "ﾊﾛｰ\n");
+        let host = ja_host("a.md", "ﾊﾛｰ\n");
         let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
         assert_eq!(status, ExitStatus::Findings);
         assert!(out.contains("no-hankaku-kana"), "{out}");
@@ -1032,7 +1041,7 @@ mod tests {
         host.put("a.md", "これは、テストです。\n");
         host.put(
             "strict.json",
-            "{ \"rules\": { \"max-ten\": { \"options\": { \"max\": 0 } } } }",
+            "{ \"language\": \"ja\", \"rules\": { \"max-ten\": { \"options\": { \"max\": 0 } } } }",
         );
         let mut c = lint_cli("a.md", OutputFormat::Text);
         c.config = Some(PathBuf::from("strict.json"));
@@ -1199,7 +1208,7 @@ mod tests {
     fn cache_persists_across_runs() {
         // Run twice against the same host: the second run loads the cache file the first wrote and
         // hits, producing identical output to the fresh lint.
-        let host = MockHost::with("a.md", "ﾊﾛｰ\n");
+        let host = ja_host("a.md", "ﾊﾛｰ\n");
         let (status1, out1, _e1) = run_capture(&lint_cli("a.md", OutputFormat::Json), &host);
         assert!(host.read("/work/.tzlintcache").is_some());
         let (status2, out2, _e2) = run_capture(&lint_cli("a.md", OutputFormat::Json), &host);
@@ -1231,7 +1240,9 @@ mod tests {
             }
         }
         let host = ReadOkWriteFailHost {
-            source: "ﾊﾛｰ\n".to_string(),
+            // `no-todo` is language-neutral, so it fires without a configured language (R6) — this
+            // test is about the cache-write warning, not language scoping.
+            source: "TODO fix\n".to_string(),
         };
         let (status, _out, err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
         assert_eq!(status, ExitStatus::Findings); // cache write failure did NOT become an error
@@ -1279,6 +1290,7 @@ mod tests {
     fn lint_reads_stdin_under_the_stdin_label() {
         // `-` reads stdin; the diagnostic is labeled `<stdin>` and counted like a file.
         let host = MockHost::new();
+        host.put("/work/.tzlintrc.json", "{ \"language\": \"ja\" }"); // JA rules in scope (R6)
         let (status, out, _err) = run_capture_stdin(
             &lint_cli("-", OutputFormat::Text),
             &host,
@@ -1293,7 +1305,7 @@ mod tests {
     #[test]
     fn lint_lints_stdin_and_a_file_together() {
         // `-` may be combined with file paths; stdin is reported first, then the file.
-        let host = MockHost::with("a.md", "本文。\n");
+        let host = ja_host("a.md", "本文。\n");
         let c = cli(Command::Lint {
             paths: vec![PathBuf::from("-"), PathBuf::from("a.md")],
             format: OutputFormat::Text,
@@ -1485,7 +1497,7 @@ mod tests {
     fn lint_routes_through_processor_seam_unchanged_for_markdown() {
         // Same half-width-kana input as `lint_reports_a_violation_*`: routing through the
         // processor seam must still produce the `no-hankaku-kana` diagnostic identically.
-        let host = MockHost::with("a.md", "ﾊﾛｰ\n");
+        let host = ja_host("a.md", "ﾊﾛｰ\n");
         let (status, out, _err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
         assert_eq!(status, ExitStatus::Findings);
         assert!(out.contains("no-hankaku-kana"), "{out}");
@@ -1693,7 +1705,9 @@ mod tests {
         host.put("a.md", "私は彼は来た。\n");
         host.put(
             "c.json",
-            &format!(r#"{{ "morphology": {{ "path": "ja.dict.zst", "pin": "{PIN64}" }} }}"#),
+            &format!(
+                r#"{{ "language": "ja", "morphology": {{ "path": "ja.dict.zst", "pin": "{PIN64}" }} }}"#
+            ),
         );
         let mut c = lint_cli("a.md", OutputFormat::Text);
         c.config = Some(PathBuf::from("c.json"));
@@ -1732,7 +1746,7 @@ mod tests {
         host.put(
             "c.json",
             &format!(
-                r#"{{ "morphology": {{ "path": "ja.dict.zst", "pin": "{PIN64}" }}, "rules": {{ "no-doubled-joshi": false }}, "formats": {{ "csv": {{ "columns": {{ "1": {{ "rules": {{ "no-doubled-joshi": true }} }} }} }} }} }}"#
+                r#"{{ "language": "ja", "morphology": {{ "path": "ja.dict.zst", "pin": "{PIN64}" }}, "rules": {{ "no-doubled-joshi": false }}, "formats": {{ "csv": {{ "columns": {{ "1": {{ "rules": {{ "no-doubled-joshi": true }} }} }} }} }} }}"#
             ),
         );
         let mut c = lint_cli("a.csv", OutputFormat::Text);
@@ -1772,7 +1786,7 @@ mod tests {
         host.put(
             "c.json",
             &format!(
-                r#"{{ "morphology": {{ "url": "https://dict.example.com/ja.dict.zst", "pin": "{PIN64}" }} }}"#
+                r#"{{ "language": "ja", "morphology": {{ "url": "https://dict.example.com/ja.dict.zst", "pin": "{PIN64}" }} }}"#
             ),
         );
         let mut c = lint_cli("a.md", OutputFormat::Text);

--- a/crates/tzlint_cli/src/output.rs
+++ b/crates/tzlint_cli/src/output.rs
@@ -391,6 +391,47 @@ mod tests {
     }
 
     #[test]
+    fn json_contract_is_stable() {
+        // The full JSON contract the `editors/vscode/` extension parses (see docs/json-output.md).
+        // Pin every key and nesting level so an accidental shape change fails loudly. Source
+        // "あ x\n": あ = bytes 0..3, space 3, 'x' 4..5 — so the span over 'x' is at column 3.
+        let diag = Diagnostic::new("no-todo", Severity::Warning, Span::new(4, 5), "found x")
+            .with_fix(Fix::replace(Span::new(4, 5), "y"));
+        let value = render_json_value(&[report("doc.md", "あ x\n", vec![diag])]);
+        assert_eq!(
+            value,
+            json!([
+                {
+                    "path": "doc.md",
+                    "diagnostics": [
+                        {
+                            "rule_id": "no-todo",
+                            "severity": "warning",
+                            "message": "found x",
+                            "span": { "start": 4, "end": 5 },
+                            "position": {
+                                "start": { "line": 1, "column": 3, "utf16Column": 3 },
+                                "end": { "line": 1, "column": 4, "utf16Column": 4 },
+                            },
+                            "fixes": [
+                                {
+                                    "span": { "start": 4, "end": 5 },
+                                    "position": {
+                                        "start": { "line": 1, "column": 3, "utf16Column": 3 },
+                                        "end": { "line": 1, "column": 4, "utf16Column": 4 },
+                                    },
+                                    "replacement": "y",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]),
+            "{value:#}"
+        );
+    }
+
+    #[test]
     fn json_carries_a_utf16_column_alongside_the_scalar_column() {
         // "😀" is an astral-plane char: one scalar value but two UTF-16 code units. The diagnostic
         // covers the 'x' that follows it, so the UTF-16 column runs ahead of the scalar column —

--- a/crates/tzlint_cli/src/output.rs
+++ b/crates/tzlint_cli/src/output.rs
@@ -64,8 +64,9 @@ pub fn render_text(writer: &mut dyn Write, reports: &[FileReport]) -> io::Result
 
 /// Render `reports` as a pretty-printed JSON array of `{ path, diagnostics }` objects.
 ///
-/// Each diagnostic carries the raw byte `span`, the mapped 1-based line/column `position`,
-/// the lowercase `severity`, the `rule_id`, the `message`, and any `fixes`.
+/// Each diagnostic carries the raw byte `span`, the mapped 1-based `position` (each end with a
+/// scalar-value `column` and an additive UTF-16 `utf16Column`), the lowercase `severity`, the
+/// `rule_id`, the `message`, and any `fixes`.
 pub fn render_json(writer: &mut dyn Write, reports: &[FileReport]) -> io::Result<()> {
     let files: Vec<Value> = reports
         .iter()
@@ -88,21 +89,29 @@ pub fn render_json(writer: &mut dyn Write, reports: &[FileReport]) -> io::Result
     writeln!(writer)
 }
 
+/// One end of a `position`: the 1-based `line`, the scalar-value `column` (the original key,
+/// left untouched), and the additive `utf16Column` — the UTF-16 code-unit column editors and the
+/// LSP address text by. See [`LineIndex::utf16_column`].
+fn point(index: &LineIndex, source: &str, offset: u32) -> Value {
+    let (line, column) = index.position(source, offset);
+    json!({
+        "line": line,
+        "column": column,
+        "utf16Column": index.utf16_column(source, offset),
+    })
+}
+
 /// The JSON object for a single diagnostic.
 fn diagnostic_json(source: &str, index: &LineIndex, diagnostic: &Diagnostic) -> Value {
-    let (start_line, start_col) = index.position(source, diagnostic.span.start);
-    let (end_line, end_col) = index.position(source, diagnostic.span.end);
     let fixes: Vec<Value> = diagnostic
         .fixes
         .iter()
         .map(|fix| {
-            let (fix_start_line, fix_start_col) = index.position(source, fix.span.start);
-            let (fix_end_line, fix_end_col) = index.position(source, fix.span.end);
             json!({
                 "span": { "start": fix.span.start, "end": fix.span.end },
                 "position": {
-                    "start": { "line": fix_start_line, "column": fix_start_col },
-                    "end": { "line": fix_end_line, "column": fix_end_col },
+                    "start": point(index, source, fix.span.start),
+                    "end": point(index, source, fix.span.end),
                 },
                 "replacement": fix.replacement,
             })
@@ -114,8 +123,8 @@ fn diagnostic_json(source: &str, index: &LineIndex, diagnostic: &Diagnostic) -> 
         "message": diagnostic.message,
         "span": { "start": diagnostic.span.start, "end": diagnostic.span.end },
         "position": {
-            "start": { "line": start_line, "column": start_col },
-            "end": { "line": end_line, "column": end_col },
+            "start": point(index, source, diagnostic.span.start),
+            "end": point(index, source, diagnostic.span.end),
         },
         "fixes": fixes,
     })
@@ -364,16 +373,44 @@ mod tests {
         assert_eq!(d["rule_id"], "max-ten");
         assert_eq!(d["severity"], "info");
         assert_eq!(d["span"], json!({ "start": 4, "end": 7 }));
-        assert_eq!(d["position"]["start"], json!({ "line": 2, "column": 1 }));
+        // "壱\nabc\n": the span starts at 'a' (line 2, col 1). All BMP, so utf16Column == column.
+        assert_eq!(
+            d["position"]["start"],
+            json!({ "line": 2, "column": 1, "utf16Column": 1 })
+        );
         assert_eq!(d["fixes"][0]["replacement"], "、");
         assert_eq!(d["fixes"][0]["span"], json!({ "start": 4, "end": 7 }));
         assert_eq!(
             d["fixes"][0]["position"]["start"],
-            json!({ "line": 2, "column": 1 })
+            json!({ "line": 2, "column": 1, "utf16Column": 1 })
         );
         assert_eq!(
             d["fixes"][0]["position"]["end"],
-            json!({ "line": 2, "column": 4 })
+            json!({ "line": 2, "column": 4, "utf16Column": 4 })
+        );
+    }
+
+    #[test]
+    fn json_carries_a_utf16_column_alongside_the_scalar_column() {
+        // "😀" is an astral-plane char: one scalar value but two UTF-16 code units. The diagnostic
+        // covers the 'x' that follows it, so the UTF-16 column runs ahead of the scalar column —
+        // and the scalar `column` key is untouched.
+        let diag = Diagnostic::new("no-todo", Severity::Warning, Span::new(4, 5), "msg")
+            .with_fix(Fix::replace(Span::new(4, 5), "y"));
+        let value = render_json_value(&[report("a.md", "😀x\n", vec![diag])]);
+        let d = &value[0]["diagnostics"][0];
+        assert_eq!(
+            d["position"]["start"],
+            json!({ "line": 1, "column": 2, "utf16Column": 3 })
+        );
+        assert_eq!(
+            d["position"]["end"],
+            json!({ "line": 1, "column": 3, "utf16Column": 4 })
+        );
+        // The fix position carries it too.
+        assert_eq!(
+            d["fixes"][0]["position"]["start"],
+            json!({ "line": 1, "column": 2, "utf16Column": 3 })
         );
     }
 

--- a/crates/tzlint_cli/src/rules.rs
+++ b/crates/tzlint_cli/src/rules.rs
@@ -13,6 +13,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::Value;
+use tzlint_ast::morphology::Lang;
 use tzlint_core::processor::{ColumnTarget, DelimitedConfig};
 use tzlint_core::{Config, ProcessorConfig, RegionRules, RuleSetting};
 use tzlint_pdk::{Rule, RuleId, Severity};
@@ -86,11 +87,27 @@ pub fn processor_config_for(config: &Config, ext: Option<&str>) -> ProcessorConf
     }
 }
 
+/// Drop the rules that do not apply to the document language `lang` (R6 scoping).
+///
+/// A language-neutral rule always survives; a language-scoped rule survives only when `lang` is
+/// one of its languages — and never when `lang` is `None` (an unset language runs only the neutral
+/// rules). This is applied where the lint-time rule set is built (not in [`resolve_rules`] or
+/// [`rule_infos`], so `rules list` still reports every configured rule regardless of language).
+fn scope_to_language(rules: Vec<Box<dyn Rule>>, lang: Option<Lang>) -> Vec<Box<dyn Rule>> {
+    rules
+        .into_iter()
+        .filter(|rule| rule.meta().applies_to(lang))
+        .collect()
+}
+
 /// The [`RegionRules`] for a file with extension `ext` under `config`: a base set from
-/// `config.rules`, plus one set per configured column (its overlay layered over the base).
+/// `config.rules`, plus one set per configured column (its overlay layered over the base). Both
+/// are scoped to the document language ([`Config::document_lang`]): a JA-only rule does not run on
+/// non-Japanese (or untagged) text.
 #[must_use]
 pub fn region_rules_for(config: &Config, ext: Option<&str>) -> RegionRules {
-    let mut rr = RegionRules::base_only(resolve_rules(config));
+    let lang = config.document_lang();
+    let mut rr = RegionRules::base_only(scope_to_language(resolve_rules(config), lang));
     if let Some(fmt) = ext.and_then(|e| config.formats.get(&e.to_ascii_lowercase())) {
         for col in &fmt.columns {
             // base ⊕ column overlay (column wins).
@@ -98,7 +115,7 @@ pub fn region_rules_for(config: &Config, ext: Option<&str>) -> RegionRules {
             for (id, setting) in &col.rules {
                 merged.insert(id.clone(), setting.clone());
             }
-            let rules = resolve_rules_from_map(&merged);
+            let rules = scope_to_language(resolve_rules_from_map(&merged), lang);
             match &col.selector {
                 tzlint_core::processor::ColumnSelector::Index(one_based) => {
                     rr.push_column(one_based.checked_sub(1), None, rules);
@@ -397,6 +414,47 @@ mod processing_builders {
             processor_config_for(&config, Some("md"))
                 .delimited
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn region_rules_for_scopes_rules_by_document_language() {
+        use tzlint_core::RegionTag;
+        let names = |config: &Config| -> Vec<String> {
+            region_rules_for(config, None)
+                .for_tag(&RegionTag::whole())
+                .iter()
+                .map(|r| r.meta().id.as_str().to_string())
+                .collect()
+        };
+
+        // Language unset ⇒ only language-neutral rules run; JA-only rules are scoped out.
+        let unset = names(&Config::default());
+        assert!(
+            unset.contains(&"no-nfd".to_string()),
+            "a neutral rule still runs"
+        );
+        assert!(
+            !unset.contains(&"sentence-length".to_string()),
+            "a JA-only rule is scoped out when the language is unset"
+        );
+        assert!(
+            !unset.contains(&"no-doubled-joshi".to_string()),
+            "a JA morphology rule is scoped out when the language is unset"
+        );
+
+        // language: ja ⇒ JA rules run alongside the neutral ones.
+        let ja = names(&Config {
+            language: Some("ja".into()),
+            ..Default::default()
+        });
+        assert!(
+            ja.contains(&"sentence-length".to_string()),
+            "JA-only runs under ja"
+        );
+        assert!(
+            ja.contains(&"no-nfd".to_string()),
+            "neutral still runs under ja"
         );
     }
 

--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -27,6 +27,7 @@ mod schema;
 use std::collections::BTreeMap;
 use std::fmt;
 
+use tzlint_ast::morphology::Lang;
 use tzlint_pdk::RuleId;
 
 pub use discover::{DiscoveredConfig, ShadowedCandidate, discover};
@@ -92,6 +93,25 @@ impl Config {
     /// preset are errors. Rule-specific `options` are preserved verbatim as JSON values.
     pub fn parse(text: &str, format: ConfigFormat) -> Result<Self, ConfigError> {
         format::parse(text, format)
+    }
+
+    /// The document [`Lang`] this config's [`language`](Config::language) tag resolves to, or
+    /// `None` when the tag is unset or unrecognized.
+    ///
+    /// The primary subtag is matched case-insensitively (`"ja"`, `"JA"`, `"ja-JP"` all map to
+    /// [`Lang::JA`]), so an editor- or BCP-47-style tag works. An unknown language is treated as
+    /// unset rather than an error: rule scoping then runs only the language-neutral rules, which is
+    /// the predictable behavior for untagged text.
+    #[must_use]
+    pub fn document_lang(&self) -> Option<Lang> {
+        let tag = self.language.as_deref()?;
+        let primary = tag.split(['-', '_']).next().unwrap_or(tag);
+        match primary.to_ascii_lowercase().as_str() {
+            "ja" => Some(Lang::JA),
+            "ko" => Some(Lang::KO),
+            "zh" => Some(Lang::ZH),
+            _ => None,
+        }
     }
 }
 
@@ -263,6 +283,29 @@ mod tests {
             Config::parse("{ not json", ConfigFormat::Json),
             Err(ConfigError::Parse { .. })
         ));
+    }
+
+    #[test]
+    fn document_lang_maps_known_tags_and_leaves_the_rest_unset() {
+        use tzlint_ast::morphology::Lang;
+        let lang = |tag: Option<&str>| {
+            Config {
+                language: tag.map(str::to_string),
+                ..Default::default()
+            }
+            .document_lang()
+        };
+        // Unset stays unset (⇒ neutral-only scoping downstream).
+        assert_eq!(lang(None), None);
+        // Known primary subtags map to their `Lang`, case- and region-insensitively.
+        assert_eq!(lang(Some("ja")), Some(Lang::JA));
+        assert_eq!(lang(Some("JA")), Some(Lang::JA));
+        assert_eq!(lang(Some("ja-JP")), Some(Lang::JA));
+        assert_eq!(lang(Some("ko")), Some(Lang::KO));
+        assert_eq!(lang(Some("zh-Hans")), Some(Lang::ZH));
+        // An unrecognized tag is treated as unset, not an error.
+        assert_eq!(lang(Some("en")), None);
+        assert_eq!(lang(Some("")), None);
     }
 }
 

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -37,6 +37,15 @@ impl Preset {
         }
     }
 
+    /// The document language this preset implies, layered under (and overridden by) the user's own
+    /// `language`. The `ja-*` presets imply `"ja"` so their Japanese rules run out of the box; a
+    /// future language-neutral preset would return `None`.
+    pub fn language(self) -> Option<&'static str> {
+        match self {
+            Preset::JaBasic | Preset::JaTechnicalWriting => Some("ja"),
+        }
+    }
+
     /// The rule settings this preset contributes as a base layer.
     ///
     /// Rule ids are referenced as strings (no dependency on `tzlint_rules`); they MUST match the
@@ -97,12 +106,15 @@ fn ja_technical_writing() -> BTreeMap<RuleId, RuleSetting> {
 /// Resolve a `user` config over an optional `preset` base.
 ///
 /// The preset's rules form the base layer; the user's rules override by id (user wins on a
-/// collision). `language`/`message_language` come from the user config — presets do not set
-/// them in M1.
+/// collision). `language` comes from the user config, falling back to the preset's implied
+/// language (a `ja-*` preset implies `"ja"`, so its Japanese rules run without the user writing
+/// `language: ja`); `message_language` is the user's alone.
 pub fn resolve(preset: Option<Preset>, user: Config) -> Config {
     let base = preset.map(Preset::rules).unwrap_or_default();
     Config {
-        language: user.language,
+        language: user
+            .language
+            .or_else(|| preset.and_then(Preset::language).map(str::to_string)),
         message_language: user.message_language,
         rules: merge(base, user.rules),
         // Formats are not preset-layered; layering preserves the user's resolved formats.
@@ -191,6 +203,25 @@ mod tests {
         assert!(resolved.rules.contains_key(&RuleId::from("custom-rule")));
         // No preset → identity.
         assert_eq!(resolve(None, user.clone()), user);
+    }
+
+    #[test]
+    fn a_ja_preset_implies_language_ja_unless_the_user_sets_it() {
+        // A `ja-*` preset implies `language: ja`, so its JA rules fire out of the box without the
+        // user having to write `language: ja`.
+        let resolved = resolve(Some(Preset::JaTechnicalWriting), Config::default());
+        assert_eq!(resolved.language.as_deref(), Some("ja"));
+
+        // The user's own language wins over the preset's implied one.
+        let user = Config {
+            language: Some("ko".into()),
+            ..Default::default()
+        };
+        let resolved = resolve(Some(Preset::JaTechnicalWriting), user);
+        assert_eq!(resolved.language.as_deref(), Some("ko"));
+
+        // No preset ⇒ language is whatever the user had (here, unset).
+        assert_eq!(resolve(None, Config::default()).language, None);
     }
 
     #[test]

--- a/crates/tzlint_core/src/position.rs
+++ b/crates/tzlint_core/src/position.rs
@@ -7,8 +7,9 @@
 /// to a 1-based `(line, column)` position.
 ///
 /// Column is counted in **Unicode scalar values** (chars) from the start of the line,
-/// matching typical CLI output; a UTF-16 column (for LSP) can be layered on later. Build
-/// the index with the same text whose offsets you will map.
+/// matching typical CLI output; [`utf16_column`](LineIndex::utf16_column) layers a UTF-16
+/// code-unit column on top (for editors/LSP that address text in UTF-16). Build the index with
+/// the same text whose offsets you will map.
 #[derive(Debug, Clone)]
 pub struct LineIndex {
     /// Byte offset at which each line begins. Always starts with `0`.
@@ -34,15 +35,14 @@ impl LineIndex {
         self.line_starts.len()
     }
 
-    /// Map an absolute byte `offset` into `text` to a 1-based `(line, column)`.
+    /// Clamp `offset` into range and down to a char boundary, then locate its line.
     ///
-    /// `text` must be the same source passed to [`LineIndex::new`]. An out-of-range or
-    /// non-char-boundary offset is clamped, never panics.
-    pub fn position(&self, text: &str, offset: u32) -> (u32, u32) {
-        // Clamp into range and down to a char boundary: the slice below then can't panic,
-        // and an offset that lands inside a multibyte char maps to the column of the char
-        // that contains it (a multibyte char never straddles a newline, so this stays on
-        // the same line).
+    /// Returns the 0-based line index plus the `start..end` byte range of the line prefix up to
+    /// the (clamped) offset — the slice whose length, counted in some unit, is the column. An
+    /// offset that lands inside a multibyte char floors to that char's start; since a multibyte
+    /// char never straddles a newline, this stays on the same line. The returned range is always
+    /// a valid `text` slice, so callers can `text.get(start..end)` without panicking.
+    fn locate(&self, text: &str, offset: u32) -> (usize, usize, usize) {
         let mut end = (offset as usize).min(text.len());
         while end > 0 && !text.is_char_boundary(end) {
             end -= 1;
@@ -54,6 +54,15 @@ impl LineIndex {
             .saturating_sub(1);
         let line_start = self.line_starts.get(line_idx).copied().unwrap_or(0) as usize;
         let start = line_start.min(end);
+        (line_idx, start, end)
+    }
+
+    /// Map an absolute byte `offset` into `text` to a 1-based `(line, column)`.
+    ///
+    /// Column is counted in Unicode scalar values. `text` must be the same source passed to
+    /// [`LineIndex::new`]. An out-of-range or non-char-boundary offset is clamped, never panics.
+    pub fn position(&self, text: &str, offset: u32) -> (u32, u32) {
+        let (line_idx, start, end) = self.locate(text, offset);
         let column = text.get(start..end).map_or(0, |slice| {
             let mut count = 0;
             for &b in slice.as_bytes() {
@@ -66,6 +75,21 @@ impl LineIndex {
             count
         });
         (line_idx as u32 + 1, column as u32 + 1)
+    }
+
+    /// The 1-based **UTF-16 code-unit** column for an absolute byte `offset`.
+    ///
+    /// Counts UTF-16 code units from the start of the line, so a BMP char counts as 1 and an
+    /// astral-plane char (≥ U+10000, encoded as a surrogate pair) counts as 2 — the column
+    /// editors and the LSP use, which address text in UTF-16. The line is the same one
+    /// [`position`](Self::position) reports; clamping is identical. Add this alongside the scalar
+    /// column rather than replacing it.
+    pub fn utf16_column(&self, text: &str, offset: u32) -> u32 {
+        let (_, start, end) = self.locate(text, offset);
+        let units = text
+            .get(start..end)
+            .map_or(0, |slice| slice.chars().map(char::len_utf16).sum::<usize>());
+        units as u32 + 1
     }
 }
 
@@ -139,5 +163,37 @@ mod tests {
         assert_eq!(idx.position(text, 1), (1, 1)); // inside あ → floors to 0 → column 1
         assert_eq!(idx.position(text, 3), (1, 2)); // start of い
         assert_eq!(idx.position(text, 4), (1, 2)); // inside い → floors to 3 → column 2
+    }
+
+    #[test]
+    fn utf16_column_matches_scalar_for_bmp() {
+        // Every BMP char (including CJK) is a single UTF-16 code unit, so the UTF-16 column
+        // equals the scalar column there.
+        let text = "あいう\nx"; // 9 bytes + '\n' + 'x'
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.utf16_column(text, 0), 1); // あ
+        assert_eq!(idx.utf16_column(text, 3), 2); // い
+        assert_eq!(idx.utf16_column(text, 6), 3); // う
+        assert_eq!(idx.utf16_column(text, 9), 4); // '\n'
+        assert_eq!(idx.utf16_column(text, 10), 1); // x on line 2 — UTF-16 column resets per line
+    }
+
+    #[test]
+    fn utf16_column_counts_astral_chars_as_two_units() {
+        // "😀" is U+1F600 (astral plane): 4 UTF-8 bytes but 2 UTF-16 code units (a surrogate pair).
+        let text = "😀x"; // 😀 occupies bytes 0..4; 'x' starts at byte 4
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.utf16_column(text, 0), 1); // start of 😀
+        // Before 'x' there is one scalar value but two UTF-16 units.
+        assert_eq!(idx.position(text, 4), (1, 2)); // scalar column
+        assert_eq!(idx.utf16_column(text, 4), 3); // UTF-16 column
+    }
+
+    #[test]
+    fn utf16_column_clamps_like_position() {
+        let text = "😀"; // boundaries at 0 and 4
+        let idx = LineIndex::new(text);
+        assert_eq!(idx.utf16_column(text, 2), 1); // inside the astral char → floors to its start
+        assert_eq!(idx.utf16_column(text, 999), 3); // past the end → clamps to end (2 units + 1)
     }
 }

--- a/crates/tzlint_pdk/src/lib.rs
+++ b/crates/tzlint_pdk/src/lib.rs
@@ -20,7 +20,7 @@ mod node;
 mod rule;
 
 pub use diagnostic::{Diagnostic, Fix, RuleId, Severity};
-pub use meta::{Requirements, RuleMeta};
+pub use meta::{Applicability, Requirements, RuleMeta};
 pub use morphology::{MorphologyError, MorphologyProvider, WhitespaceProvider};
 pub use node::{Children, NodeRef};
 pub use rule::{Context, Rule};

--- a/crates/tzlint_pdk/src/meta.rs
+++ b/crates/tzlint_pdk/src/meta.rs
@@ -45,6 +45,28 @@ impl Requirements {
     }
 }
 
+/// Which document languages a rule applies to — independent of whether it needs morphology.
+///
+/// Defaults to [`Applicability::Neutral`]: a rule with no language tag runs on every document,
+/// including one whose language is unset. A rule scoped to a [`Languages`](Applicability::Languages)
+/// set runs only when the document's language is in that set, and **never** when the language is
+/// unset — so a language-specific rule never fires on untagged text.
+///
+/// This descriptor is consumed by the engine's language scoping; it changes no scheduling on its
+/// own and is purely additive to the PDK metadata — it touches neither the AST nor the wire format.
+/// A morphology rule pinned via [`RuleMeta::with_morphology`] is implicitly scoped to its
+/// dictionary language (the builder records it here too), so it is the single source of truth
+/// [`applies_to`](RuleMeta::applies_to) reads.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum Applicability {
+    /// Runs on any document language, including when the language is unset. The default.
+    #[default]
+    Neutral,
+    /// Runs only when the document language is one of these. Non-empty by construction — built one
+    /// language at a time via [`RuleMeta::for_language`] (or pinned by `with_morphology`).
+    Languages(Vec<Lang>),
+}
+
 /// Static metadata describing a rule: its id, the [`NodeKind`]s it wants to visit, its default
 /// severity, and what it [`requires`](RuleMeta::requires) to run.
 ///
@@ -63,6 +85,10 @@ pub struct RuleMeta {
     /// (nothing) — see [`with_morphology`](RuleMeta::with_morphology) to opt in. Private so the
     /// pair stays consistent; read it via [`requires`](RuleMeta::requires).
     requires: Requirements,
+    /// Which document languages this rule applies to. Defaults to [`Applicability::Neutral`]
+    /// (every document). Private so the engine reads it only through
+    /// [`applies_to`](RuleMeta::applies_to); set it with [`for_language`](RuleMeta::for_language).
+    applicability: Applicability,
 }
 
 impl RuleMeta {
@@ -78,18 +104,44 @@ impl RuleMeta {
             default_severity,
             node_kinds: node_kinds.into(),
             requires: Requirements::default(),
+            applicability: Applicability::Neutral,
         }
     }
 
     /// Declare that this rule reads the morphology table, pinned to dictionary language `lang`.
     ///
     /// The engine uses this to provision `lang`'s dictionary and to skip the rule when
-    /// morphology is unavailable, instead of running it against an empty table.
+    /// morphology is unavailable, instead of running it against an empty table. A morphology rule
+    /// can only run where its dictionary is provisioned, so it is inherently scoped to `lang`:
+    /// this also records that [`Applicability`], making it the single source of truth
+    /// [`applies_to`](Self::applies_to) reads — no separate [`for_language`](Self::for_language)
+    /// call is needed.
     #[must_use]
     pub fn with_morphology(mut self, lang: Lang) -> Self {
         self.requires = Requirements {
             morphology: true,
             lang: Some(lang),
+        };
+        self.applicability = Applicability::Languages(Vec::from([lang]));
+        self
+    }
+
+    /// Scope this rule to documents written in `lang` (e.g. a JA-only typography rule).
+    ///
+    /// Additive: a rule with no such tag stays [`Applicability::Neutral`] and runs on every
+    /// document. Call more than once to widen the set (idempotent per language). A morphology
+    /// rule pinned via [`with_morphology`](Self::with_morphology) is already scoped to its
+    /// dictionary language, so it needs no separate `for_language` tag.
+    #[must_use]
+    pub fn for_language(mut self, lang: Lang) -> Self {
+        self.applicability = match self.applicability {
+            Applicability::Neutral => Applicability::Languages(Vec::from([lang])),
+            Applicability::Languages(mut langs) => {
+                if !langs.contains(&lang) {
+                    langs.push(lang);
+                }
+                Applicability::Languages(langs)
+            }
         };
         self
     }
@@ -115,6 +167,26 @@ impl RuleMeta {
     #[must_use]
     pub fn required_lang(&self) -> Option<Lang> {
         self.requires.lang()
+    }
+
+    /// This rule's language [`Applicability`] (see [`for_language`](Self::for_language)).
+    #[must_use]
+    pub fn applicability(&self) -> &Applicability {
+        &self.applicability
+    }
+
+    /// Whether this rule applies to a document whose language is `doc_lang` (`None` = unset).
+    ///
+    /// [`Neutral`](Applicability::Neutral) always applies — on any language and when the language
+    /// is unset. A [`Languages`](Applicability::Languages) set applies only when `doc_lang` is one
+    /// of its languages, and never when the language is unset. The engine consumes this for
+    /// language scoping; on its own it changes no scheduling.
+    #[must_use]
+    pub fn applies_to(&self, doc_lang: Option<Lang>) -> bool {
+        match &self.applicability {
+            Applicability::Neutral => true,
+            Applicability::Languages(langs) => doc_lang.is_some_and(|l| langs.contains(&l)),
+        }
     }
 }
 
@@ -175,5 +247,68 @@ mod tests {
         assert_eq!(meta.id.as_str(), "no-doubled-joshi");
         assert_eq!(meta.default_severity, Severity::Error);
         assert!(meta.visits(NodeKind::TEXT));
+    }
+
+    #[test]
+    fn applicability_defaults_to_neutral_and_runs_everywhere() {
+        let meta = RuleMeta::new("no-nfd", Severity::Warning, vec![NodeKind::TEXT]);
+        assert_eq!(meta.applicability(), &Applicability::Neutral);
+        // Neutral runs on any language *and* when the language is unset.
+        assert!(meta.applies_to(None));
+        assert!(meta.applies_to(Some(Lang::JA)));
+        assert!(meta.applies_to(Some(Lang::KO)));
+    }
+
+    #[test]
+    fn for_language_scopes_to_that_language_and_never_to_unset() {
+        let meta = RuleMeta::new(
+            "sentence-length",
+            Severity::Warning,
+            vec![NodeKind::PARAGRAPH],
+        )
+        .for_language(Lang::JA);
+        assert_eq!(
+            meta.applicability(),
+            &Applicability::Languages(vec![Lang::JA])
+        );
+        assert!(meta.applies_to(Some(Lang::JA)));
+        assert!(!meta.applies_to(Some(Lang::KO)));
+        // A language-scoped rule never fires on untagged (unset-language) text.
+        assert!(!meta.applies_to(None));
+    }
+
+    #[test]
+    fn for_language_chains_into_a_set_without_duplicates() {
+        let meta = RuleMeta::new("hypothetical", Severity::Warning, vec![NodeKind::TEXT])
+            .for_language(Lang::JA)
+            .for_language(Lang::KO)
+            .for_language(Lang::JA); // idempotent
+        assert_eq!(
+            meta.applicability(),
+            &Applicability::Languages(vec![Lang::JA, Lang::KO])
+        );
+        assert!(meta.applies_to(Some(Lang::JA)));
+        assert!(meta.applies_to(Some(Lang::KO)));
+        assert!(!meta.applies_to(Some(Lang::ZH)));
+        assert!(!meta.applies_to(None));
+    }
+
+    #[test]
+    fn with_morphology_implies_language_applicability() {
+        // A morphology rule pinned to a dictionary language is inherently scoped to it — the
+        // single source of truth `applies_to` reads, no separate `for_language` needed.
+        let meta = RuleMeta::new(
+            "no-doubled-joshi",
+            Severity::Warning,
+            vec![NodeKind::PARAGRAPH],
+        )
+        .with_morphology(Lang::JA);
+        assert_eq!(
+            meta.applicability(),
+            &Applicability::Languages(vec![Lang::JA])
+        );
+        assert!(meta.applies_to(Some(Lang::JA)));
+        assert!(!meta.applies_to(Some(Lang::KO)));
+        assert!(!meta.applies_to(None));
     }
 }

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -149,6 +149,51 @@ mod tests {
     }
 
     #[test]
+    fn rule_language_applicability_is_tagged() {
+        use tzlint_ast::morphology::Lang;
+
+        // The R5 classification. JA-only rules run only on Japanese documents and never on
+        // untagged (unset-language) text; every other rule is language-neutral and runs on any
+        // document, including untagged text.
+        const JA_ONLY: &[&str] = &[
+            "sentence-length",
+            "max-ten",
+            "no-hankaku-kana",
+            "ja-no-mixed-period",
+            "no-doubled-joshi", // JA via its morphology pin
+        ];
+
+        for id in RULE_IDS {
+            let meta_holder = build_rule(id, &Value::Null, None).expect("every id builds");
+            let meta = meta_holder.meta();
+            if JA_ONLY.contains(id) {
+                assert!(meta.applies_to(Some(Lang::JA)), "{id} should apply to JA");
+                assert!(
+                    !meta.applies_to(Some(Lang::KO)),
+                    "{id} (JA-only) should not apply to KO"
+                );
+                assert!(
+                    !meta.applies_to(None),
+                    "{id} (JA-only) should not fire on untagged text"
+                );
+            } else {
+                assert!(
+                    meta.applies_to(None),
+                    "{id} (neutral) should run on untagged text"
+                );
+                assert!(
+                    meta.applies_to(Some(Lang::JA)),
+                    "{id} (neutral) should run on JA"
+                );
+                assert!(
+                    meta.applies_to(Some(Lang::KO)),
+                    "{id} (neutral) should run on KO"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn rules_construct_via_default() {
         // `Default` delegates to `new()`; exercise each so the delegation is covered.
         assert_eq!(

--- a/crates/tzlint_rules/src/rules/ja_no_mixed_period.rs
+++ b/crates/tzlint_rules/src/rules/ja_no_mixed_period.rs
@@ -4,6 +4,7 @@
 //! `check` call (visited-guarded, so a byte-valid but cyclic archive can neither loop nor OOM),
 //! collecting `。` and qualifying `.` terminators, then reports the minority style.
 
+use tzlint_ast::morphology::Lang;
 use tzlint_ast::{NodeKind, Span};
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
@@ -19,7 +20,7 @@ impl JaNoMixedPeriod {
     /// Construct the rule (no options).
     pub fn new() -> Self {
         JaNoMixedPeriod {
-            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::ROOT]),
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::ROOT]).for_language(Lang::JA),
         }
     }
 

--- a/crates/tzlint_rules/src/rules/max_ten.rs
+++ b/crates/tzlint_rules/src/rules/max_ten.rs
@@ -1,6 +1,7 @@
 //! `max-ten` — flag sentences with too many 読点 (Japanese commas).
 
 use serde_json::Value;
+use tzlint_ast::morphology::Lang;
 use tzlint_ast::{NodeKind, Span};
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
@@ -27,7 +28,8 @@ impl MaxTen {
                 ID,
                 Severity::Warning,
                 vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
-            ),
+            )
+            .for_language(Lang::JA),
             max: DEFAULT_MAX,
             touten: DEFAULT_TOUTEN,
             kuten: DEFAULT_KUTEN,

--- a/crates/tzlint_rules/src/rules/no_hankaku_kana.rs
+++ b/crates/tzlint_rules/src/rules/no_hankaku_kana.rs
@@ -1,5 +1,6 @@
 //! `no-hankaku-kana` — flag half-width katakana (full-width is preferred).
 
+use tzlint_ast::morphology::Lang;
 use tzlint_ast::{NodeKind, Span};
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
@@ -18,7 +19,7 @@ impl NoHankakuKana {
     /// Construct the rule (no options).
     pub fn new() -> Self {
         NoHankakuKana {
-            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]),
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]).for_language(Lang::JA),
         }
     }
 }

--- a/crates/tzlint_rules/src/rules/sentence_length.rs
+++ b/crates/tzlint_rules/src/rules/sentence_length.rs
@@ -2,6 +2,7 @@
 
 use serde_json::Value;
 use tzlint_ast::NodeKind;
+use tzlint_ast::morphology::Lang;
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use crate::util::{split_sentences, strip_urls};
@@ -26,7 +27,8 @@ impl SentenceLength {
                 ID,
                 Severity::Warning,
                 vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
-            ),
+            )
+            .for_language(Lang::JA),
             max: DEFAULT_MAX,
             skip_urls: true,
         }

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -1,0 +1,92 @@
+# JSON output format
+
+`tzlint lint --format json` emits a stable, machine-readable report. It is the contract the
+`editors/vscode/` extension parses (over `tzlint lint - --format json`, feeding the document on
+stdin), so the shape below is treated as a stable interface: it evolves **additively** — new keys
+may appear, but existing keys and their meanings do not change within a `0.x` minor series.
+
+The text and SARIF formats (`--format text|sarif`) are documented separately; this page covers
+only `--format json`.
+
+## Shape
+
+The top level is an array with one object per linted file, in the run's file order (a stdin
+source is reported first, under the path `<stdin>`):
+
+```jsonc
+[
+  {
+    "path": "doc.md",            // the file path, or "<stdin>"
+    "diagnostics": [ /* … */ ]   // empty array when the file is clean
+  }
+]
+```
+
+Each diagnostic:
+
+| Field      | Type     | Meaning                                                                       |
+| ---------- | -------- | ----------------------------------------------------------------------------- |
+| `rule_id`  | string   | The rule that produced the diagnostic (e.g. `"no-todo"`).                     |
+| `severity` | string   | One of `"error"`, `"warning"`, `"info"`, `"hint"` (always lowercase).         |
+| `message`  | string   | The human-readable message.                                                   |
+| `span`     | object   | The source range as **absolute byte offsets**: `{ "start", "end" }`, `end` exclusive. |
+| `position` | object   | The same range mapped to line/column (see below).                             |
+| `fixes`    | array    | Zero or more autofixes (see below); empty when the diagnostic is not fixable. |
+
+A `position` (and every `fixes[].position`) has a `start` and an `end`, each a point:
+
+| Field         | Type   | Meaning                                                                          |
+| ------------- | ------ | -------------------------------------------------------------------------------- |
+| `line`        | number | 1-based line.                                                                    |
+| `column`      | number | 1-based column, counted in **Unicode scalar values** (matches the text format).  |
+| `utf16Column` | number | 1-based column, counted in **UTF-16 code units** (a BMP char is 1, an astral-plane char is 2). Editors and the LSP address text in UTF-16. |
+
+Each fix:
+
+| Field         | Type   | Meaning                                                              |
+| ------------- | ------ | ------------------------------------------------------------------- |
+| `span`        | object | The byte range the fix replaces (`{ "start", "end" }`).             |
+| `position`    | object | That range as line/column points (same shape as a diagnostic's).    |
+| `replacement` | string | The text to substitute for `span`.                                  |
+
+## Example
+
+For the source `"あ x\n"` (the full-width `あ` is three UTF-8 bytes, so the `x` at byte offset 4
+is at column 3):
+
+```json
+[
+  {
+    "path": "doc.md",
+    "diagnostics": [
+      {
+        "rule_id": "no-todo",
+        "severity": "warning",
+        "message": "found x",
+        "span": { "start": 4, "end": 5 },
+        "position": {
+          "start": { "line": 1, "column": 3, "utf16Column": 3 },
+          "end": { "line": 1, "column": 4, "utf16Column": 4 }
+        },
+        "fixes": [
+          {
+            "span": { "start": 4, "end": 5 },
+            "position": {
+              "start": { "line": 1, "column": 3, "utf16Column": 3 },
+              "end": { "line": 1, "column": 4, "utf16Column": 4 }
+            },
+            "replacement": "y"
+          }
+        ]
+      }
+    ]
+  }
+]
+```
+
+## Stability
+
+The CLI and the editor integrations route through the same `tzlint_core::lint_document`, so an
+editor sees byte-for-byte the diagnostics `tzlint lint` produces, in the same total order
+(`span.start`, `span.end`, `rule_id`, `message`). A golden test (`json_contract_is_stable` in
+`crates/tzlint_cli/src/output.rs`) pins this shape so an accidental change fails CI.


### PR DESCRIPTION
First of a **4-PR stack** building the 0.1.0 release (Japanese textlint-replacement MVP, #57). Foundational, rule-agnostic changes the later PRs build on.

### Included
- **Rule applicability metadata (R5)** — additive PDK `Applicability` (`Neutral` | `Languages(Vec<Lang>)`) on `RuleMeta`, with `for_language` / `with_morphology` builders and `applies_to(Option<Lang>)`.
- **Language scoping (R6)** — `config.language` selects which rules run. Decision: unset ⇒ language-neutral rules only; the `ja-*` presets imply `language: ja` (user-overridable). Implemented at the CLI rule-set build (`region_rules_for`), so the engine/`lint_document`/`test_support` are untouched.
- **UTF-16 column (R2)** — an additive `utf16Column` in `--format json` positions (text/SARIF untouched), for the future LSP.
- **JSON output contract (R3)** — a golden `json_contract_is_stable` test + `docs/json-output.md` pinning the contract the editor integrations parse.
- Seeds `CHANGELOG.md` (the `[0.1.0]` section grows over the stack).

### Stack
1. **foundations** (this PR, base `main`)
2. ja-style-rules → base this branch
3. prh → base ja-style-rules
4. release (version bump) → base prh, merges last

Workspace version stays `0.0.0` until the final release PR. `just check` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 言語設定に基づくルール自動適用機構を実装。日本語設定時は日本語専用ルールが有効化されます。
  * JSON出力に UTF-16 カラム情報を追加。エディタ統合の精度が向上します。

* **ドキュメント**
  * 変更履歴を記録するCHANGELOG.mdを追加。
  * JSON出力仕様をドキュメント化。

* **テスト**
  * 言語別ルール適用の検証テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->