### PR TITLE
feat(0.1.0): Japanese morphology style rules + ja-technical-writing preset wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ accumulate as the release is built.
   in one sentence (the subject-marking 格助詞「が」 is not counted).
   `ja-no-redundant-expression` flags the redundant「〜することができる」family (こと + が +
   できる/可能), which reads more tightly as 「〜できる」.
+  `no-dropping-the-ra` flags ら抜き言葉 (a 一段/カ変 verb + the potential 「れる」 where
+  「られる」 is standard, e.g. 見れる → 見られる; 五段 passives like 書かれる are not flagged).
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ accumulate as the release is built.
   `no-mixed-zenkaku-hankaku-alphabet`, `no-nfd`, `no-zero-width-spaces`,
   `ja-no-mixed-period`, `no-exclamation-question-mark`, `no-todo`, `sentence-length`,
   `max-ten`, `max-kanji-continuous-len`, and the morphology-backed `no-doubled-joshi`.
+- **Japanese morphology style rules.** `no-mix-dearu-desumasu` flags mixing the である
+  (plain) and ですます (polite) sentence styles within a document — auto-detecting the
+  majority and flagging the minority, or enforcing a configured `prefer`red style.
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ accumulate as the release is built.
   できる/可能), which reads more tightly as 「〜できる」.
   `no-dropping-the-ra` flags ら抜き言葉 (a 一段/カ変 verb + the potential 「れる」 where
   「られる」 is standard, e.g. 見れる → 見られる; 五段 passives like 書かれる are not flagged).
+  `no-double-negative-ja` flags a rhetorical double negative — a negative closed by
+  「は」+ another negative (ないことはない / なくはない); 〜なければならない is not flagged.
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ accumulate as the release is built.
 - **Japanese morphology style rules.** `no-mix-dearu-desumasu` flags mixing the である
   (plain) and ですます (polite) sentence styles within a document — auto-detecting the
   majority and flagging the minority, or enforcing a configured `prefer`red style.
+  `no-doubled-conjunctive-particle-ga` flags the 逆接の接続助詞「が」 used more than once
+  in one sentence (the subject-marking 格助詞「が」 is not counted).
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ accumulate as the release is built.
   majority and flagging the minority, or enforcing a configured `prefer`red style.
   `no-doubled-conjunctive-particle-ga` flags the 逆接の接続助詞「が」 used more than once
   in one sentence (the subject-marking 格助詞「が」 is not counted).
+  `ja-no-redundant-expression` flags the redundant「〜することができる」family (こと + が +
+  できる/可能), which reads more tightly as 「〜できる」.
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ accumulate as the release is built.
   「られる」 is standard, e.g. 見れる → 見られる; 五段 passives like 書かれる are not flagged).
   `no-double-negative-ja` flags a rhetorical double negative — a negative closed by
   「は」+ another negative (ないことはない / なくはない); 〜なければならない is not flagged.
+  All five ship enabled in the `ja-technical-writing` preset (alongside `no-doubled-joshi`),
+  mirroring `textlint-rule-preset-ja-technical-writing`; they stay no-ops until a morphology
+  dictionary is configured.
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -49,11 +49,11 @@ impl Preset {
     /// The rule settings this preset contributes as a base layer.
     ///
     /// Rule ids are referenced as strings (no dependency on `tzlint_rules`); they MUST match the
-    /// ids in `tzlint_rules::RULE_IDS` verbatim. The morphology-backed `no-doubled-joshi` is part
-    /// of `ja-technical-writing`; it is a no-op until a dictionary is provisioned (the engine skips
-    /// it), so enabling it without a configured `morphology` source is harmless. The options set
-    /// here are routed into the constructed rule instances (via `tzlint_rules::build_rule`) when a
-    /// config selects this preset through `extends`.
+    /// ids in `tzlint_rules::RULE_IDS` verbatim. The morphology-backed style rules (`no-doubled-joshi`
+    /// and the `no-mix-dearu-desumasu` family) are part of `ja-technical-writing`; each is a no-op
+    /// until a dictionary is provisioned (the engine skips it), so enabling them without a configured
+    /// `morphology` source is harmless. The options set here are routed into the constructed rule
+    /// instances (via `tzlint_rules::build_rule`) when a config selects this preset through `extends`.
     fn rules(self) -> BTreeMap<RuleId, RuleSetting> {
         match self {
             Preset::JaBasic => ja_basic(),
@@ -98,9 +98,15 @@ fn ja_technical_writing() -> BTreeMap<RuleId, RuleSetting> {
         ("no-zero-width-spaces", on(Value::Null)),
         ("no-exclamation-question-mark", on(Value::Null)),
         ("ja-no-mixed-period", on(Value::Null)),
-        // Morphology-backed: a no-op until a dictionary is provisioned (the engine skips it), so
-        // it is safe to enable here even when `morphology` is unconfigured.
+        // Morphology-backed style rules (mirroring textlint's preset-ja-technical-writing): each is
+        // a no-op until a dictionary is provisioned (the engine skips morphology rules when there is
+        // no tokenizer), so enabling them here is safe even when `morphology` is unconfigured.
         ("no-doubled-joshi", on(Value::Null)),
+        ("no-mix-dearu-desumasu", on(Value::Null)),
+        ("no-doubled-conjunctive-particle-ga", on(Value::Null)),
+        ("ja-no-redundant-expression", on(Value::Null)),
+        ("no-dropping-the-ra", on(Value::Null)),
+        ("no-double-negative-ja", on(Value::Null)),
     ]
     .into_iter()
     .map(|(id, setting)| (RuleId::from(id), setting))
@@ -273,5 +279,45 @@ mod tests {
                 .rules()
                 .contains_key(&RuleId::from("no-doubled-joshi"))
         );
+    }
+
+    #[test]
+    fn ja_technical_writing_bundles_the_morphology_style_rules() {
+        // The Japanese morphology *style* rules mirror textlint's preset-ja-technical-writing
+        // composition: they ship enabled in the technical-writing preset (a no-op until a
+        // dictionary is provisioned, exactly like no-doubled-joshi), and are absent from the
+        // lighter ja-basic base.
+        let style_rules = [
+            "no-mix-dearu-desumasu",
+            "no-doubled-conjunctive-particle-ga",
+            "ja-no-redundant-expression",
+            "no-dropping-the-ra",
+            "no-double-negative-ja",
+        ];
+        let technical = Preset::JaTechnicalWriting.rules();
+        let basic = Preset::JaBasic.rules();
+        for id in style_rules {
+            assert!(
+                technical.contains_key(&RuleId::from(id)),
+                "ja-technical-writing should bundle {id}"
+            );
+            assert!(
+                !basic.contains_key(&RuleId::from(id)),
+                "ja-basic should not bundle the style rule {id}"
+            );
+        }
+    }
+
+    #[test]
+    fn ja_prh_is_not_bundled_in_a_preset() {
+        // `ja-prh` is configured per project (its term list is supplied via `options.terms`), so it
+        // is intentionally not part of either built-in preset — it is a no-op without terms.
+        for preset in [Preset::JaBasic, Preset::JaTechnicalWriting] {
+            assert!(
+                !preset.rules().contains_key(&RuleId::from("ja-prh")),
+                "{} should not bundle ja-prh",
+                preset.id()
+            );
+        }
     }
 }

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -49,10 +49,11 @@ impl Preset {
     /// The rule settings this preset contributes as a base layer.
     ///
     /// Rule ids are referenced as strings (no dependency on `tzlint_rules`); they MUST match the
-    /// ids in `tzlint_rules::RULE_IDS` verbatim. Rules whose detection needs morphology (M2),
-    /// such as `no-doubled-joshi`, are intentionally omitted until that lands — additively.
-    /// The options set here are routed into the constructed rule instances (via
-    /// `tzlint_rules::build_rule`) when a config selects this preset through `extends`.
+    /// ids in `tzlint_rules::RULE_IDS` verbatim. The morphology-backed `no-doubled-joshi` is part
+    /// of `ja-technical-writing`; it is a no-op until a dictionary is provisioned (the engine skips
+    /// it), so enabling it without a configured `morphology` source is harmless. The options set
+    /// here are routed into the constructed rule instances (via `tzlint_rules::build_rule`) when a
+    /// config selects this preset through `extends`.
     fn rules(self) -> BTreeMap<RuleId, RuleSetting> {
         match self {
             Preset::JaBasic => ja_basic(),
@@ -97,6 +98,9 @@ fn ja_technical_writing() -> BTreeMap<RuleId, RuleSetting> {
         ("no-zero-width-spaces", on(Value::Null)),
         ("no-exclamation-question-mark", on(Value::Null)),
         ("ja-no-mixed-period", on(Value::Null)),
+        // Morphology-backed: a no-op until a dictionary is provisioned (the engine skips it), so
+        // it is safe to enable here even when `morphology` is unconfigured.
+        ("no-doubled-joshi", on(Value::Null)),
     ]
     .into_iter()
     .map(|(id, setting)| (RuleId::from(id), setting))
@@ -249,6 +253,25 @@ mod tests {
             !Preset::JaBasic
                 .rules()
                 .contains_key(&RuleId::from("sentence-length"))
+        );
+    }
+
+    #[test]
+    fn ja_technical_writing_enables_the_morphology_flagship_rule() {
+        // `no-doubled-joshi` is the morphology-backed flagship of the technical-writing preset. It
+        // is a no-op until a dictionary is provisioned (engine skips it), so enabling it in the
+        // preset is safe even when morphology is unconfigured.
+        assert!(
+            Preset::JaTechnicalWriting
+                .rules()
+                .contains_key(&RuleId::from("no-doubled-joshi")),
+            "ja-technical-writing should enable no-doubled-joshi"
+        );
+        // It is intentionally NOT in the lighter ja-basic preset.
+        assert!(
+            !Preset::JaBasic
+                .rules()
+                .contains_key(&RuleId::from("no-doubled-joshi"))
         );
     }
 }

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -23,16 +23,17 @@ use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use rules::{
     ja_no_mixed_period, ja_no_redundant_expression, max_kanji_continuous_len, max_ten,
-    no_doubled_conjunctive_particle_ga, no_doubled_joshi, no_exclamation_question_mark,
-    no_hankaku_kana, no_mix_dearu_desumasu, no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo,
-    no_zero_width_spaces, sentence_length,
+    no_doubled_conjunctive_particle_ga, no_doubled_joshi, no_dropping_the_ra,
+    no_exclamation_question_mark, no_hankaku_kana, no_mix_dearu_desumasu,
+    no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_zero_width_spaces, sentence_length,
 };
 pub use rules::{
     ja_no_mixed_period::JaNoMixedPeriod, ja_no_redundant_expression::JaNoRedundantExpression,
     max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
     no_doubled_conjunctive_particle_ga::NoDoubledConjunctiveParticleGa,
-    no_doubled_joshi::NoDoubledJoshi, no_exclamation_question_mark::NoExclamationQuestionMark,
-    no_hankaku_kana::NoHankakuKana, no_mix_dearu_desumasu::NoMixDearuDesumasu,
+    no_doubled_joshi::NoDoubledJoshi, no_dropping_the_ra::NoDroppingTheRa,
+    no_exclamation_question_mark::NoExclamationQuestionMark, no_hankaku_kana::NoHankakuKana,
+    no_mix_dearu_desumasu::NoMixDearuDesumasu,
     no_mixed_zenkaku_hankaku_alphabet::NoMixedZenkakuHankakuAlphabet, no_nfd::NoNfd,
     no_todo::NoTodo, no_zero_width_spaces::NoZeroWidthSpaces, sentence_length::SentenceLength,
 };
@@ -54,6 +55,7 @@ pub const RULE_IDS: &[&str] = &[
     no_doubled_joshi::ID,
     no_doubled_conjunctive_particle_ga::ID,
     ja_no_redundant_expression::ID,
+    no_dropping_the_ra::ID,
 ];
 
 /// Construct a single built-in rule by `id`, applying config `options` (through the rule's
@@ -80,6 +82,7 @@ pub fn build_rule(id: &str, options: &Value, severity: Option<Severity>) -> Opti
         no_doubled_joshi::ID => Box::new(NoDoubledJoshi::from_options(options)),
         no_doubled_conjunctive_particle_ga::ID => Box::new(NoDoubledConjunctiveParticleGa::new()),
         ja_no_redundant_expression::ID => Box::new(JaNoRedundantExpression::new()),
+        no_dropping_the_ra::ID => Box::new(NoDroppingTheRa::new()),
         _ => return None,
     };
     Some(match severity {
@@ -173,6 +176,7 @@ mod tests {
             "no-mix-dearu-desumasu",              // JA via its morphology pin
             "no-doubled-conjunctive-particle-ga", // JA via its morphology pin
             "ja-no-redundant-expression",         // JA via its morphology pin
+            "no-dropping-the-ra",                 // JA via its morphology pin
         ];
 
         for id in RULE_IDS {

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -22,15 +22,15 @@ use serde_json::Value;
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use rules::{
-    ja_no_mixed_period, max_kanji_continuous_len, max_ten, no_doubled_joshi,
-    no_exclamation_question_mark, no_hankaku_kana, no_mix_dearu_desumasu,
+    ja_no_mixed_period, max_kanji_continuous_len, max_ten, no_doubled_conjunctive_particle_ga,
+    no_doubled_joshi, no_exclamation_question_mark, no_hankaku_kana, no_mix_dearu_desumasu,
     no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_zero_width_spaces, sentence_length,
 };
 pub use rules::{
     ja_no_mixed_period::JaNoMixedPeriod, max_kanji_continuous_len::MaxKanjiContinuousLen,
-    max_ten::MaxTen, no_doubled_joshi::NoDoubledJoshi,
-    no_exclamation_question_mark::NoExclamationQuestionMark, no_hankaku_kana::NoHankakuKana,
-    no_mix_dearu_desumasu::NoMixDearuDesumasu,
+    max_ten::MaxTen, no_doubled_conjunctive_particle_ga::NoDoubledConjunctiveParticleGa,
+    no_doubled_joshi::NoDoubledJoshi, no_exclamation_question_mark::NoExclamationQuestionMark,
+    no_hankaku_kana::NoHankakuKana, no_mix_dearu_desumasu::NoMixDearuDesumasu,
     no_mixed_zenkaku_hankaku_alphabet::NoMixedZenkakuHankakuAlphabet, no_nfd::NoNfd,
     no_todo::NoTodo, no_zero_width_spaces::NoZeroWidthSpaces, sentence_length::SentenceLength,
 };
@@ -50,6 +50,7 @@ pub const RULE_IDS: &[&str] = &[
     ja_no_mixed_period::ID,
     no_todo::ID,
     no_doubled_joshi::ID,
+    no_doubled_conjunctive_particle_ga::ID,
 ];
 
 /// Construct a single built-in rule by `id`, applying config `options` (through the rule's
@@ -74,6 +75,7 @@ pub fn build_rule(id: &str, options: &Value, severity: Option<Severity>) -> Opti
         ja_no_mixed_period::ID => Box::new(JaNoMixedPeriod::new()),
         no_todo::ID => Box::new(NoTodo::from_options(options)),
         no_doubled_joshi::ID => Box::new(NoDoubledJoshi::from_options(options)),
+        no_doubled_conjunctive_particle_ga::ID => Box::new(NoDoubledConjunctiveParticleGa::new()),
         _ => return None,
     };
     Some(match severity {
@@ -163,8 +165,9 @@ mod tests {
             "max-ten",
             "no-hankaku-kana",
             "ja-no-mixed-period",
-            "no-doubled-joshi",      // JA via its morphology pin
-            "no-mix-dearu-desumasu", // JA via its morphology pin
+            "no-doubled-joshi",                   // JA via its morphology pin
+            "no-mix-dearu-desumasu",              // JA via its morphology pin
+            "no-doubled-conjunctive-particle-ga", // JA via its morphology pin
         ];
 
         for id in RULE_IDS {

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -255,6 +255,22 @@ mod tests {
             NoMixDearuDesumasu::default().meta().id.as_str(),
             "no-mix-dearu-desumasu"
         );
+        assert_eq!(
+            NoDoubledConjunctiveParticleGa::default().meta().id.as_str(),
+            "no-doubled-conjunctive-particle-ga"
+        );
+        assert_eq!(
+            JaNoRedundantExpression::default().meta().id.as_str(),
+            "ja-no-redundant-expression"
+        );
+        assert_eq!(
+            NoDroppingTheRa::default().meta().id.as_str(),
+            "no-dropping-the-ra"
+        );
+        assert_eq!(
+            NoDoubleNegativeJa::default().meta().id.as_str(),
+            "no-double-negative-ja"
+        );
     }
 
     #[test]

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -23,13 +23,14 @@ use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use rules::{
     ja_no_mixed_period, ja_no_redundant_expression, max_kanji_continuous_len, max_ten,
-    no_doubled_conjunctive_particle_ga, no_doubled_joshi, no_dropping_the_ra,
-    no_exclamation_question_mark, no_hankaku_kana, no_mix_dearu_desumasu,
+    no_double_negative_ja, no_doubled_conjunctive_particle_ga, no_doubled_joshi,
+    no_dropping_the_ra, no_exclamation_question_mark, no_hankaku_kana, no_mix_dearu_desumasu,
     no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_zero_width_spaces, sentence_length,
 };
 pub use rules::{
     ja_no_mixed_period::JaNoMixedPeriod, ja_no_redundant_expression::JaNoRedundantExpression,
     max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
+    no_double_negative_ja::NoDoubleNegativeJa,
     no_doubled_conjunctive_particle_ga::NoDoubledConjunctiveParticleGa,
     no_doubled_joshi::NoDoubledJoshi, no_dropping_the_ra::NoDroppingTheRa,
     no_exclamation_question_mark::NoExclamationQuestionMark, no_hankaku_kana::NoHankakuKana,
@@ -56,6 +57,7 @@ pub const RULE_IDS: &[&str] = &[
     no_doubled_conjunctive_particle_ga::ID,
     ja_no_redundant_expression::ID,
     no_dropping_the_ra::ID,
+    no_double_negative_ja::ID,
 ];
 
 /// Construct a single built-in rule by `id`, applying config `options` (through the rule's
@@ -83,6 +85,7 @@ pub fn build_rule(id: &str, options: &Value, severity: Option<Severity>) -> Opti
         no_doubled_conjunctive_particle_ga::ID => Box::new(NoDoubledConjunctiveParticleGa::new()),
         ja_no_redundant_expression::ID => Box::new(JaNoRedundantExpression::new()),
         no_dropping_the_ra::ID => Box::new(NoDroppingTheRa::new()),
+        no_double_negative_ja::ID => Box::new(NoDoubleNegativeJa::new()),
         _ => return None,
     };
     Some(match severity {
@@ -177,6 +180,7 @@ mod tests {
             "no-doubled-conjunctive-particle-ga", // JA via its morphology pin
             "ja-no-redundant-expression",         // JA via its morphology pin
             "no-dropping-the-ra",                 // JA via its morphology pin
+            "no-double-negative-ja",              // JA via its morphology pin
         ];
 
         for id in RULE_IDS {

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -22,13 +22,15 @@ use serde_json::Value;
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use rules::{
-    ja_no_mixed_period, max_kanji_continuous_len, max_ten, no_doubled_conjunctive_particle_ga,
-    no_doubled_joshi, no_exclamation_question_mark, no_hankaku_kana, no_mix_dearu_desumasu,
-    no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_zero_width_spaces, sentence_length,
+    ja_no_mixed_period, ja_no_redundant_expression, max_kanji_continuous_len, max_ten,
+    no_doubled_conjunctive_particle_ga, no_doubled_joshi, no_exclamation_question_mark,
+    no_hankaku_kana, no_mix_dearu_desumasu, no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo,
+    no_zero_width_spaces, sentence_length,
 };
 pub use rules::{
-    ja_no_mixed_period::JaNoMixedPeriod, max_kanji_continuous_len::MaxKanjiContinuousLen,
-    max_ten::MaxTen, no_doubled_conjunctive_particle_ga::NoDoubledConjunctiveParticleGa,
+    ja_no_mixed_period::JaNoMixedPeriod, ja_no_redundant_expression::JaNoRedundantExpression,
+    max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
+    no_doubled_conjunctive_particle_ga::NoDoubledConjunctiveParticleGa,
     no_doubled_joshi::NoDoubledJoshi, no_exclamation_question_mark::NoExclamationQuestionMark,
     no_hankaku_kana::NoHankakuKana, no_mix_dearu_desumasu::NoMixDearuDesumasu,
     no_mixed_zenkaku_hankaku_alphabet::NoMixedZenkakuHankakuAlphabet, no_nfd::NoNfd,
@@ -51,6 +53,7 @@ pub const RULE_IDS: &[&str] = &[
     no_todo::ID,
     no_doubled_joshi::ID,
     no_doubled_conjunctive_particle_ga::ID,
+    ja_no_redundant_expression::ID,
 ];
 
 /// Construct a single built-in rule by `id`, applying config `options` (through the rule's
@@ -76,6 +79,7 @@ pub fn build_rule(id: &str, options: &Value, severity: Option<Severity>) -> Opti
         no_todo::ID => Box::new(NoTodo::from_options(options)),
         no_doubled_joshi::ID => Box::new(NoDoubledJoshi::from_options(options)),
         no_doubled_conjunctive_particle_ga::ID => Box::new(NoDoubledConjunctiveParticleGa::new()),
+        ja_no_redundant_expression::ID => Box::new(JaNoRedundantExpression::new()),
         _ => return None,
     };
     Some(match severity {
@@ -168,6 +172,7 @@ mod tests {
             "no-doubled-joshi",                   // JA via its morphology pin
             "no-mix-dearu-desumasu",              // JA via its morphology pin
             "no-doubled-conjunctive-particle-ga", // JA via its morphology pin
+            "ja-no-redundant-expression",         // JA via its morphology pin
         ];
 
         for id in RULE_IDS {

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -23,13 +23,14 @@ use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use rules::{
     ja_no_mixed_period, max_kanji_continuous_len, max_ten, no_doubled_joshi,
-    no_exclamation_question_mark, no_hankaku_kana, no_mixed_zenkaku_hankaku_alphabet, no_nfd,
-    no_todo, no_zero_width_spaces, sentence_length,
+    no_exclamation_question_mark, no_hankaku_kana, no_mix_dearu_desumasu,
+    no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_zero_width_spaces, sentence_length,
 };
 pub use rules::{
     ja_no_mixed_period::JaNoMixedPeriod, max_kanji_continuous_len::MaxKanjiContinuousLen,
     max_ten::MaxTen, no_doubled_joshi::NoDoubledJoshi,
     no_exclamation_question_mark::NoExclamationQuestionMark, no_hankaku_kana::NoHankakuKana,
+    no_mix_dearu_desumasu::NoMixDearuDesumasu,
     no_mixed_zenkaku_hankaku_alphabet::NoMixedZenkakuHankakuAlphabet, no_nfd::NoNfd,
     no_todo::NoTodo, no_zero_width_spaces::NoZeroWidthSpaces, sentence_length::SentenceLength,
 };
@@ -41,6 +42,7 @@ pub const RULE_IDS: &[&str] = &[
     max_ten::ID,
     max_kanji_continuous_len::ID,
     no_hankaku_kana::ID,
+    no_mix_dearu_desumasu::ID,
     no_mixed_zenkaku_hankaku_alphabet::ID,
     no_nfd::ID,
     no_zero_width_spaces::ID,
@@ -62,6 +64,7 @@ pub fn build_rule(id: &str, options: &Value, severity: Option<Severity>) -> Opti
         max_ten::ID => Box::new(MaxTen::from_options(options)),
         max_kanji_continuous_len::ID => Box::new(MaxKanjiContinuousLen::from_options(options)),
         no_hankaku_kana::ID => Box::new(NoHankakuKana::new()),
+        no_mix_dearu_desumasu::ID => Box::new(NoMixDearuDesumasu::from_options(options)),
         no_mixed_zenkaku_hankaku_alphabet::ID => Box::new(NoMixedZenkakuHankakuAlphabet::new()),
         no_nfd::ID => Box::new(NoNfd::new()),
         no_zero_width_spaces::ID => Box::new(NoZeroWidthSpaces::new()),
@@ -160,7 +163,8 @@ mod tests {
             "max-ten",
             "no-hankaku-kana",
             "ja-no-mixed-period",
-            "no-doubled-joshi", // JA via its morphology pin
+            "no-doubled-joshi",      // JA via its morphology pin
+            "no-mix-dearu-desumasu", // JA via its morphology pin
         ];
 
         for id in RULE_IDS {
@@ -230,6 +234,10 @@ mod tests {
         assert_eq!(
             NoDoubledJoshi::default().meta().id.as_str(),
             "no-doubled-joshi"
+        );
+        assert_eq!(
+            NoMixDearuDesumasu::default().meta().id.as_str(),
+            "no-mix-dearu-desumasu"
         );
     }
 

--- a/crates/tzlint_rules/src/rules/ja_no_redundant_expression.rs
+++ b/crates/tzlint_rules/src/rules/ja_no_redundant_expression.rs
@@ -1,0 +1,242 @@
+//! `ja-no-redundant-expression` — flag a small, high-confidence set of redundant Japanese
+//! expressions (冗長表現) that a tighter form expresses just as well.
+//!
+//! A **morphology-dependent** rule (Japanese). 0.1.0 ships the canonical「〜することができる」family:
+//! the token run `こと` (名詞) → `が` (格助詞) → `できる` (動詞) or `可能` (名詞), which reads more
+//! tightly as 「〜できる」. It is **report-only** (rewriting needs verb conjugation — 泳ぐことができる →
+//! 泳げる — which is unsafe to automate). The pattern set is intentionally narrow and extensible;
+//! it keys on IPADIC POS literals, so an unrecognized tagset matches nothing (a false negative,
+//! never a false positive — mirrors `no-doubled-joshi`).
+
+use tzlint_ast::morphology::{ArchivedMorphologyV1, ArchivedToken, FeatureKey, Lang};
+use tzlint_ast::{ArchivedAst, NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "ja-no-redundant-expression";
+
+/// Flags a redundant「〜することができる」-family expression.
+pub struct JaNoRedundantExpression {
+    meta: RuleMeta,
+}
+
+impl JaNoRedundantExpression {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        JaNoRedundantExpression {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .with_morphology(Lang::JA),
+        }
+    }
+}
+
+impl Default for JaNoRedundantExpression {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for JaNoRedundantExpression {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let Some(table) = cx.morphology() else {
+            return; // belt-and-suspenders over the engine's morphology gate
+        };
+        let ast = cx.ast();
+
+        let mut tokens: Vec<&ArchivedToken> = cx.tokens_of(node.id()).collect();
+        tokens.sort_by_key(|t| (t.surface().start, t.surface().end));
+
+        // Scan for the こと + が + (できる | 可能) run on adjacent tokens.
+        for window in tokens.windows(3) {
+            let [koto, ga, tail] = window else {
+                continue;
+            };
+            if koto.is_unknown() || ga.is_unknown() || tail.is_unknown() {
+                continue;
+            }
+            let is_koto = pos(koto, table) == Some("名詞") && surface(koto, ast) == Some("こと");
+            let is_ga = pos(ga, table) == Some("助詞")
+                && sub1(ga, table) == Some("格助詞")
+                && surface(ga, ast) == Some("が");
+            let is_tail = (pos(tail, table) == Some("動詞")
+                && tail.base_form(table) == Some("できる"))
+                || (pos(tail, table) == Some("名詞") && surface(tail, ast) == Some("可能"));
+            if is_koto && is_ga && is_tail {
+                cx.report(Span::new(koto.surface().start, tail.surface().end), MESSAGE);
+            }
+        }
+    }
+}
+
+/// The Japanese diagnostic for a「〜することができる」-family redundancy.
+const MESSAGE: &str = "冗長な表現「ことができる」がみつかりました。\n\n\
+「〜できる」と簡潔に書けないか検討してください（例: 泳ぐことができる → 泳げる）。";
+
+fn pos<'a>(tok: &ArchivedToken, table: &'a ArchivedMorphologyV1) -> Option<&'a str> {
+    feature(tok, table, FeatureKey::POS)
+}
+fn sub1<'a>(tok: &ArchivedToken, table: &'a ArchivedMorphologyV1) -> Option<&'a str> {
+    feature(tok, table, FeatureKey::POS_SUB_1)
+}
+fn surface<'a>(tok: &ArchivedToken, ast: &'a ArchivedAst) -> Option<&'a str> {
+    ast.text_of(tok.surface())
+}
+
+/// Resolve a feature value (e.g. POS) of `token` against `table`, or `None`.
+fn feature<'a>(
+    token: &ArchivedToken,
+    table: &'a ArchivedMorphologyV1,
+    key: FeatureKey,
+) -> Option<&'a str> {
+    token
+        .features(table)
+        .find(|(k, _)| *k == key)
+        .and_then(|(_, value)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{diagnose, diagnose_with_morphology};
+    use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+    use tzlint_ast::{NodeId, Span};
+
+    fn push(
+        b: &mut MorphologyBuilder,
+        node: NodeId,
+        start: u32,
+        end: u32,
+        base: Option<&str>,
+        feats: &[(FeatureKey, &str)],
+    ) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags: 0,
+            },
+            None,
+            base,
+            feats,
+        );
+    }
+
+    fn verb(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32, base: &str) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            Some(base),
+            &[(FeatureKey::POS, "動詞")],
+        );
+    }
+    fn koto(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(b, node, start, end, None, &[(FeatureKey::POS, "名詞")]);
+    }
+    fn case_ga(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            None,
+            &[(FeatureKey::POS, "助詞"), (FeatureKey::POS_SUB_1, "格助詞")],
+        );
+    }
+    fn kanou(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(b, node, start, end, None, &[(FeatureKey::POS, "名詞")]);
+    }
+
+    #[test]
+    fn flags_koto_ga_dekiru() {
+        // 泳ぐことができる — こと(6..12) が(12..15) できる(15..24) → flag こと..できる (6..24).
+        let diags = diagnose_with_morphology(
+            &JaNoRedundantExpression::new(),
+            "泳ぐことができる",
+            |p, b| {
+                verb(b, p, 0, 6, "泳ぐ"); // 泳ぐ
+                koto(b, p, 6, 12); // こと
+                case_ga(b, p, 12, 15); // が
+                verb(b, p, 15, 24, "できる"); // できる
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (6, 24));
+        assert!(
+            diags[0].message.contains("ことができる"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_koto_ga_kanou() {
+        // 利用することが可能 — こと(12..18) が(18..21) 可能(21..27) → flag こと..可能.
+        let diags = diagnose_with_morphology(
+            &JaNoRedundantExpression::new(),
+            "利用することが可能",
+            |p, b| {
+                koto(b, p, 0, 6); // 利用 (treated as 名詞 here)
+                verb(b, p, 6, 12, "する"); // する
+                koto(b, p, 12, 18); // こと
+                case_ga(b, p, 18, 21); // が
+                kanou(b, p, 21, 27); // 可能
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (12, 27));
+    }
+
+    #[test]
+    fn a_lone_koto_is_clean() {
+        // ことが大事 — こと + が + 大事(not できる/可能) → not a redundant run.
+        let diags = diagnose_with_morphology(
+            &JaNoRedundantExpression::new(),
+            "ことが大事",
+            |p, b| {
+                koto(b, p, 0, 6); // こと
+                case_ga(b, p, 6, 9); // が
+                kanou(b, p, 9, 15); // 大事 (名詞, surface != 可能)
+            },
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn subject_koto_then_dekiru_without_ga_is_clean() {
+        // こと を できる (を, not が) → no match.
+        let diags = diagnose_with_morphology(
+            &JaNoRedundantExpression::new(),
+            "ことをできる",
+            |p, b| {
+                koto(b, p, 0, 6); // こと
+                push(
+                    b,
+                    p,
+                    6,
+                    9,
+                    None,
+                    &[(FeatureKey::POS, "助詞"), (FeatureKey::POS_SUB_1, "格助詞")],
+                ); // を (格助詞 but surface を)
+                verb(b, p, 9, 18, "できる"); // できる
+            },
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn no_op_without_a_morphology_table() {
+        assert!(diagnose(&JaNoRedundantExpression::new(), "泳ぐことができる").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -6,6 +6,7 @@ pub mod max_ten;
 pub mod no_doubled_joshi;
 pub mod no_exclamation_question_mark;
 pub mod no_hankaku_kana;
+pub mod no_mix_dearu_desumasu;
 pub mod no_mixed_zenkaku_hankaku_alphabet;
 pub mod no_nfd;
 pub mod no_todo;

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -4,6 +4,7 @@ pub mod ja_no_mixed_period;
 pub mod ja_no_redundant_expression;
 pub mod max_kanji_continuous_len;
 pub mod max_ten;
+pub mod no_double_negative_ja;
 pub mod no_doubled_conjunctive_particle_ga;
 pub mod no_doubled_joshi;
 pub mod no_dropping_the_ra;

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -3,6 +3,7 @@
 pub mod ja_no_mixed_period;
 pub mod max_kanji_continuous_len;
 pub mod max_ten;
+pub mod no_doubled_conjunctive_particle_ga;
 pub mod no_doubled_joshi;
 pub mod no_exclamation_question_mark;
 pub mod no_hankaku_kana;

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -1,6 +1,7 @@
 //! The built-in rules, one module each.
 
 pub mod ja_no_mixed_period;
+pub mod ja_no_redundant_expression;
 pub mod max_kanji_continuous_len;
 pub mod max_ten;
 pub mod no_doubled_conjunctive_particle_ga;

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -6,6 +6,7 @@ pub mod max_kanji_continuous_len;
 pub mod max_ten;
 pub mod no_doubled_conjunctive_particle_ga;
 pub mod no_doubled_joshi;
+pub mod no_dropping_the_ra;
 pub mod no_exclamation_question_mark;
 pub mod no_hankaku_kana;
 pub mod no_mix_dearu_desumasu;

--- a/crates/tzlint_rules/src/rules/no_double_negative_ja.rs
+++ b/crates/tzlint_rules/src/rules/no_double_negative_ja.rs
@@ -1,0 +1,284 @@
+//! `no-double-negative-ja` — flag a rhetorical double negative (二重否定): a negative earlier in a
+//! sentence closed by 「は」+ another negative (e.g. ないことはない / なくはない / ないわけではない),
+//! which reads more directly stated in the affirmative.
+//!
+//! A **morphology-dependent** rule (Japanese). To stay high-precision it matches one well-defined
+//! shape: within a sentence, the run 「は」 (助詞) → negative, with at least one **earlier** negative
+//! in the same sentence. A "negative" is the 助動詞 ない/ぬ/ず or the 補助形容詞「ない」. This
+//! deliberately does NOT flag a single negation (問題ではない), nor the grammatical 〜なければならない
+//! (no 「は」 before the closing negative) — both false positives a looser scan would produce. The
+//! pattern set is narrow and extensible; it keys on IPADIC literals, so an unrecognized tagset
+//! matches nothing (a false negative, never a false positive).
+
+use tzlint_ast::morphology::{ArchivedMorphologyV1, ArchivedToken, FeatureKey, Lang};
+use tzlint_ast::{ArchivedAst, NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-double-negative-ja";
+
+/// Sentence terminators that bound the per-sentence scan.
+const TERMINATORS: [char; 7] = ['。', '．', '.', '！', '？', '!', '?'];
+
+/// Flags a 「…ない…はない」-shape rhetorical double negative.
+pub struct NoDoubleNegativeJa {
+    meta: RuleMeta,
+}
+
+impl NoDoubleNegativeJa {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        NoDoubleNegativeJa {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .with_morphology(Lang::JA),
+        }
+    }
+}
+
+impl Default for NoDoubleNegativeJa {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoDoubleNegativeJa {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let Some(table) = cx.morphology() else {
+            return; // belt-and-suspenders over the engine's morphology gate
+        };
+        let ast = cx.ast();
+        let base = node.span().start;
+        let text = node.text();
+
+        let mut tokens: Vec<&ArchivedToken> = cx.tokens_of(node.id()).collect();
+        tokens.sort_by_key(|t| (t.surface().start, t.surface().end));
+
+        let sentence_idx = |start: u32| -> usize {
+            let upto = start.saturating_sub(base) as usize;
+            text.get(..upto)
+                .unwrap_or("")
+                .chars()
+                .filter(|c| TERMINATORS.contains(c))
+                .count()
+        };
+
+        // Within each sentence, the closing 「は」+ negative is a double negative when an earlier
+        // negative is present. Track the running count of negatives seen in the current sentence.
+        let mut current_sentence: Option<usize> = None;
+        let mut negatives_before = 0u32;
+        for (i, &tok) in tokens.iter().enumerate() {
+            let idx = sentence_idx(tok.surface().start);
+            if current_sentence != Some(idx) {
+                current_sentence = Some(idx);
+                negatives_before = 0;
+            }
+            // A 「は」 immediately followed by a negative, with ≥1 earlier negative this sentence.
+            if negatives_before >= 1
+                && is_wa(tok, table, ast)
+                && tokens
+                    .get(i + 1)
+                    .is_some_and(|next| is_negative(next, table))
+            {
+                let closing = tokens[i + 1];
+                cx.report(
+                    Span::new(tok.surface().start, closing.surface().end),
+                    MESSAGE,
+                );
+            }
+            if is_negative(tok, table) {
+                negatives_before += 1;
+            }
+        }
+    }
+}
+
+/// Whether `tok` is a negation: the 助動詞 ない/ぬ/ず or the 補助形容詞「ない」.
+fn is_negative(tok: &ArchivedToken, table: &ArchivedMorphologyV1) -> bool {
+    if tok.is_unknown() {
+        return false;
+    }
+    match feature(tok, table, FeatureKey::POS) {
+        Some("助動詞") => matches!(tok.base_form(table), Some("ない") | Some("ぬ") | Some("ず")),
+        Some("形容詞") => tok.base_form(table) == Some("ない"),
+        _ => false,
+    }
+}
+
+/// Whether `tok` is the binding particle「は」(助詞, surface は).
+fn is_wa(tok: &ArchivedToken, table: &ArchivedMorphologyV1, ast: &ArchivedAst) -> bool {
+    !tok.is_unknown()
+        && feature(tok, table, FeatureKey::POS) == Some("助詞")
+        && ast.text_of(tok.surface()) == Some("は")
+}
+
+/// The Japanese diagnostic for a double negative.
+const MESSAGE: &str = "二重否定がみつかりました。\n\n\
+否定の否定はまわりくどく読みにくいので、肯定の表現に言い換えられないか検討してください\
+（例: できないことはない → できる）。";
+
+/// Resolve a feature value (e.g. POS) of `token` against `table`, or `None`.
+fn feature<'a>(
+    token: &ArchivedToken,
+    table: &'a ArchivedMorphologyV1,
+    key: FeatureKey,
+) -> Option<&'a str> {
+    token
+        .features(table)
+        .find(|(k, _)| *k == key)
+        .and_then(|(_, value)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{diagnose, diagnose_with_morphology};
+    use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+    use tzlint_ast::{NodeId, Span};
+
+    fn push(
+        b: &mut MorphologyBuilder,
+        node: NodeId,
+        start: u32,
+        end: u32,
+        base: Option<&str>,
+        feats: &[(FeatureKey, &str)],
+    ) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags: 0,
+            },
+            None,
+            base,
+            feats,
+        );
+    }
+
+    fn word(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(b, node, start, end, None, &[(FeatureKey::POS, "名詞")]);
+    }
+    /// The 助動詞 negative ない (base ない).
+    fn nai_aux(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            Some("ない"),
+            &[(FeatureKey::POS, "助動詞")],
+        );
+    }
+    /// The 補助形容詞 ない (base ない).
+    fn nai_adj(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            Some("ない"),
+            &[(FeatureKey::POS, "形容詞")],
+        );
+    }
+    /// The binding particle は.
+    fn wa(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            None,
+            &[(FeatureKey::POS, "助詞"), (FeatureKey::POS_SUB_1, "係助詞")],
+        );
+    }
+
+    #[test]
+    fn flags_nai_koto_wa_nai() {
+        // ないことはない — ない(0..6) こと(6..12) は(12..15) ない(15..21) → flag は..ない (12..21).
+        let diags = diagnose_with_morphology(
+            &NoDoubleNegativeJa::new(),
+            "ないことはない",
+            |p, b| {
+                nai_aux(b, p, 0, 6); // ない (first negative)
+                word(b, p, 6, 12); // こと
+                wa(b, p, 12, 15); // は
+                nai_adj(b, p, 15, 21); // ない (closing negative)
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (12, 21));
+        assert!(
+            diags[0].message.contains("二重否定"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_naku_wa_nai() {
+        // なくはない — なく(形容詞 ない, 0..6) は(6..9) ない(形容詞 ない, 9..15) → flagged.
+        let diags =
+            diagnose_with_morphology(&NoDoubleNegativeJa::new(), "なくはない", |p, b| {
+                nai_adj(b, p, 0, 6); // なく (補助形容詞 ない, first negative)
+                wa(b, p, 6, 9); // は
+                nai_adj(b, p, 9, 15); // ない (closing)
+            });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (6, 15));
+    }
+
+    #[test]
+    fn a_single_negation_with_wa_is_clean() {
+        // 問題はない — は+ない but NO earlier negative (問題 is a noun) → not a double negative.
+        let diags =
+            diagnose_with_morphology(&NoDoubleNegativeJa::new(), "問題はない", |p, b| {
+                word(b, p, 0, 6); // 問題
+                wa(b, p, 6, 9); // は
+                nai_aux(b, p, 9, 15); // ない
+            });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn a_lone_negation_is_clean() {
+        // 行かない — one negative, no は+negative closing → clean.
+        let diags = diagnose_with_morphology(&NoDoubleNegativeJa::new(), "行かない", |p, b| {
+            push(b, p, 0, 6, Some("行く"), &[(FeatureKey::POS, "動詞")]); // 行か
+            nai_aux(b, p, 6, 12); // ない
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn a_sentence_boundary_separates_two_negatives() {
+        // 行かない。問題はない — the earlier negative is in sentence 0; the は+ない is in sentence 1
+        // with no earlier negative there → clean (the count resets per sentence).
+        let diags = diagnose_with_morphology(
+            &NoDoubleNegativeJa::new(),
+            "行かない。問題はない",
+            |p, b| {
+                push(b, p, 0, 6, Some("行く"), &[(FeatureKey::POS, "動詞")]); // 行か
+                nai_aux(b, p, 6, 12); // ない  (。 12..15)
+                word(b, p, 15, 21); // 問題
+                wa(b, p, 21, 24); // は
+                nai_aux(b, p, 24, 30); // ない
+            },
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn no_op_without_a_morphology_table() {
+        assert!(diagnose(&NoDoubleNegativeJa::new(), "ないことはない").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/no_doubled_conjunctive_particle_ga.rs
+++ b/crates/tzlint_rules/src/rules/no_doubled_conjunctive_particle_ga.rs
@@ -1,0 +1,274 @@
+//! `no-doubled-conjunctive-particle-ga` — flag the 逆接の接続助詞「が」 used more than once in a
+//! single sentence (e.g. 「Aだが、Bするが、C」), which muddles what connects to what.
+//!
+//! A **morphology-dependent** rule (Japanese, via [`with_morphology`](RuleMeta::with_morphology)).
+//! It counts only the **conjunctive**「が」— a 助詞 whose surface is `が` and whose IPADIC POS
+//! sub-type is `接続助詞` — so the subject-marking 格助詞「が」 is never counted. When a sentence
+//! holds two or more, every occurrence after the first is reported. Keys on the IPADIC POS
+//! literals, so an unrecognized tagset simply matches nothing (a false negative, never a false
+//! positive — mirrors `no-doubled-joshi`).
+
+use tzlint_ast::NodeKind;
+use tzlint_ast::morphology::{ArchivedMorphologyV1, ArchivedToken, FeatureKey, Lang};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-doubled-conjunctive-particle-ga";
+
+/// Sentence terminators that reset the per-sentence count.
+const TERMINATORS: [char; 7] = ['。', '．', '.', '！', '？', '!', '?'];
+
+/// Flags the conjunctive「が」repeated within one sentence.
+pub struct NoDoubledConjunctiveParticleGa {
+    meta: RuleMeta,
+}
+
+impl NoDoubledConjunctiveParticleGa {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        NoDoubledConjunctiveParticleGa {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .with_morphology(Lang::JA),
+        }
+    }
+}
+
+impl Default for NoDoubledConjunctiveParticleGa {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoDoubledConjunctiveParticleGa {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let Some(table) = cx.morphology() else {
+            return; // belt-and-suspenders over the engine's morphology gate
+        };
+        let ast = cx.ast();
+        let base = node.span().start;
+        let text = node.text();
+
+        let mut tokens: Vec<&ArchivedToken> = cx.tokens_of(node.id()).collect();
+        tokens.sort_by_key(|t| (t.surface().start, t.surface().end));
+
+        // The sentence index of a byte offset = the number of terminators before it in the block.
+        let sentence_idx = |start: u32| -> usize {
+            let upto = start.saturating_sub(base) as usize;
+            text.get(..upto)
+                .unwrap_or("")
+                .chars()
+                .filter(|c| TERMINATORS.contains(c))
+                .count()
+        };
+
+        // Walk source-ordered tokens; per sentence, the first conjunctive が is allowed and every
+        // later one is reported.
+        let mut current_sentence: Option<usize> = None;
+        let mut seen_in_sentence = 0u32;
+        for &tok in &tokens {
+            if !is_conjunctive_ga(tok, table, ast) {
+                continue;
+            }
+            let idx = sentence_idx(tok.surface().start);
+            if current_sentence != Some(idx) {
+                current_sentence = Some(idx);
+                seen_in_sentence = 0;
+            }
+            seen_in_sentence += 1;
+            if seen_in_sentence >= 2 {
+                cx.report(tok.surface(), MESSAGE);
+            }
+        }
+    }
+}
+
+/// Whether `tok` is a trusted conjunctive「が」 (助詞 / 接続助詞 / surface `が`).
+fn is_conjunctive_ga(
+    tok: &ArchivedToken,
+    table: &ArchivedMorphologyV1,
+    ast: &tzlint_ast::ArchivedAst,
+) -> bool {
+    if tok.is_unknown() {
+        return false;
+    }
+    feature(tok, table, FeatureKey::POS) == Some("助詞")
+        && feature(tok, table, FeatureKey::POS_SUB_1) == Some("接続助詞")
+        && ast.text_of(tok.surface()) == Some("が")
+}
+
+/// The Japanese diagnostic for a repeated conjunctive が.
+const MESSAGE: &str = "一文に二回以上利用されている接続助詞「が」がみつかりました。\n\n\
+逆接の「が」を一文に複数置くと係り受けが分かりにくくなります。文を分割するか、\
+二つ目以降の「が」を別の表現に書き換えてください。";
+
+/// Resolve a feature value (e.g. POS) of `token` against `table`, or `None`.
+fn feature<'a>(
+    token: &ArchivedToken,
+    table: &'a ArchivedMorphologyV1,
+    key: FeatureKey,
+) -> Option<&'a str> {
+    token
+        .features(table)
+        .find(|(k, _)| *k == key)
+        .and_then(|(_, value)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{diagnose, diagnose_with_morphology};
+    use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+    use tzlint_ast::{NodeId, Span};
+
+    /// Push a token with major POS `pos` and optional sub-type at `[start, end)`.
+    fn push(
+        b: &mut MorphologyBuilder,
+        node: NodeId,
+        start: u32,
+        end: u32,
+        feats: &[(FeatureKey, &str)],
+    ) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags: 0,
+            },
+            None,
+            None,
+            feats,
+        );
+    }
+
+    fn word(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(b, node, start, end, &[(FeatureKey::POS, "名詞")]);
+    }
+    /// A conjunctive が at `[start, end)` (surface is whatever the source has there).
+    fn conj_ga(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            &[
+                (FeatureKey::POS, "助詞"),
+                (FeatureKey::POS_SUB_1, "接続助詞"),
+            ],
+        );
+    }
+    /// A subject-marking 格助詞 が at `[start, end)`.
+    fn case_ga(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            &[(FeatureKey::POS, "助詞"), (FeatureKey::POS_SUB_1, "格助詞")],
+        );
+    }
+
+    #[test]
+    fn flags_the_second_conjunctive_ga_in_a_sentence() {
+        // 雨だが寒いが行く — two 接続助詞 が in one sentence → flag the second (at 18..21).
+        let diags = diagnose_with_morphology(
+            &NoDoubledConjunctiveParticleGa::new(),
+            "雨だが寒いが行く",
+            |p, b| {
+                word(b, p, 0, 6); // 雨だ
+                conj_ga(b, p, 6, 9); // が (1st)
+                word(b, p, 9, 15); // 寒い
+                conj_ga(b, p, 15, 18); // が (2nd) -> flagged
+                word(b, p, 18, 24); // 行く
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (15, 18));
+        assert!(
+            diags[0].message.contains("接続助詞「が」"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn a_single_conjunctive_ga_is_clean() {
+        let diags = diagnose_with_morphology(
+            &NoDoubledConjunctiveParticleGa::new(),
+            "雨だが行く",
+            |p, b| {
+                word(b, p, 0, 6); // 雨だ
+                conj_ga(b, p, 6, 9); // が
+                word(b, p, 9, 15); // 行く
+            },
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn the_case_marking_ga_is_not_counted() {
+        // 雨が降るが寒い — a 格助詞 が (subject) then one 接続助詞 が → only one conjunctive → clean.
+        let diags = diagnose_with_morphology(
+            &NoDoubledConjunctiveParticleGa::new(),
+            "雨が降るが寒い",
+            |p, b| {
+                word(b, p, 0, 3); // 雨
+                case_ga(b, p, 3, 6); // が (格助詞 — not counted)
+                word(b, p, 6, 12); // 降る
+                conj_ga(b, p, 12, 15); // が (接続助詞 — first conjunctive)
+                word(b, p, 15, 21); // 寒い
+            },
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn a_sentence_boundary_resets_the_count() {
+        // 雨だが。寒いが。 — one 接続助詞 が per sentence → never doubled.
+        let diags = diagnose_with_morphology(
+            &NoDoubledConjunctiveParticleGa::new(),
+            "雨だが。寒いが。",
+            |p, b| {
+                word(b, p, 0, 6); // 雨だ
+                conj_ga(b, p, 6, 9); // が   (。 9..12)
+                word(b, p, 12, 18); // 寒い
+                conj_ga(b, p, 18, 21); // が  (。 21..24)
+            },
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn three_ga_flags_the_second_and_third() {
+        // Aが Bが Cが (all 接続助詞, one sentence) → the 2nd and 3rd are reported.
+        let diags = diagnose_with_morphology(
+            &NoDoubledConjunctiveParticleGa::new(),
+            "甲が乙が丙が",
+            |p, b| {
+                word(b, p, 0, 3); // 甲
+                conj_ga(b, p, 3, 6); // が (1st)
+                word(b, p, 6, 9); // 乙
+                conj_ga(b, p, 9, 12); // が (2nd) -> flagged
+                word(b, p, 12, 15); // 丙
+                conj_ga(b, p, 15, 18); // が (3rd) -> flagged
+            },
+        );
+        assert_eq!(diags.len(), 2, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (9, 12));
+        assert_eq!((diags[1].span.start, diags[1].span.end), (15, 18));
+    }
+
+    #[test]
+    fn no_op_without_a_morphology_table() {
+        assert!(diagnose(&NoDoubledConjunctiveParticleGa::new(), "雨だが寒いが行く").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/no_dropping_the_ra.rs
+++ b/crates/tzlint_rules/src/rules/no_dropping_the_ra.rs
@@ -1,0 +1,204 @@
+//! `no-dropping-the-ra` — flag ら抜き言葉: a 一段 or カ変 verb taking the potential auxiliary
+//! 「れる」 where standard Japanese requires 「られる」 (e.g. 見れる → 見られる, 来れる → 来られる).
+//!
+//! A **morphology-dependent** rule (Japanese). The discriminator is precise: the auxiliary れる
+//! attaches to a 一段/カ変 verb **only** in the ら抜き mistake — both the potential and the passive
+//! of those verbs otherwise use られる. A 五段 verb + れる is the legitimate passive (書かれる) and
+//! is therefore left alone, which is why the rule keys on the preceding verb's 活用型 (一段 / カ変).
+//! base form `れる` vs `られる` on the auxiliary is the second half of the test. Keys on IPADIC
+//! literals, so an unrecognized tagset matches nothing (a false negative, never a false positive).
+
+use tzlint_ast::morphology::{ArchivedMorphologyV1, ArchivedToken, FeatureKey, Lang};
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-dropping-the-ra";
+
+/// Flags a 一段/カ変 verb followed by the potential auxiliary れる (the ら抜き mistake).
+pub struct NoDroppingTheRa {
+    meta: RuleMeta,
+}
+
+impl NoDroppingTheRa {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        NoDroppingTheRa {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .with_morphology(Lang::JA),
+        }
+    }
+}
+
+impl Default for NoDroppingTheRa {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoDroppingTheRa {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let Some(table) = cx.morphology() else {
+            return; // belt-and-suspenders over the engine's morphology gate
+        };
+
+        let mut tokens: Vec<&ArchivedToken> = cx.tokens_of(node.id()).collect();
+        tokens.sort_by_key(|t| (t.surface().start, t.surface().end));
+
+        // A 一段/カ変 verb immediately followed by the auxiliary れる (base form れる) is ら抜き.
+        for pair in tokens.windows(2) {
+            let [verb, aux] = pair else { continue };
+            if verb.is_unknown() || aux.is_unknown() {
+                continue;
+            }
+            if is_ichidan_or_kahen_verb(verb, table) && is_reru_auxiliary(aux, table) {
+                cx.report(Span::new(verb.surface().start, aux.surface().end), MESSAGE);
+            }
+        }
+    }
+}
+
+/// Whether `tok` is a verb whose 活用型 is 一段 or カ変 — the only conjugations for which a
+/// following れる is ら抜き (五段 + れる is the legitimate passive).
+fn is_ichidan_or_kahen_verb(tok: &ArchivedToken, table: &ArchivedMorphologyV1) -> bool {
+    feature(tok, table, FeatureKey::POS) == Some("動詞")
+        && feature(tok, table, FeatureKey::CONJUGATION_TYPE)
+            .is_some_and(|c| c.starts_with("一段") || c.starts_with("カ変"))
+}
+
+/// Whether `tok` is the potential/passive auxiliary れる (base form れる, **not** られる).
+fn is_reru_auxiliary(tok: &ArchivedToken, table: &ArchivedMorphologyV1) -> bool {
+    // れる is tagged 動詞 (接尾) or 助動詞 depending on the dictionary; the base form is the signal.
+    matches!(
+        feature(tok, table, FeatureKey::POS),
+        Some("動詞") | Some("助動詞")
+    ) && tok.base_form(table) == Some("れる")
+}
+
+/// The Japanese diagnostic for a ら抜き expression.
+const MESSAGE: &str = "ら抜き言葉がみつかりました。\n\n\
+一段動詞・カ変動詞には「られる」を使ってください（例: 見れる → 見られる、来れる → 来られる）。";
+
+/// Resolve a feature value (e.g. POS) of `token` against `table`, or `None`.
+fn feature<'a>(
+    token: &ArchivedToken,
+    table: &'a ArchivedMorphologyV1,
+    key: FeatureKey,
+) -> Option<&'a str> {
+    token
+        .features(table)
+        .find(|(k, _)| *k == key)
+        .and_then(|(_, value)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{diagnose, diagnose_with_morphology};
+    use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+    use tzlint_ast::{NodeId, Span};
+
+    fn push(
+        b: &mut MorphologyBuilder,
+        node: NodeId,
+        start: u32,
+        end: u32,
+        base: Option<&str>,
+        feats: &[(FeatureKey, &str)],
+    ) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags: 0,
+            },
+            None,
+            base,
+            feats,
+        );
+    }
+
+    /// A 動詞 with the given 活用型 (CONJUGATION_TYPE).
+    fn verb(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32, conj: &str) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            None,
+            &[
+                (FeatureKey::POS, "動詞"),
+                (FeatureKey::CONJUGATION_TYPE, conj),
+            ],
+        );
+    }
+    /// The auxiliary れる/られる with `base` as its base form.
+    fn aux(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32, base: &str) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            Some(base),
+            &[(FeatureKey::POS, "助動詞")],
+        );
+    }
+
+    #[test]
+    fn flags_ichidan_ra_nuki() {
+        // 見れる — 見(一段) + れる(base れる) → ら抜き → flag 見..れる (0..9).
+        let diags = diagnose_with_morphology(&NoDroppingTheRa::new(), "見れる", |p, b| {
+            verb(b, p, 0, 3, "一段"); // 見
+            aux(b, p, 3, 9, "れる"); // れる
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (0, 9));
+        assert!(diags[0].message.contains("ら抜き"), "{}", diags[0].message);
+    }
+
+    #[test]
+    fn the_correct_rareru_is_clean() {
+        // 見られる — 見(一段) + られる(base られる) → correct → no flag.
+        let diags = diagnose_with_morphology(&NoDroppingTheRa::new(), "見られる", |p, b| {
+            verb(b, p, 0, 3, "一段"); // 見
+            aux(b, p, 3, 12, "られる"); // られる
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn flags_kahen_ra_nuki() {
+        // 来れる — 来(カ変・クル) + れる(base れる) → ら抜き.
+        let diags = diagnose_with_morphology(&NoDroppingTheRa::new(), "来れる", |p, b| {
+            verb(b, p, 0, 3, "カ変・クル"); // 来
+            aux(b, p, 3, 9, "れる"); // れる
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (0, 9));
+    }
+
+    #[test]
+    fn godan_passive_reru_is_clean() {
+        // 書かれる — 書か(五段・カ行イ音便) + れる(base れる) → legitimate passive, NOT ら抜き.
+        let diags = diagnose_with_morphology(&NoDroppingTheRa::new(), "書かれる", |p, b| {
+            verb(b, p, 0, 6, "五段・カ行イ音便"); // 書か
+            aux(b, p, 6, 12, "れる"); // れる
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn no_op_without_a_morphology_table() {
+        assert!(diagnose(&NoDroppingTheRa::new(), "見れる").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/no_mix_dearu_desumasu.rs
+++ b/crates/tzlint_rules/src/rules/no_mix_dearu_desumasu.rs
@@ -1,0 +1,489 @@
+//! `no-mix-dearu-desumasu` — flag mixing the である (plain/literary) and ですます (polite)
+//! sentence styles (文体) within one document.
+//!
+//! A **morphology-dependent**, **document-level** rule. It declares
+//! [`with_morphology`](RuleMeta::with_morphology) for Japanese (so the engine runs it only when a
+//! morphology table is available, and R5 scopes it to JA) and visits the prose block kinds purely
+//! so the engine **tokenizes** them; the real work is in [`finish`](Rule::finish), which re-walks
+//! the document, classifies each sentence's final predicate from its tokens, then flags the
+//! minority style across the whole document.
+//!
+//! **Classification** scans a sentence's tokens from the end, skipping sentence-final particles
+//! and non-determining auxiliaries (た/ない/…), and decides on the first style-bearing token: a
+//! 助動詞 whose base form is です/ます ⇒ ですます; だ/である ⇒ である; a plain 動詞/形容詞 ⇒ である;
+//! a 名詞 with no copula (体言止め) ⇒ unclassified (skipped). It keys on **IPADIC** POS literals,
+//! so an unrecognized tagset simply yields no classification — a false negative, never a false
+//! positive (mirrors `no-doubled-joshi`).
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use tzlint_ast::morphology::{ArchivedMorphologyV1, ArchivedToken, FeatureKey, Lang};
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-mix-dearu-desumasu";
+
+/// Sentence terminators that end a sentence for style classification.
+const TERMINATORS: [char; 7] = ['。', '．', '.', '！', '？', '!', '?'];
+
+/// A Japanese sentence style.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Style {
+    /// である体 (plain / literary).
+    Dearu,
+    /// ですます体 (polite).
+    Desumasu,
+}
+
+/// Flags sentences whose style is the document minority (or, with `prefer`, not the chosen style).
+pub struct NoMixDearuDesumasu {
+    meta: RuleMeta,
+    /// The style to enforce. When set, every sentence not in this style is flagged regardless of
+    /// counts; when `None`, the document majority wins and the minority is flagged.
+    prefer: Option<Style>,
+}
+
+impl NoMixDearuDesumasu {
+    /// Construct with the default options (auto-detect the majority; no forced preference).
+    pub fn new() -> Self {
+        NoMixDearuDesumasu {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .with_morphology(Lang::JA),
+            prefer: None,
+        }
+    }
+
+    /// Construct from config `options`, leniently: `prefer` is `"dearu"` or `"desumasu"`; any other
+    /// value (or absent) leaves the rule in auto-detect mode.
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        rule.prefer = match options.get("prefer").and_then(Value::as_str) {
+            Some("dearu") => Some(Style::Dearu),
+            Some("desumasu") => Some(Style::Desumasu),
+            _ => None,
+        };
+        rule
+    }
+}
+
+impl Default for NoMixDearuDesumasu {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoMixDearuDesumasu {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    // Per-node work is unnecessary: the node kinds are declared only so the engine tokenizes the
+    // prose blocks. Document-wide classification happens once in `finish`.
+    fn check<'ast>(&self, _node: NodeRef<'ast>, _cx: &mut Context<'ast>) {}
+
+    fn finish<'ast>(&self, cx: &mut Context<'ast>) {
+        let Some(table) = cx.morphology() else {
+            return; // belt-and-suspenders over the engine's morphology gate
+        };
+        let ast = cx.ast();
+        let Some(root) = NodeRef::root(ast) else {
+            return;
+        };
+
+        // Document-wide: collect each classifiable sentence's (style, determining-token span) via a
+        // cycle-safe walk. A classifiable block is self-contained, so its subtree is not descended.
+        let mut sentences: Vec<(Style, Span)> = Vec::new();
+        let mut visited = vec![false; ast.len()];
+        if let Some(slot) = visited.get_mut(root.id().0 as usize) {
+            *slot = true;
+        }
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            if matches!(
+                node.kind(),
+                NodeKind::PARAGRAPH | NodeKind::HEADING | NodeKind::TABLE_CELL
+            ) {
+                classify_block(node, cx, table, &mut sentences);
+                continue;
+            }
+            for child in node.children() {
+                if let Some(slot) = visited.get_mut(child.id().0 as usize)
+                    && !*slot
+                {
+                    *slot = true;
+                    stack.push(child);
+                }
+            }
+        }
+
+        // Decide which style is the violation set.
+        let dearu = sentences.iter().filter(|(s, _)| *s == Style::Dearu).count();
+        let desumasu = sentences.len() - dearu;
+        let flagged = match self.prefer {
+            // A forced preference flags anything not in it — even a single-style document.
+            Some(Style::Dearu) => Style::Desumasu,
+            Some(Style::Desumasu) => Style::Dearu,
+            None => {
+                // Auto-detect: only a genuine mix is a violation; flag the minority. On a tie, the
+                // である sentences are flagged (ですます is treated as the default majority).
+                if dearu == 0 || desumasu == 0 {
+                    return;
+                }
+                if desumasu >= dearu {
+                    Style::Dearu
+                } else {
+                    Style::Desumasu
+                }
+            }
+        };
+
+        let message = mixed_style_message(flagged);
+        for (style, span) in sentences {
+            if style == flagged {
+                cx.report(span, message.as_str());
+            }
+        }
+    }
+}
+
+/// Classify every sentence in one prose block (split on [`TERMINATORS`]) and append each
+/// classifiable sentence's `(style, determining-token span)` to `out`.
+fn classify_block<'ast>(
+    node: NodeRef<'ast>,
+    cx: &Context<'ast>,
+    table: &'ast ArchivedMorphologyV1,
+    out: &mut Vec<(Style, Span)>,
+) {
+    let base = node.span().start;
+    let text = node.text();
+    let mut tokens: Vec<&ArchivedToken> = cx.tokens_of(node.id()).collect();
+    // The `(node, surface.start)` emission order is a producer contract, not enforced — sort.
+    tokens.sort_by_key(|t| (t.surface().start, t.surface().end));
+
+    // Sentence index of a byte offset = the number of terminators before it within the block.
+    let sentence_idx = |start: u32| -> usize {
+        let upto = start.saturating_sub(base) as usize;
+        text.get(..upto)
+            .unwrap_or("")
+            .chars()
+            .filter(|c| TERMINATORS.contains(c))
+            .count()
+    };
+
+    // Group source-ordered tokens by sentence, then classify each sentence's final predicate.
+    let mut groups: BTreeMap<usize, Vec<&ArchivedToken>> = BTreeMap::new();
+    for &t in &tokens {
+        groups
+            .entry(sentence_idx(t.surface().start))
+            .or_default()
+            .push(t);
+    }
+    for group in groups.values() {
+        if let Some(styled) = classify_sentence(group, table) {
+            out.push(styled);
+        }
+    }
+}
+
+/// Classify a sentence from its source-ordered `tokens` by its final predicate, returning the
+/// [`Style`] and the span of the style-determining token. `None` for an unclassifiable sentence
+/// (体言止め, a fragment, or an unrecognized tagset whose POS literals do not match).
+///
+/// Scans from the end: sentence-final particles, symbols, and non-determining auxiliaries (た /
+/// ない / う / …) are skipped; the first style-bearing token decides — a 助動詞 with base です/ます
+/// ⇒ ですます, だ/である ⇒ である, a plain 動詞/形容詞 ⇒ である, a 名詞 with no copula ⇒ none.
+fn classify_sentence(
+    tokens: &[&ArchivedToken],
+    table: &ArchivedMorphologyV1,
+) -> Option<(Style, Span)> {
+    for &tok in tokens.iter().rev() {
+        if tok.is_unknown() {
+            continue; // an OOV guess is not trusted (mirrors no-doubled-joshi)
+        }
+        match feature(tok, table, FeatureKey::POS) {
+            Some("助動詞") => match tok.base_form(table) {
+                Some("です") | Some("ます") => return Some((Style::Desumasu, tok.surface())),
+                Some("だ") | Some("である") => return Some((Style::Dearu, tok.surface())),
+                // た / ない / う / ん / … don't fix politeness — keep scanning back.
+                _ => continue,
+            },
+            // A plain verbal / adjectival predicate is である体.
+            Some("動詞") | Some("形容詞") => return Some((Style::Dearu, tok.surface())),
+            // A nominal ending with no copula is 体言止め — a style we do not classify.
+            Some("名詞") | Some("代名詞") | Some("形状詞") => return None,
+            // Particles, symbols, prefixes, …: skip and keep looking for the predicate.
+            _ => continue,
+        }
+    }
+    None
+}
+
+/// The Japanese diagnostic for a sentence in the `flagged` (violating) style; it names the style
+/// to unify toward (the other one — the document majority, or the `prefer`red style).
+fn mixed_style_message(flagged: Style) -> String {
+    let (flagged_name, target_name) = match flagged {
+        Style::Dearu => ("である", "ですます"),
+        Style::Desumasu => ("ですます", "である"),
+    };
+    format!(
+        "文体が混在しています。この文は「{flagged_name}」体ですが、文書全体では「{target_name}」体に統一してください。"
+    )
+}
+
+/// Resolve a feature value (e.g. POS) of `token` against `table`, or `None`.
+fn feature<'a>(
+    token: &ArchivedToken,
+    table: &'a ArchivedMorphologyV1,
+    key: FeatureKey,
+) -> Option<&'a str> {
+    token
+        .features(table)
+        .find(|(k, _)| *k == key)
+        .and_then(|(_, value)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{diagnose, diagnose_with_morphology};
+    use tzlint_ast::NodeId;
+    use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+
+    /// Push a token with major POS `pos` and optional `base` form at `[start, end)`.
+    fn tok(
+        b: &mut MorphologyBuilder,
+        node: NodeId,
+        start: u32,
+        end: u32,
+        pos: &str,
+        base: Option<&str>,
+    ) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags: 0,
+            },
+            None,
+            base,
+            &[(FeatureKey::POS, pos)],
+        );
+    }
+
+    fn noun(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        tok(b, node, start, end, "名詞", None);
+    }
+    /// A 助動詞 (auxiliary) with the given base form (です / ます / だ / た / ない / …).
+    fn aux(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32, base: &str) {
+        tok(b, node, start, end, "助動詞", Some(base));
+    }
+    fn verb(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32, base: &str) {
+        tok(b, node, start, end, "動詞", Some(base));
+    }
+    fn particle(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        tok(b, node, start, end, "助詞", None);
+    }
+
+    #[test]
+    fn flags_the_minority_dearu_sentence() {
+        // 猫です。犬です。鳥だ。 — two ですます, one である → flag the lone である sentence at だ (27..30).
+        let diags = diagnose_with_morphology(
+            &NoMixDearuDesumasu::new(),
+            "猫です。犬です。鳥だ。",
+            |p, b| {
+                noun(b, p, 0, 3); // 猫
+                aux(b, p, 3, 9, "です"); // です
+                noun(b, p, 12, 15); // 犬   (。 9..12)
+                aux(b, p, 15, 21, "です"); // です
+                noun(b, p, 24, 27); // 鳥   (。 21..24)
+                aux(b, p, 27, 30, "だ"); // だ   (。 30..33)
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (27, 30));
+    }
+
+    #[test]
+    fn flags_the_minority_desumasu_sentence() {
+        // 猫だ。犬だ。鳥です。 — two である, one ですます → flag です (21..27).
+        let diags = diagnose_with_morphology(
+            &NoMixDearuDesumasu::new(),
+            "猫だ。犬だ。鳥です。",
+            |p, b| {
+                noun(b, p, 0, 3); // 猫
+                aux(b, p, 3, 6, "だ"); // だ   (。 6..9)
+                noun(b, p, 9, 12); // 犬
+                aux(b, p, 12, 15, "だ"); // だ  (。 15..18)
+                noun(b, p, 18, 21); // 鳥
+                aux(b, p, 21, 27, "です"); // です (。 27..30)
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (21, 27));
+        assert!(
+            diags[0].message.contains("ですます"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn a_single_style_document_is_clean() {
+        // All ですます → no mix → no diagnostics.
+        let diags = diagnose_with_morphology(
+            &NoMixDearuDesumasu::new(),
+            "猫です。犬です。",
+            |p, b| {
+                noun(b, p, 0, 3);
+                aux(b, p, 3, 9, "です");
+                noun(b, p, 12, 15);
+                aux(b, p, 15, 21, "です");
+            },
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn taigendome_sentences_are_not_classified() {
+        // 猫です。犬です。鳥。 — the noun-ending (体言止め) third sentence is skipped, leaving a single
+        // style → clean. (If 鳥 were misclassified as である, we'd see a flagged mix.)
+        let diags = diagnose_with_morphology(
+            &NoMixDearuDesumasu::new(),
+            "猫です。犬です。鳥。",
+            |p, b| {
+                noun(b, p, 0, 3);
+                aux(b, p, 3, 9, "です");
+                noun(b, p, 12, 15); // 犬 (。 9..12)
+                aux(b, p, 15, 21, "です");
+                noun(b, p, 24, 27); // 鳥 (。 21..24) — bare noun, no copula → skipped
+            },
+        );
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn past_tense_is_classified_by_the_auxiliary_before_ta() {
+        // 猫でした。犬だった。 — でした=ですます (です before た), だった=である (だ before た) → tie → flag
+        // である (だっ at 18..21).
+        let diags = diagnose_with_morphology(
+            &NoMixDearuDesumasu::new(),
+            "猫でした。犬だった。",
+            |p, b| {
+                noun(b, p, 0, 3); // 猫
+                aux(b, p, 3, 9, "です"); // でし
+                aux(b, p, 9, 12, "た"); // た   (。 12..15)
+                noun(b, p, 15, 18); // 犬
+                aux(b, p, 18, 21, "だ"); // だっ
+                aux(b, p, 21, 24, "た"); // た   (。 24..27)
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (18, 21));
+    }
+
+    #[test]
+    fn plain_verb_is_dearu_and_masu_is_desumasu() {
+        // 歩く。走ります。 — 歩く (plain 動詞)=である, 走ります (ます)=ですます → tie → flag である (歩く).
+        let diags = diagnose_with_morphology(
+            &NoMixDearuDesumasu::new(),
+            "歩く。走ります。",
+            |p, b| {
+                verb(b, p, 0, 6, "歩く"); // 歩く  (。 6..9)
+                verb(b, p, 9, 15, "走る"); // 走り
+                aux(b, p, 15, 21, "ます"); // ます  (。 21..24)
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (0, 6));
+    }
+
+    #[test]
+    fn a_trailing_question_particle_is_skipped() {
+        // 行きますか。帰る。 — 〜ますか=ですます (か skipped, ます found), 帰る=である → tie → flag である.
+        let diags = diagnose_with_morphology(
+            &NoMixDearuDesumasu::new(),
+            "行きますか。帰る。",
+            |p, b| {
+                verb(b, p, 0, 6, "行く"); // 行き
+                aux(b, p, 6, 12, "ます"); // ます
+                particle(b, p, 12, 15); // か   (。 15..18)
+                verb(b, p, 18, 24, "帰る"); // 帰る  (。 24..27)
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (18, 24));
+    }
+
+    #[test]
+    fn prefer_dearu_flags_every_desumasu_sentence() {
+        // prefer:"dearu" flags ですます even when it is the majority.
+        let rule = NoMixDearuDesumasu::from_options(&serde_json::json!({ "prefer": "dearu" }));
+        let diags = diagnose_with_morphology(&rule, "猫です。犬だ。", |p, b| {
+            noun(b, p, 0, 3);
+            aux(b, p, 3, 9, "です"); // です (。 9..12)
+            noun(b, p, 12, 15);
+            aux(b, p, 15, 18, "だ"); // だ
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (3, 9)); // the です sentence
+    }
+
+    #[test]
+    fn a_tie_flags_the_dearu_sentences() {
+        // One of each, no prefer → tie → である is flagged (ですます treated as the default majority).
+        let diags = diagnose_with_morphology(
+            &NoMixDearuDesumasu::new(),
+            "猫です。犬だ。",
+            |p, b| {
+                noun(b, p, 0, 3);
+                aux(b, p, 3, 9, "です"); // です (。 9..12)
+                noun(b, p, 12, 15);
+                aux(b, p, 15, 18, "だ"); // だ
+            },
+        );
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (15, 18)); // the だ sentence
+    }
+
+    #[test]
+    fn no_op_without_a_morphology_table() {
+        // In production with no JA provider injected, the engine passes no table → rule skipped.
+        assert!(diagnose(&NoMixDearuDesumasu::new(), "猫です。犬だ。").is_empty());
+    }
+
+    #[test]
+    fn an_unrecognized_predicate_pos_yields_no_classification() {
+        // 猫です。あ。 — the second sentence's only token is a 感動詞 (not a predicate POS we match) →
+        // unclassified, leaving a single style → clean. A false negative, never a false positive.
+        let diags =
+            diagnose_with_morphology(&NoMixDearuDesumasu::new(), "猫です。あ。", |p, b| {
+                noun(b, p, 0, 3);
+                aux(b, p, 3, 9, "です"); // です (。 9..12)
+                tok(b, p, 12, 15, "感動詞", None); // あ (。 15..18)
+            });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn build_rule_routes_the_prefer_option() {
+        use crate::build_rule;
+        // prefer:"desumasu" reaches the constructed rule and flags the である sentence.
+        let rule = build_rule(ID, &serde_json::json!({ "prefer": "desumasu" }), None).unwrap();
+        let diags = diagnose_with_morphology(rule.as_ref(), "猫です。犬だ。", |p, b| {
+            noun(b, p, 0, 3);
+            aux(b, p, 3, 9, "です");
+            noun(b, p, 12, 15);
+            aux(b, p, 15, 18, "だ"); // だ
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (15, 18)); // the だ sentence
+    }
+}

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -35,17 +35,22 @@
   collision). Built-in presets:
   - `ja-basic` — `no-hankaku-kana`, `no-mixed-zenkaku-hankaku-alphabet`, `no-nfd`,
     `no-zero-width-spaces`, `ja-no-mixed-period`.
-  - `ja-technical-writing` — the above plus `no-exclamation-question-mark`, and thresholds:
-    `sentence-length` `max: 100`, `max-ten` `max: 3`, `max-kanji-continuous-len` `max: 6`.
+  - `ja-technical-writing` — the above plus `no-exclamation-question-mark`, the
+    morphology-backed `no-doubled-joshi`, and thresholds: `sentence-length` `max: 100`,
+    `max-ten` `max: 3`, `max-kanji-continuous-len` `max: 6`.
 
-  Because activation is opt-out, a preset does **not** restrict *which* rules run — every
-  built-in rule is already on, so a preset effectively supplies **options and severities** for
-  the rules it names. To run a narrower set, disable the unwanted rules explicitly. Morphology
-  rules (e.g. `no-doubled-joshi`) are intentionally absent from the presets: they are no-ops
-  until a [`morphology`](#morphology--dictionary-for-morphology-dependent-rules) dictionary is
-  configured, so a preset never silently requires one.
+  The `ja-*` presets imply `language: ja` (your own `language` overrides it), so their Japanese
+  rules run out of the box. Because activation is opt-out, a preset does **not** restrict *which*
+  rules run — every built-in rule is already on, so a preset effectively supplies **options and
+  severities** for the rules it names. To run a narrower set, disable the unwanted rules
+  explicitly. `ja-technical-writing` enables the morphology-backed `no-doubled-joshi`, but it is a
+  no-op until a [`morphology`](#morphology--dictionary-for-morphology-dependent-rules) dictionary
+  is configured (the engine skips it), so a preset never *silently requires* one.
 - **Language:** `language` (e.g. `ja`) and `message-language` (the diagnostic locale,
   independent of the document language). Config keys are kebab-case (`message-language`).
+  `language` also **scopes** which rules run: a JA-only rule (e.g. `sentence-length`, `max-ten`,
+  `no-doubled-joshi`) runs only on Japanese documents, and when `language` is unset only the
+  language-neutral rules run — so set `language: ja` (or extend a `ja-*` preset) to lint Japanese.
 - **JSON Schema:** a Draft 2020-12 schema is published as `tzlint_core::CONFIG_SCHEMA`
   (`$id` `https://tsuzulint.dev/schema/config/v1.json`) for editor completion/validation and
   CLI emission. It describes the **JSON-level** contract and is intentionally stricter than the

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -35,17 +35,20 @@
   collision). Built-in presets:
   - `ja-basic` — `no-hankaku-kana`, `no-mixed-zenkaku-hankaku-alphabet`, `no-nfd`,
     `no-zero-width-spaces`, `ja-no-mixed-period`.
-  - `ja-technical-writing` — the above plus `no-exclamation-question-mark`, the
-    morphology-backed `no-doubled-joshi`, and thresholds: `sentence-length` `max: 100`,
-    `max-ten` `max: 3`, `max-kanji-continuous-len` `max: 6`.
+  - `ja-technical-writing` — the above plus `no-exclamation-question-mark`, thresholds
+    (`sentence-length` `max: 100`, `max-ten` `max: 3`, `max-kanji-continuous-len` `max: 6`), and the
+    morphology-backed style rules `no-doubled-joshi`, `no-mix-dearu-desumasu`,
+    `no-doubled-conjunctive-particle-ga`, `ja-no-redundant-expression`, `no-dropping-the-ra`, and
+    `no-double-negative-ja` (mirroring `textlint-rule-preset-ja-technical-writing`). `ja-prh` is not
+    bundled — its term list is project-specific, so configure it explicitly.
 
   The `ja-*` presets imply `language: ja` (your own `language` overrides it), so their Japanese
   rules run out of the box. Because activation is opt-out, a preset does **not** restrict *which*
   rules run — every built-in rule is already on, so a preset effectively supplies **options and
   severities** for the rules it names. To run a narrower set, disable the unwanted rules
-  explicitly. `ja-technical-writing` enables the morphology-backed `no-doubled-joshi`, but it is a
-  no-op until a [`morphology`](#morphology--dictionary-for-morphology-dependent-rules) dictionary
-  is configured (the engine skips it), so a preset never *silently requires* one.
+  explicitly. The morphology-backed style rules `ja-technical-writing` enables are no-ops until a
+  [`morphology`](#morphology--dictionary-for-morphology-dependent-rules) dictionary is configured
+  (the engine skips them), so a preset never *silently requires* one.
 - **Language:** `language` (e.g. `ja`) and `message-language` (the diagnostic locale,
   independent of the document language). Config keys are kebab-case (`message-language`).
   `language` also **scopes** which rules run: a JA-only rule (e.g. `sentence-length`, `max-ten`,


### PR DESCRIPTION
Second of the **0.1.0 4-PR stack** — based on `feat/0.1.0-foundations` (needs the R5 applicability API). The headline Japanese morphology *style* rules, mirroring `textlint-rule-preset-ja-technical-writing`.

### New rules (morphology-backed, false-negative-safe — no-ops until a dictionary is provisioned)
- **`no-mix-dearu-desumasu`** — flags mixing である/ですます styles in a document (auto-detect majority → flag minority, or enforce a configured `prefer`).
- **`no-doubled-conjunctive-particle-ga`** — 逆接の接続助詞「が」 used more than once in a sentence (the subject-marking 格助詞「が」 is not counted).
- **`ja-no-redundant-expression`** — the redundant「〜することができる」family.
- **`no-dropping-the-ra`** — ら抜き言葉 (一段/カ変 + 「れる」; 五段 passives like 書かれる are not flagged).
- **`no-double-negative-ja`** — rhetorical double negatives (ないことはない / なくはない; 〜なければならない is not flagged).

### Preset wiring
- **R4** enables the morphology-backed `no-doubled-joshi` in `ja-technical-writing`.
- **R12** bundles all five style rules into `ja-technical-writing` alongside it (textlint parity). They stay no-ops until a `morphology` dictionary is configured.

`just check` green (558 tests at this branch's tip).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 日本語モルフォロジー依存のスタイルルール5件を追加（文体混在・接続助詞「が」重複・冗長表現・ら抜き・二重否定検出）。ja-technical-writingプリセットで有効化（形態素辞書未設定時は無害でスキップ）。

* **Documentation**
  * 設定リファレンスとCHANGELOGを更新し、プリセットの内容と形態素辞書の扱いを明記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->