### PR TITLE
feat(0.1.0): ja-prh terminology rule + .prh.yml dictionary import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,12 @@ accumulate as the release is built.
 - **Terminology / 表記ゆれ (`ja-prh`).** The `prh` counterpart: each configured term pairs
   an `expected` spelling with the `patterns` to rewrite to it (e.g. `Javascript` →
   `JavaScript`, `サーバ` → `サーバー`), reported with an autofix. Idempotent (a match already
-  in the expected form is left alone). Terms are supplied inline via `options.terms`;
-  loading external `prh` YAML dictionaries is a planned follow-up.
+  in the expected form is left alone). Terms are supplied inline via `options.terms` and/or by
+  importing external [`prh`](https://github.com/prh/prh) `.prh.yml` dictionaries named in
+  `options.dictionaries` (with `imports` followed). Patterns may be literal or regex
+  (`/source/flags`), and `expected` is a `$1`-style replacement template for a regex match; regex
+  matching uses the ReDoS-free `regex-lite` engine (lookaround/backreferences and Unicode-property
+  classes are unsupported and such patterns are skipped).
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ accumulate as the release is built.
   All five ship enabled in the `ja-technical-writing` preset (alongside `no-doubled-joshi`),
   mirroring `textlint-rule-preset-ja-technical-writing`; they stay no-ops until a morphology
   dictionary is configured.
+- **Terminology / 表記ゆれ (`ja-prh`).** The `prh` counterpart: each configured term pairs
+  an `expected` spelling with the `patterns` to rewrite to it (e.g. `Javascript` →
+  `JavaScript`, `サーバ` → `サーバー`), reported with an autofix. Idempotent (a match already
+  in the expected form is left alone). Terms are supplied inline via `options.terms`;
+  loading external `prh` YAML dictionaries is a planned follow-up.
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1699,6 +1699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,6 +2398,7 @@ dependencies = [
 name = "tzlint_rules"
 version = "0.0.0"
 dependencies = [
+ "regex-lite",
  "serde_json",
  "tzlint_ast",
  "tzlint_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,17 @@ ruzstd = { version = "0.8.3", default-features = false, features = ["std", "hash
 # The guard itself does no I/O, so this never pulls networking into the wasm-clean core.
 url = "2"
 
+# Regular-expression engine for `ja-prh` patterns imported from `prh` `.prh.yml` dictionaries
+# (the `/source/flags` form). `regex-lite` (same author as `regex`) is chosen over the full `regex`
+# deliberately: it has **zero runtime dependencies** and a much smaller binary, so it barely grows
+# the `wasm32` artifact (the rule crate ships into the embeddable build — the embeddability moat).
+# It keeps the guarantees that matter here: worst-case `O(m*n)` matching (no catastrophic
+# backtracking → ReDoS is impossible) and a non-panicking API (`Regex::new` returns a `Result`;
+# matching never panics — required by the deny-unwrap/panic library lints). The trade-off is
+# ASCII-only Perl classes (`\d`/`\w`) and no `\p{...}`; Japanese is matched as literals in prh
+# dictionaries, so this rarely bites. Pure Rust, MIT/Apache-2.0.
+regex-lite = "0.1"
+
 # Argument parsing for the native `tzlint` CLI (the `derive` API: `Parser`/`Subcommand`/
 # `ValueEnum`). CLI-only — it never reaches the AST or the `wasm32` core (the wasm CI job
 # builds `tzlint_core` lib-only), so a native-only dependency here is fine.

--- a/crates/tzlint_cli/src/app.rs
+++ b/crates/tzlint_cli/src/app.rs
@@ -31,6 +31,7 @@ use tzlint_pdk::Diagnostic;
 use crate::cli::{Cli, Command, OutputFormat, RuleListFormat, RulesCommand};
 use crate::expand;
 use crate::output::{self, FileReport};
+use crate::prh_dict;
 use crate::rules::{
     any_effective_rules, processor_config_for, region_rules_for, rule_info, rule_infos,
     unknown_rule_ids,
@@ -191,7 +192,8 @@ fn lint(
     let stdin: &mut dyn Read = &mut *streams.stdin;
     let stdout: &mut dyn Write = &mut *streams.stdout;
     let stderr: &mut dyn Write = &mut *streams.stderr;
-    let config = load_config(cli, host, cwd, stderr)?;
+    let (mut config, base_dir) = load_config(cli, host, cwd, stderr)?;
+    prh_dict::apply_prh_dictionaries(&mut config, host, &base_dir, stderr);
     note_if_no_rules(&config, stderr);
     note_unknown_rules(&config, stderr);
     // One processor registry for the whole run, shared by every file and the stdin source.
@@ -365,7 +367,8 @@ fn fix(
     let stdin: &mut dyn Read = &mut *streams.stdin;
     let stdout: &mut dyn Write = &mut *streams.stdout;
     let stderr: &mut dyn Write = &mut *streams.stderr;
-    let config = load_config(cli, host, cwd, stderr)?;
+    let (mut config, base_dir) = load_config(cli, host, cwd, stderr)?;
+    prh_dict::apply_prh_dictionaries(&mut config, host, &base_dir, stderr);
     note_if_no_rules(&config, stderr);
     note_unknown_rules(&config, stderr);
     let registry = Registry::with_builtins();
@@ -562,7 +565,9 @@ fn rules_cmd(
 ) -> Result<ExitStatus, String> {
     let stdout: &mut dyn Write = &mut *streams.stdout;
     let stderr: &mut dyn Write = &mut *streams.stderr;
-    let config = load_config(cli, host, cwd, stderr)?;
+    // `rules` reports the configured rule set; ja-prh dictionaries affect lint/fix output, not the
+    // listing, so they are not loaded here (avoids I/O for a query command).
+    let (config, _base_dir) = load_config(cli, host, cwd, stderr)?;
     note_unknown_rules(&config, stderr);
     match command {
         RulesCommand::List { format } => {
@@ -594,12 +599,15 @@ fn rules_cmd(
 
 /// Resolve the configuration: read `--config` if given (format inferred from its name, JSONC
 /// otherwise), else walk up from the working directory via [`discover`], else the default.
+/// Load the resolved [`Config`] and the **base directory** for resolving config-relative resources
+/// (currently `ja-prh`'s `dictionaries` paths): the directory of the config file when one is used,
+/// otherwise `cwd`.
 fn load_config(
     cli: &Cli,
     host: &dyn Host,
     cwd: &Path,
     stderr: &mut dyn Write,
-) -> Result<Config, String> {
+) -> Result<(Config, PathBuf), String> {
     if let Some(path) = &cli.config {
         // Infer the format from the name and fail loudly on an unrecognized one, rather than
         // silently assuming JSONC and surfacing a confusing parse error downstream.
@@ -617,7 +625,7 @@ fn load_config(
         if cli.verbose {
             let _ = writeln!(stderr, "note: using config {}", path.display());
         }
-        return Ok(config);
+        return Ok((config, config_base_dir(path, cwd)));
     }
 
     match discover(host, cwd) {
@@ -628,15 +636,25 @@ fn load_config(
                     let _ = writeln!(stderr, "note: {warning}");
                 }
             }
-            Ok(found.config)
+            let base = config_base_dir(&found.path, cwd);
+            Ok((found.config, base))
         }
         Ok(None) => {
             if cli.verbose {
                 let _ = writeln!(stderr, "note: no config file found; using defaults");
             }
-            Ok(Config::default())
+            Ok((Config::default(), cwd.to_path_buf()))
         }
         Err(e) => Err(e.to_string()),
+    }
+}
+
+/// The directory config-relative resource paths resolve against: the config file's parent, or
+/// `cwd` when the path has no parent (a bare `.tzlintrc` in the working directory).
+fn config_base_dir(config_path: &Path, cwd: &Path) -> PathBuf {
+    match config_path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => cwd.to_path_buf(),
     }
 }
 
@@ -1068,6 +1086,28 @@ mod tests {
         let (status, _out, err) = run_capture(&bad, &host);
         assert_eq!(status, ExitStatus::Error);
         assert!(err.contains("unknown preset"), "{err}");
+    }
+
+    #[test]
+    fn ja_prh_loads_terms_from_a_configured_prh_dictionary() {
+        // End-to-end: a `.prh.yml` named in ja-prh's `dictionaries` option is read (relative to the
+        // config dir), its terms folded in, and a 表記ゆれ in the document is flagged at lint time.
+        let host = MockHost::with("a.md", "Javascript は楽しい。\n");
+        host.put(
+            "/work/.tzlintrc.json",
+            "{ \"language\": \"ja\", \
+               \"rules\": { \"ja-prh\": { \"options\": { \"dictionaries\": [\"web.prh.yml\"] } } } }",
+        );
+        host.put(
+            "/work/web.prh.yml",
+            "rules:\n  - expected: JavaScript\n    patterns: [Javascript]\n",
+        );
+
+        let (status, out, err) = run_capture(&lint_cli("a.md", OutputFormat::Text), &host);
+        assert_eq!(status, ExitStatus::Findings, "out=<{out}> err=<{err}>");
+        assert!(out.contains("ja-prh"), "{out}");
+        // The dictionary term was loaded and matched: the message names the expected spelling.
+        assert!(out.contains("JavaScript"), "{out}");
     }
 
     #[test]

--- a/crates/tzlint_cli/src/main.rs
+++ b/crates/tzlint_cli/src/main.rs
@@ -22,6 +22,7 @@ mod cli;
 mod expand;
 mod host;
 mod output;
+mod prh_dict;
 mod rules;
 
 fn main() -> ExitCode {

--- a/crates/tzlint_cli/src/prh_dict.rs
+++ b/crates/tzlint_cli/src/prh_dict.rs
@@ -1,0 +1,384 @@
+//! Loading [`prh`](https://github.com/prh/prh) `.prh.yml` dictionaries configured on the `ja-prh`
+//! rule and folding their terms into that rule's options before linting.
+//!
+//! The rule itself stays pure (no I/O): the CLI owns the [`Host`], so it is the CLI that reads the
+//! dictionary files named in `rules.ja-prh.options.dictionaries`, parses them with
+//! [`tzlint_core::parse_prh`], follows their `imports`, and appends the resulting terms to the
+//! rule's `options.terms` (the same shape an inline term takes). A dictionary that cannot be read
+//! or parsed is reported on stderr and skipped — best-effort prh migration, never a hard failure.
+
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+
+use serde_json::{Map, Value, json};
+use tzlint_core::io::MAX_CONFIG;
+use tzlint_core::{Config, Host, PrhPattern, PrhRule, RuleSetting, parse_prh};
+use tzlint_pdk::RuleId;
+
+/// The rule whose `dictionaries` option this module resolves.
+const JA_PRH_ID: &str = "ja-prh";
+
+/// Bound on `imports` recursion so a deep or pathological include chain cannot run away (a cycle is
+/// already stopped by the visited set; this also caps a very long linear chain).
+const MAX_IMPORT_DEPTH: usize = 16;
+
+/// Resolve the `ja-prh` rule's `dictionaries` option in place.
+///
+/// Each entry is a path to a `.prh.yml` file (relative paths resolved against `base_dir`, the
+/// directory of the config file). Every file is read through `host`, parsed, and its `imports`
+/// followed; the accumulated terms are appended to the rule's `options.terms`, after any inline
+/// terms. A no-op when `ja-prh` is disabled or names no dictionaries.
+pub fn apply_prh_dictionaries(
+    config: &mut Config,
+    host: &dyn Host,
+    base_dir: &Path,
+    stderr: &mut dyn Write,
+) {
+    let id = RuleId::from(JA_PRH_ID);
+    let (severity, mut options) = match config.rules.get(&id) {
+        Some(RuleSetting::On { severity, options }) => (*severity, options.clone()),
+        // Off, or absent (the rule then runs with default — empty — options, so no dictionaries).
+        _ => return,
+    };
+
+    let dict_paths: Vec<String> = options
+        .get("dictionaries")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    if dict_paths.is_empty() {
+        return;
+    }
+
+    let mut visited = BTreeSet::new();
+    let mut terms: Vec<Value> = Vec::new();
+    for rel in &dict_paths {
+        let path = normalize(&base_dir.join(rel));
+        load_into(&path, host, &mut visited, 0, stderr, &mut terms);
+    }
+    if terms.is_empty() {
+        return;
+    }
+
+    append_terms(&mut options, terms);
+    config
+        .rules
+        .insert(id, RuleSetting::On { severity, options });
+}
+
+/// Read, parse, and recursively `import` the dictionary at `path`, appending each rule's term to
+/// `terms`. Errors are noted on `stderr` and skipped. The `visited` set (keyed by the normalized
+/// path) stops cycles and avoids loading a diamond-included file twice.
+fn load_into(
+    path: &Path,
+    host: &dyn Host,
+    visited: &mut BTreeSet<PathBuf>,
+    depth: usize,
+    stderr: &mut dyn Write,
+    terms: &mut Vec<Value>,
+) {
+    if depth > MAX_IMPORT_DEPTH {
+        let _ = writeln!(
+            stderr,
+            "note: ja-prh: prh import depth limit reached at {}",
+            path.display()
+        );
+        return;
+    }
+    if !visited.insert(path.to_path_buf()) {
+        return; // already loaded (a cycle, or a diamond include)
+    }
+    let text = match host.read_to_string(path, MAX_CONFIG) {
+        Ok(text) => text,
+        Err(e) => {
+            let _ = writeln!(
+                stderr,
+                "note: ja-prh: could not read prh dictionary {}: {e}",
+                path.display()
+            );
+            return;
+        }
+    };
+    let dict = match parse_prh(&text) {
+        Ok(dict) => dict,
+        Err(e) => {
+            let _ = writeln!(stderr, "note: ja-prh: {}: {e}", path.display());
+            return;
+        }
+    };
+    // Imports are resolved relative to *this* file's directory.
+    let parent = path.parent().unwrap_or(Path::new(""));
+    for import in &dict.imports {
+        load_into(
+            &normalize(&parent.join(import)),
+            host,
+            visited,
+            depth + 1,
+            stderr,
+            terms,
+        );
+    }
+    for rule in &dict.rules {
+        terms.push(rule_to_term(rule));
+    }
+}
+
+/// Convert a parsed [`PrhRule`] into the `ja-prh` term JSON: `{ expected, patterns?, regexPatterns? }`.
+fn rule_to_term(rule: &PrhRule) -> Value {
+    let mut literals: Vec<Value> = Vec::new();
+    let mut regexes: Vec<Value> = Vec::new();
+    for pattern in &rule.patterns {
+        match pattern {
+            PrhPattern::Literal(s) => literals.push(Value::String(s.clone())),
+            PrhPattern::Regex {
+                source,
+                ignore_case,
+                multiline,
+            } => regexes.push(json!({
+                "source": source,
+                "ignoreCase": ignore_case,
+                "multiline": multiline,
+            })),
+        }
+    }
+    let mut term = Map::new();
+    term.insert("expected".to_string(), Value::String(rule.expected.clone()));
+    if !literals.is_empty() {
+        term.insert("patterns".to_string(), Value::Array(literals));
+    }
+    if !regexes.is_empty() {
+        term.insert("regexPatterns".to_string(), Value::Array(regexes));
+    }
+    Value::Object(term)
+}
+
+/// Append `loaded` terms to `options.terms` (creating the array if needed), keeping any inline
+/// terms first. `options` is the rule's options object (it is, since we read `dictionaries` from
+/// it); a non-object is left untouched.
+fn append_terms(options: &mut Value, loaded: Vec<Value>) {
+    let Value::Object(obj) = options else { return };
+    match obj.get_mut("terms") {
+        Some(Value::Array(existing)) => existing.extend(loaded),
+        _ => {
+            obj.insert("terms".to_string(), Value::Array(loaded));
+        }
+    }
+}
+
+/// Lexically normalize a path — collapse `.` and resolve `..` components — so paths reached by
+/// different spellings (`a/./b`, `a/../a/b`) compare equal in the `visited` cycle guard and read
+/// the same file.
+fn normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use tzlint_core::{DirEntry, IoError};
+
+    /// A minimal in-memory [`Host`]: only registered paths exist; only reads are exercised here.
+    struct MapHost {
+        files: BTreeMap<PathBuf, String>,
+    }
+
+    impl MapHost {
+        fn new(files: &[(&str, &str)]) -> Self {
+            MapHost {
+                files: files
+                    .iter()
+                    .map(|(p, c)| (PathBuf::from(p), c.to_string()))
+                    .collect(),
+            }
+        }
+    }
+
+    impl Host for MapHost {
+        fn read_to_string(&self, path: &Path, _limit: usize) -> Result<String, IoError> {
+            self.files.get(path).cloned().ok_or(IoError::NotFound)
+        }
+        fn write_atomic(&self, _path: &Path, _contents: &[u8]) -> Result<(), IoError> {
+            Err(IoError::Other("read-only test host".to_string()))
+        }
+        fn exists(&self, path: &Path) -> bool {
+            self.files.contains_key(path)
+        }
+        fn list_dir(&self, _dir: &Path) -> Result<Vec<DirEntry>, IoError> {
+            Ok(Vec::new())
+        }
+    }
+
+    /// A config with `ja-prh` enabled and the given options.
+    fn config_with_options(options: Value) -> Config {
+        let mut rules = BTreeMap::new();
+        rules.insert(
+            RuleId::from(JA_PRH_ID),
+            RuleSetting::On {
+                severity: None,
+                options,
+            },
+        );
+        Config {
+            rules,
+            ..Default::default()
+        }
+    }
+
+    /// The `terms` array folded into the ja-prh options after resolution.
+    fn resolved_terms(config: &Config) -> Vec<Value> {
+        let RuleSetting::On { options, .. } = config.rules.get(&RuleId::from(JA_PRH_ID)).unwrap()
+        else {
+            panic!("ja-prh missing");
+        };
+        options
+            .get("terms")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn run(config: &mut Config, host: &dyn Host) -> String {
+        let mut stderr = Vec::new();
+        apply_prh_dictionaries(config, host, Path::new("/work"), &mut stderr);
+        String::from_utf8(stderr).unwrap()
+    }
+
+    #[test]
+    fn loads_literal_and_regex_terms_from_a_dictionary() {
+        let host = MapHost::new(&[(
+            "/work/web.prh.yml",
+            "rules:\n  - expected: JavaScript\n    patterns: [Javascript]\n  \
+             - expected: （$1）\n    pattern: /\\(([^)]+)\\)/\n",
+        )]);
+        let mut config = config_with_options(json!({ "dictionaries": ["web.prh.yml"] }));
+        assert!(run(&mut config, &host).is_empty());
+        let terms = resolved_terms(&config);
+        assert_eq!(terms.len(), 2, "{terms:?}");
+        assert_eq!(terms[0]["expected"], json!("JavaScript"));
+        assert_eq!(terms[0]["patterns"], json!(["Javascript"]));
+        assert_eq!(terms[1]["expected"], json!("（$1）"));
+        assert_eq!(
+            terms[1]["regexPatterns"][0]["source"],
+            json!("\\(([^)]+)\\)")
+        );
+    }
+
+    #[test]
+    fn inline_terms_are_kept_before_loaded_ones() {
+        let host = MapHost::new(&[(
+            "/work/d.prh.yml",
+            "rules:\n  - expected: B\n    pattern: b\n",
+        )]);
+        let mut config = config_with_options(json!({
+            "terms": [{ "expected": "A", "patterns": ["a"] }],
+            "dictionaries": ["d.prh.yml"],
+        }));
+        run(&mut config, &host);
+        let terms = resolved_terms(&config);
+        assert_eq!(terms.len(), 2);
+        assert_eq!(terms[0]["expected"], json!("A")); // inline first
+        assert_eq!(terms[1]["expected"], json!("B")); // loaded after
+    }
+
+    #[test]
+    fn follows_imports_relative_to_the_importing_file() {
+        let host = MapHost::new(&[
+            (
+                "/work/main.prh.yml",
+                "imports:\n  - ./sub/base.prh.yml\nrules:\n  - expected: Main\n    pattern: main\n",
+            ),
+            (
+                "/work/sub/base.prh.yml",
+                "rules:\n  - expected: Base\n    pattern: base\n",
+            ),
+        ]);
+        let mut config = config_with_options(json!({ "dictionaries": ["main.prh.yml"] }));
+        run(&mut config, &host);
+        let expecteds: Vec<String> = resolved_terms(&config)
+            .iter()
+            .filter_map(|t| t["expected"].as_str().map(str::to_string))
+            .collect();
+        // Imported terms load before the importing file's own.
+        assert_eq!(expecteds, vec!["Base".to_string(), "Main".to_string()]);
+    }
+
+    #[test]
+    fn a_cyclic_import_terminates() {
+        let host = MapHost::new(&[
+            (
+                "/work/a.prh.yml",
+                "imports:\n  - ./b.prh.yml\nrules:\n  - expected: A\n    pattern: a\n",
+            ),
+            (
+                "/work/b.prh.yml",
+                "imports:\n  - ./a.prh.yml\nrules:\n  - expected: B\n    pattern: b\n",
+            ),
+        ]);
+        let mut config = config_with_options(json!({ "dictionaries": ["a.prh.yml"] }));
+        run(&mut config, &host); // must not loop forever
+        // Each file loads exactly once.
+        assert_eq!(resolved_terms(&config).len(), 2);
+    }
+
+    #[test]
+    fn a_missing_dictionary_is_noted_and_skipped() {
+        let host = MapHost::new(&[]);
+        let mut config = config_with_options(json!({ "dictionaries": ["nope.prh.yml"] }));
+        let notes = run(&mut config, &host);
+        assert!(notes.contains("could not read"), "{notes}");
+        assert!(resolved_terms(&config).is_empty());
+    }
+
+    #[test]
+    fn no_dictionaries_option_is_a_no_op() {
+        let host = MapHost::new(&[]);
+        let mut config =
+            config_with_options(json!({ "terms": [{ "expected": "A", "patterns": ["a"] }] }));
+        run(&mut config, &host);
+        // Untouched: just the inline term.
+        assert_eq!(resolved_terms(&config).len(), 1);
+    }
+
+    #[test]
+    fn disabled_ja_prh_is_left_alone() {
+        let host = MapHost::new(&[(
+            "/work/d.prh.yml",
+            "rules:\n  - expected: B\n    pattern: b\n",
+        )]);
+        let mut config = Config::default();
+        config
+            .rules
+            .insert(RuleId::from(JA_PRH_ID), RuleSetting::Off);
+        run(&mut config, &host);
+        assert!(matches!(
+            config.rules.get(&RuleId::from(JA_PRH_ID)),
+            Some(RuleSetting::Off)
+        ));
+    }
+
+    #[test]
+    fn normalize_collapses_dot_and_parent_components() {
+        assert_eq!(
+            normalize(Path::new("/work/./sub/../a.yml")),
+            PathBuf::from("/work/a.yml")
+        );
+    }
+}

--- a/crates/tzlint_cli/src/prh_dict.rs
+++ b/crates/tzlint_cli/src/prh_dict.rs
@@ -175,18 +175,29 @@ fn append_terms(options: &mut Value, loaded: Vec<Value>) {
 /// Lexically normalize a path — collapse `.` and resolve `..` components — so paths reached by
 /// different spellings (`a/./b`, `a/../a/b`) compare equal in the `visited` cycle guard and read
 /// the same file.
+///
+/// A `..` cancels a preceding normal segment, but a leading (or stacked) `..` on a *relative* path
+/// is kept: it cannot be resolved without knowing the cwd, so `../shared/x.yml` must stay
+/// `../shared/x.yml` — otherwise a dictionary or `imports` entry reached from a config given as
+/// `--config ../cfg/.tzlintrc.json` would resolve to the wrong file (or fail to read). A `..`
+/// directly under a root/prefix is dropped, since the root has no parent.
 fn normalize(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
+    let mut out: Vec<Component> = Vec::new();
     for component in path.components() {
         match component {
             Component::CurDir => {}
-            Component::ParentDir => {
-                out.pop();
-            }
+            // `.copied()` releases the borrow on `out` so the `out.pop()` arm can mutate it.
+            Component::ParentDir => match out.last().copied() {
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                }
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => out.push(Component::ParentDir),
+            },
             other => out.push(other),
         }
     }
-    out
+    out.into_iter().collect()
 }
 
 #[cfg(test)]
@@ -348,6 +359,34 @@ mod tests {
     }
 
     #[test]
+    fn a_malformed_dictionary_is_noted_and_skipped() {
+        // A dictionary that does not parse is reported with its path and skipped, never fatal.
+        let host = MapHost::new(&[("/work/broken.prh.yml", "rules: [unterminated\n")]);
+        let mut config = config_with_options(json!({ "dictionaries": ["broken.prh.yml"] }));
+        let notes = run(&mut config, &host);
+        assert!(notes.contains("broken.prh.yml"), "{notes}");
+        assert!(resolved_terms(&config).is_empty());
+    }
+
+    #[test]
+    fn a_relative_config_dir_keeps_parent_segments_when_resolving() {
+        // Regression: with `--config ../cfg/.tzlintrc.json` the dictionary base dir is relative and
+        // begins with `..`. The dictionary must resolve under that `../cfg`, not a `..`-stripped
+        // `cfg` — `normalize` keeps a leading `..` it cannot cancel.
+        let host = MapHost::new(&[(
+            "../cfg/web.prh.yml",
+            "rules:\n  - expected: JavaScript\n    pattern: Javascript\n",
+        )]);
+        let mut config = config_with_options(json!({ "dictionaries": ["web.prh.yml"] }));
+        let mut stderr = Vec::new();
+        apply_prh_dictionaries(&mut config, &host, Path::new("../cfg"), &mut stderr);
+        assert!(String::from_utf8(stderr).unwrap().is_empty());
+        let terms = resolved_terms(&config);
+        assert_eq!(terms.len(), 1, "{terms:?}");
+        assert_eq!(terms[0]["expected"], json!("JavaScript"));
+    }
+
+    #[test]
     fn no_dictionaries_option_is_a_no_op() {
         let host = MapHost::new(&[]);
         let mut config =
@@ -380,5 +419,31 @@ mod tests {
             normalize(Path::new("/work/./sub/../a.yml")),
             PathBuf::from("/work/a.yml")
         );
+    }
+
+    #[test]
+    fn normalize_keeps_leading_parent_components_on_relative_paths() {
+        // A leading `..` has nothing to cancel and cannot be resolved lexically, so it is kept —
+        // a relative `--config ../cfg/.tzlintrc.json` must still reach `../shared/web.prh.yml`.
+        assert_eq!(
+            normalize(Path::new("../shared/web.prh.yml")),
+            PathBuf::from("../shared/web.prh.yml")
+        );
+        // Stacked leading `..` are all kept (the naive `PathBuf::pop()` form drops all but one).
+        assert_eq!(
+            normalize(Path::new("../../a/b/../c.yml")),
+            PathBuf::from("../../a/c.yml")
+        );
+        // An interior `..` still cancels the segment before it before the leading ones remain.
+        assert_eq!(
+            normalize(Path::new("../a/../b.yml")),
+            PathBuf::from("../b.yml")
+        );
+    }
+
+    #[test]
+    fn normalize_drops_parent_components_at_the_root() {
+        // The root has no parent, so `..` directly under it is a no-op rather than an escape.
+        assert_eq!(normalize(Path::new("/../a.yml")), PathBuf::from("/a.yml"));
     }
 }

--- a/crates/tzlint_core/src/config/format.rs
+++ b/crates/tzlint_core/src/config/format.rs
@@ -158,7 +158,7 @@ fn strip_jsonc(text: &str) -> String {
 /// `#` comment is ignored, and a `&`/`*` is only flagged when it begins a token (preceded by
 /// start-of-input, whitespace, or a flow indicator) and is followed by a name character — so
 /// arithmetic-like plain scalars such as `a & b` or `2 * 3` are not flagged.
-fn reject_yaml_anchors(text: &str) -> Result<(), String> {
+pub(crate) fn reject_yaml_anchors(text: &str) -> Result<(), String> {
     #[derive(PartialEq)]
     enum State {
         Plain,

--- a/crates/tzlint_core/src/config/mod.rs
+++ b/crates/tzlint_core/src/config/mod.rs
@@ -32,6 +32,7 @@ use tzlint_pdk::RuleId;
 
 pub use discover::{DiscoveredConfig, ShadowedCandidate, discover};
 pub use format::ConfigFormat;
+pub(crate) use format::reject_yaml_anchors;
 pub use format_config::{ColumnConfig, FormatConfig};
 pub use model::RuleSetting;
 pub use preset::{Preset, resolve};

--- a/crates/tzlint_core/src/lib.rs
+++ b/crates/tzlint_core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod morphology;
 pub mod net;
 pub mod parse;
 pub mod position;
+pub mod prh;
 pub mod processor;
 
 pub use cache::{
@@ -49,6 +50,7 @@ pub use morphology::{DictId, MorphologyRegistry};
 pub use net::{UrlPolicyError, validate_dictionary_url};
 pub use parse::{ParseError, parse};
 pub use position::LineIndex;
+pub use prh::{PrhDictionary, PrhError, PrhPattern, PrhRule, parse_prh};
 pub use processor::{
     ColumnSelector, ColumnTarget, DelimitedConfig, DelimitedProcessor, ParseMode, Parsed,
     Processor, ProcessorConfig, Region, RegionRules, RegionTag, Registry, lint_document,

--- a/crates/tzlint_core/src/prh.rs
+++ b/crates/tzlint_core/src/prh.rs
@@ -1,0 +1,352 @@
+//! Parsing of [`prh`](https://github.com/prh/prh) dictionary files (`.prh.yml`) into a neutral
+//! term model the `ja-prh` rule consumes.
+//!
+//! This module is the **pure parser** half of prh-dictionary support: it turns the YAML text of a
+//! `.prh.yml` into a [`PrhDictionary`] (the dictionary's `version`, its `imports` list, and its
+//! `rules`), classifying each `pattern` / `patterns` entry as either a [`PrhPattern::Literal`]
+//! substring or a [`PrhPattern::Regex`] (a `/source/flags` JS-style regular expression). It does
+//! **no** I/O — reading the file, resolving `imports`, and feeding the terms to the rule are the
+//! caller's job (the CLI, which owns the [`Host`](crate::io::Host)).
+//!
+//! ## prh format coverage (0.1.0)
+//!
+//! Supported: the top-level `version` / `imports` / `rules`, and per-rule `expected` (which doubles
+//! as the replacement template — it may carry `$1`-style capture references for a regex pattern),
+//! `pattern` (a single string), and `patterns` (a list). A pattern written as `/source/flags` is a
+//! regex (only the JS flags `i` and `m` are honored; the rest are accepted and ignored); any other
+//! string is a literal. The prh fields `specs`, `options` (e.g. `wordBoundary`), and
+//! `regexpMustEmpty` are parsed leniently and **ignored** for now. A rule with no usable pattern is
+//! dropped (it could never match).
+
+use std::fmt;
+
+use serde::Deserialize;
+
+/// A parsed prh dictionary: its schema `version`, the relative paths it `imports`, and its `rules`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PrhDictionary {
+    /// The declared schema `version` (prh uses `1`), or `None` when absent.
+    pub version: Option<u64>,
+    /// Relative paths to other prh dictionaries to include (resolved by the caller).
+    pub imports: Vec<String>,
+    /// The terminology rules, in document order, with empty-pattern rules dropped.
+    pub rules: Vec<PrhRule>,
+}
+
+/// One prh rule: the `expected` spelling (also the replacement template) and the patterns that
+/// should be rewritten to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrhRule {
+    /// The preferred spelling. For a [`PrhPattern::Regex`] match this is a replacement *template*
+    /// and may contain `$1`-style references to the pattern's capture groups.
+    pub expected: String,
+    /// The disallowed spellings to rewrite, each a literal or a regular expression.
+    pub patterns: Vec<PrhPattern>,
+}
+
+/// A pattern that should be rewritten to its rule's `expected` spelling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrhPattern {
+    /// A literal substring (matched verbatim, case-sensitively).
+    Literal(String),
+    /// A JS-style regular expression written `/source/flags` in the dictionary.
+    Regex {
+        /// The expression source (between the delimiting slashes).
+        source: String,
+        /// The `i` flag — case-insensitive matching.
+        ignore_case: bool,
+        /// The `m` flag — `^`/`$` match at line boundaries.
+        multiline: bool,
+    },
+}
+
+/// A failure parsing a prh dictionary.
+#[derive(Debug)]
+pub enum PrhError {
+    /// The text did not parse as YAML, or used an unsupported YAML feature (anchors/aliases).
+    Parse(String),
+}
+
+impl fmt::Display for PrhError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PrhError::Parse(message) => write!(f, "failed to parse prh dictionary: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for PrhError {}
+
+/// The JS regular-expression flags prh patterns may carry after the closing `/`. Only `i` and `m`
+/// change matching here; the others are accepted (so a real regex pattern is still recognized) but
+/// have no effect. Restricting to this set keeps a literal path like `/usr/bin` from being mistaken
+/// for a regex (`bin` is not all-flag characters).
+const JS_REGEX_FLAGS: &str = "dgimsuvy";
+
+/// Parse the text of a `.prh.yml` dictionary into a [`PrhDictionary`].
+///
+/// Lenient about content: unknown prh fields are ignored, and a rule with no usable pattern is
+/// dropped. Strict about form: malformed YAML — or YAML anchors/aliases, which enable
+/// alias-expansion denial-of-service the byte cap does not bound — is a [`PrhError::Parse`].
+pub fn parse_prh(text: &str) -> Result<PrhDictionary, PrhError> {
+    // A leading BOM is not valid YAML for every parser; strip one, matching the config loader.
+    let text = text.strip_prefix('\u{feff}').unwrap_or(text);
+    if text.trim().is_empty() {
+        return Ok(PrhDictionary::default());
+    }
+    // prh dictionaries are read through the size-bounded `Host`, but YAML anchors/aliases can still
+    // expand a small document into gigabytes; reject them up front, as the config loader does.
+    crate::config::reject_yaml_anchors(text).map_err(PrhError::Parse)?;
+
+    let raw: RawPrh = yaml_serde::from_str(text).map_err(|e| PrhError::Parse(e.to_string()))?;
+    Ok(raw.normalize())
+}
+
+/// The raw shape deserialized from a `.prh.yml`. Unknown fields (`specs`, `options`,
+/// `regexpMustEmpty`, …) are ignored rather than rejected, so a richer real-world dictionary still
+/// loads.
+#[derive(Deserialize)]
+struct RawPrh {
+    version: Option<u64>,
+    #[serde(default)]
+    imports: Vec<String>,
+    #[serde(default)]
+    rules: Vec<RawRule>,
+}
+
+/// A raw rule. `pattern` accepts either a single string or a list (some dictionaries use either);
+/// `patterns` is a list. Both are merged into the normalized rule's pattern set.
+#[derive(Deserialize)]
+struct RawRule {
+    expected: Option<String>,
+    pattern: Option<StringOrList>,
+    patterns: Option<Vec<String>>,
+}
+
+/// A YAML scalar that may be a single string or a list of strings.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StringOrList {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl StringOrList {
+    fn into_vec(self) -> Vec<String> {
+        match self {
+            StringOrList::One(s) => vec![s],
+            StringOrList::Many(v) => v,
+        }
+    }
+}
+
+impl RawPrh {
+    fn normalize(self) -> PrhDictionary {
+        let rules = self
+            .rules
+            .into_iter()
+            .filter_map(RawRule::normalize)
+            .collect();
+        PrhDictionary {
+            version: self.version,
+            imports: self.imports,
+            rules,
+        }
+    }
+}
+
+impl RawRule {
+    /// Normalize into a [`PrhRule`], or `None` when it lacks an `expected` or has no usable pattern.
+    fn normalize(self) -> Option<PrhRule> {
+        let expected = self.expected?;
+        let mut raw_patterns = self.pattern.map(StringOrList::into_vec).unwrap_or_default();
+        if let Some(more) = self.patterns {
+            raw_patterns.extend(more);
+        }
+        let patterns: Vec<PrhPattern> = raw_patterns
+            .into_iter()
+            .filter_map(|p| classify_pattern(&p))
+            .collect();
+        if patterns.is_empty() {
+            return None;
+        }
+        Some(PrhRule { expected, patterns })
+    }
+}
+
+/// Classify a pattern string as a regex (`/source/flags`) or a literal, or drop it when it is a
+/// degenerate empty pattern.
+fn classify_pattern(raw: &str) -> Option<PrhPattern> {
+    if let Some(regex) = parse_regex_literal(raw) {
+        return Some(regex);
+    }
+    if raw.is_empty() {
+        return None;
+    }
+    Some(PrhPattern::Literal(raw.to_string()))
+}
+
+/// Recognize a `/source/flags` JS-style regex literal. Returns `None` when `raw` is not a regex
+/// literal (no closing slash, an empty source, or trailing characters that are not all valid JS
+/// regex flags), so the caller falls back to a literal pattern.
+fn parse_regex_literal(raw: &str) -> Option<PrhPattern> {
+    let rest = raw.strip_prefix('/')?;
+    let close = rest.rfind('/')?;
+    let source = &rest[..close];
+    let flags = &rest[close + 1..];
+    if source.is_empty() {
+        return None;
+    }
+    if !flags.chars().all(|c| JS_REGEX_FLAGS.contains(c)) {
+        return None;
+    }
+    Some(PrhPattern::Regex {
+        source: source.to_string(),
+        ignore_case: flags.contains('i'),
+        multiline: flags.contains('m'),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lit(s: &str) -> PrhPattern {
+        PrhPattern::Literal(s.to_string())
+    }
+
+    #[test]
+    fn parses_version_imports_and_a_literal_patterns_rule() {
+        let doc = parse_prh(
+            "version: 1\n\
+             imports:\n\
+             \x20 - ./common.yml\n\
+             rules:\n\
+             \x20 - expected: ハードウェア\n\
+             \x20   patterns:\n\
+             \x20     - ハードウエア\n\
+             \x20     - ハードウエアー\n",
+        )
+        .expect("parses");
+        assert_eq!(doc.version, Some(1));
+        assert_eq!(doc.imports, vec!["./common.yml".to_string()]);
+        assert_eq!(doc.rules.len(), 1);
+        assert_eq!(doc.rules[0].expected, "ハードウェア");
+        assert_eq!(
+            doc.rules[0].patterns,
+            vec![lit("ハードウエア"), lit("ハードウエアー")]
+        );
+    }
+
+    #[test]
+    fn accepts_a_single_string_pattern() {
+        let doc = parse_prh("rules:\n  - expected: JavaScript\n    pattern: Javascript\n")
+            .expect("parses");
+        assert_eq!(doc.rules.len(), 1);
+        assert_eq!(doc.rules[0].patterns, vec![lit("Javascript")]);
+    }
+
+    #[test]
+    fn classifies_a_regex_pattern_with_capture_template() {
+        // The canonical prh form: a /regex/ pattern with an `expected` replacement template.
+        let doc = parse_prh("rules:\n  - expected: （$1）\n    pattern: /\\(([^)]+)\\)/\n")
+            .expect("parses");
+        assert_eq!(doc.rules[0].expected, "（$1）");
+        assert_eq!(
+            doc.rules[0].patterns,
+            vec![PrhPattern::Regex {
+                source: "\\(([^)]+)\\)".to_string(),
+                ignore_case: false,
+                multiline: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn honors_the_i_and_m_regex_flags() {
+        let doc = parse_prh("rules:\n  - expected: X\n    pattern: /foo/im\n").expect("parses");
+        assert_eq!(
+            doc.rules[0].patterns,
+            vec![PrhPattern::Regex {
+                source: "foo".to_string(),
+                ignore_case: true,
+                multiline: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn a_literal_with_slashes_is_not_a_regex() {
+        // `/usr/bin` has trailing `bin`, which are not all valid JS regex flags → it stays literal.
+        let doc = parse_prh("rules:\n  - expected: X\n    pattern: /usr/bin\n").expect("parses");
+        assert_eq!(doc.rules[0].patterns, vec![lit("/usr/bin")]);
+    }
+
+    #[test]
+    fn merges_pattern_and_patterns() {
+        let doc = parse_prh(
+            "rules:\n  - expected: E\n    pattern: a\n    patterns:\n      - b\n      - c\n",
+        )
+        .expect("parses");
+        assert_eq!(doc.rules[0].patterns, vec![lit("a"), lit("b"), lit("c")]);
+    }
+
+    #[test]
+    fn ignores_unknown_prh_fields() {
+        // `specs`, `options`, and `regexpMustEmpty` are parsed leniently and ignored.
+        let doc = parse_prh(
+            "rules:\n  - expected: jQuery\n    pattern: jquery\n    \
+             regexpMustEmpty: $1\n    options:\n      wordBoundary: true\n    \
+             specs:\n      - from: jquery\n        to: jQuery\n",
+        )
+        .expect("parses");
+        assert_eq!(doc.rules.len(), 1);
+        assert_eq!(doc.rules[0].expected, "jQuery");
+        assert_eq!(doc.rules[0].patterns, vec![lit("jquery")]);
+    }
+
+    #[test]
+    fn drops_a_rule_with_no_pattern() {
+        // `- expected: Cookie` alone has nothing to match (prh would derive a pattern; we do not),
+        // so it is dropped rather than kept as a no-op.
+        let doc = parse_prh("rules:\n  - expected: Cookie\n").expect("parses");
+        assert!(doc.rules.is_empty());
+    }
+
+    #[test]
+    fn empty_or_whitespace_is_an_empty_dictionary() {
+        assert_eq!(parse_prh("").expect("parses"), PrhDictionary::default());
+        assert_eq!(
+            parse_prh("  \n\t").expect("parses"),
+            PrhDictionary::default()
+        );
+    }
+
+    #[test]
+    fn version_may_be_absent() {
+        let doc = parse_prh("rules:\n  - expected: E\n    pattern: p\n").expect("parses");
+        assert_eq!(doc.version, None);
+    }
+
+    #[test]
+    fn malformed_yaml_is_an_error() {
+        assert!(matches!(
+            parse_prh("rules: [unterminated\n"),
+            Err(PrhError::Parse(_))
+        ));
+    }
+
+    #[test]
+    fn yaml_anchors_are_rejected() {
+        // Alias-expansion DoS defense, matching the config loader.
+        let bomb = "rules: &a\n  - expected: E\n    pattern: p\nmore: *a\n";
+        assert!(matches!(parse_prh(bomb), Err(PrhError::Parse(_))));
+    }
+
+    #[test]
+    fn an_empty_regex_source_falls_back_to_literal() {
+        // `//` has an empty source → not a regex; kept as the literal `//`.
+        let doc = parse_prh("rules:\n  - expected: E\n    pattern: //\n").expect("parses");
+        assert_eq!(doc.rules[0].patterns, vec![lit("//")]);
+    }
+}

--- a/crates/tzlint_rules/Cargo.toml
+++ b/crates/tzlint_rules/Cargo.toml
@@ -19,6 +19,9 @@ workspace = true
 tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
 serde_json = { workspace = true }
+# `ja-prh` regex patterns (prh `/source/flags`). A tiny, zero-dependency, ReDoS-free, non-panicking
+# engine — see the workspace dependency note for why `regex-lite` over the full `regex` here.
+regex-lite = { workspace = true }
 
 [dev-dependencies]
 # Test-only: the parser + engine, used to run a rule end-to-end over markdown (see

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -22,14 +22,14 @@ use serde_json::Value;
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use rules::{
-    ja_no_mixed_period, ja_no_redundant_expression, max_kanji_continuous_len, max_ten,
+    ja_no_mixed_period, ja_no_redundant_expression, ja_prh, max_kanji_continuous_len, max_ten,
     no_double_negative_ja, no_doubled_conjunctive_particle_ga, no_doubled_joshi,
     no_dropping_the_ra, no_exclamation_question_mark, no_hankaku_kana, no_mix_dearu_desumasu,
     no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_zero_width_spaces, sentence_length,
 };
 pub use rules::{
     ja_no_mixed_period::JaNoMixedPeriod, ja_no_redundant_expression::JaNoRedundantExpression,
-    max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
+    ja_prh::JaPrh, max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
     no_double_negative_ja::NoDoubleNegativeJa,
     no_doubled_conjunctive_particle_ga::NoDoubledConjunctiveParticleGa,
     no_doubled_joshi::NoDoubledJoshi, no_dropping_the_ra::NoDroppingTheRa,
@@ -58,6 +58,7 @@ pub const RULE_IDS: &[&str] = &[
     ja_no_redundant_expression::ID,
     no_dropping_the_ra::ID,
     no_double_negative_ja::ID,
+    ja_prh::ID,
 ];
 
 /// Construct a single built-in rule by `id`, applying config `options` (through the rule's
@@ -86,6 +87,7 @@ pub fn build_rule(id: &str, options: &Value, severity: Option<Severity>) -> Opti
         ja_no_redundant_expression::ID => Box::new(JaNoRedundantExpression::new()),
         no_dropping_the_ra::ID => Box::new(NoDroppingTheRa::new()),
         no_double_negative_ja::ID => Box::new(NoDoubleNegativeJa::new()),
+        ja_prh::ID => Box::new(JaPrh::from_options(options)),
         _ => return None,
     };
     Some(match severity {
@@ -181,6 +183,7 @@ mod tests {
             "ja-no-redundant-expression",         // JA via its morphology pin
             "no-dropping-the-ra",                 // JA via its morphology pin
             "no-double-negative-ja",              // JA via its morphology pin
+            "ja-prh",                             // JA-only (surface terminology rule)
         ];
 
         for id in RULE_IDS {

--- a/crates/tzlint_rules/src/rules/ja_prh.rs
+++ b/crates/tzlint_rules/src/rules/ja_prh.rs
@@ -1,0 +1,217 @@
+//! `ja-prh` — terminology / 表記ゆれ checking with autofix, the tzlint counterpart of `prh`.
+//!
+//! Each configured **term** pairs an `expected` spelling with the `patterns` (disallowed
+//! spellings) that should become it: e.g. `{ expected: "JavaScript", patterns: ["Javascript"] }`
+//! or `{ expected: "サーバー", patterns: ["サーバ"] }`. Every pattern occurrence in prose text is
+//! reported with a [`Fix`] that rewrites it to the expected spelling. A match that is **already**
+//! the expected form (e.g. the `サーバ` inside an existing `サーバー`) is left alone, so the rule is
+//! idempotent and never doubles a suffix.
+//!
+//! 0.1.0 takes the term list **inline** from config `options.terms`; loading external `prh` YAML
+//! dictionaries (the `.prh.yml` format) is a follow-up that will parse those files and feed the
+//! same term list. Matching is a literal, case-sensitive substring scan — patterns carry their own
+//! precision. It is a surface rule (no morphology) and JA-scoped (R5).
+
+use serde_json::Value;
+use tzlint_ast::NodeKind;
+use tzlint_ast::morphology::Lang;
+use tzlint_pdk::{Context, Fix, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "ja-prh";
+
+/// One terminology entry: the preferred spelling and the spellings that should become it.
+struct Term {
+    expected: String,
+    patterns: Vec<String>,
+}
+
+/// Flags configured 表記ゆれ / terminology patterns and rewrites them to the expected spelling.
+pub struct JaPrh {
+    meta: RuleMeta,
+    terms: Vec<Term>,
+}
+
+impl JaPrh {
+    /// Construct with no terms (a no-op until `options.terms` supplies some).
+    pub fn new() -> Self {
+        JaPrh {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]).for_language(Lang::JA),
+            terms: Vec::new(),
+        }
+    }
+
+    /// Construct from config `options`: `terms` is an array of `{ expected, pattern?, patterns? }`,
+    /// where `expected` is the preferred spelling and `pattern` (string) / `patterns` (array) list
+    /// the spellings to rewrite. Entries without a string `expected` are skipped (leniently).
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        let Some(entries) = options.get("terms").and_then(Value::as_array) else {
+            return rule;
+        };
+        for entry in entries {
+            let Some(expected) = entry.get("expected").and_then(Value::as_str) else {
+                continue;
+            };
+            let mut patterns: Vec<String> = Vec::new();
+            if let Some(single) = entry.get("pattern").and_then(Value::as_str) {
+                patterns.push(single.to_string());
+            }
+            if let Some(many) = entry.get("patterns").and_then(Value::as_array) {
+                patterns.extend(many.iter().filter_map(Value::as_str).map(str::to_string));
+            }
+            rule.terms.push(Term {
+                expected: expected.to_string(),
+                patterns,
+            });
+        }
+        rule
+    }
+}
+
+impl Default for JaPrh {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for JaPrh {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+
+        for term in &self.terms {
+            for pattern in &term.patterns {
+                // A pattern equal to (or contained inside) the expected form would loop; skip the
+                // degenerate equal case and let the "already expected" check below handle the rest.
+                if pattern.is_empty() || *pattern == term.expected {
+                    continue;
+                }
+                let mut from = 0usize;
+                while let Some(rel) = text
+                    .get(from..)
+                    .and_then(|rest| rest.find(pattern.as_str()))
+                {
+                    let off = from + rel;
+                    from = off + pattern.len();
+                    // Skip a match that is already the start of the expected spelling (e.g. the
+                    // サーバ inside サーバー) — fixing it would re-introduce the very pattern.
+                    if text
+                        .get(off..)
+                        .is_some_and(|rest| rest.starts_with(term.expected.as_str()))
+                    {
+                        continue;
+                    }
+                    let span = tzlint_ast::Span::new(
+                        base.saturating_add(off as u32),
+                        base.saturating_add(from as u32),
+                    );
+                    cx.report_with_fixes(
+                        span,
+                        message(pattern, &term.expected),
+                        [Fix::replace(span, term.expected.clone())],
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// The Japanese diagnostic for a 表記ゆれ hit.
+fn message(pattern: &str, expected: &str) -> String {
+    format!("表記ゆれ: 「{pattern}」は「{expected}」に統一してください。")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::build_rule;
+    use crate::test_support::diagnose;
+    use serde_json::json;
+
+    fn rule_with(terms: Value) -> JaPrh {
+        JaPrh::from_options(&json!({ "terms": terms }))
+    }
+
+    #[test]
+    fn rewrites_a_disallowed_spelling() {
+        let rule = rule_with(json!([{ "expected": "JavaScript", "patterns": ["Javascript"] }]));
+        let src = "I love Javascript.\n";
+        let diags = diagnose(&rule, src);
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        let d = &diags[0];
+        assert_eq!(
+            &src[d.span.start as usize..d.span.end as usize],
+            "Javascript"
+        );
+        assert_eq!(d.fixes.len(), 1);
+        assert_eq!(d.fixes[0].replacement, "JavaScript");
+        assert!(d.message.contains("JavaScript"), "{}", d.message);
+    }
+
+    #[test]
+    fn the_expected_spelling_is_not_flagged() {
+        // The text already uses the expected spelling → no diagnostic.
+        let rule = rule_with(json!([{ "expected": "JavaScript", "patterns": ["Javascript"] }]));
+        assert!(diagnose(&rule, "I love JavaScript.\n").is_empty());
+    }
+
+    #[test]
+    fn a_pattern_that_is_a_prefix_of_expected_is_idempotent() {
+        // サーバ → サーバー, but the サーバ inside an existing サーバー must NOT be flagged (no doubling).
+        let rule = rule_with(json!([{ "expected": "サーバー", "patterns": ["サーバ"] }]));
+        assert!(
+            diagnose(&rule, "このサーバーは速い。\n").is_empty(),
+            "already expected"
+        );
+        // A bare サーバ (no ー) IS flagged and fixed to サーバー.
+        let diags = diagnose(&rule, "このサーバが遅い。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!(diags[0].fixes[0].replacement, "サーバー");
+    }
+
+    #[test]
+    fn multiple_occurrences_each_flag() {
+        let rule = rule_with(json!([{ "expected": "JavaScript", "patterns": ["Javascript"] }]));
+        let diags = diagnose(&rule, "Javascript and Javascript.\n");
+        assert_eq!(diags.len(), 2, "{diags:?}");
+    }
+
+    #[test]
+    fn a_single_pattern_string_is_accepted() {
+        // The `pattern` (singular string) form works alongside `patterns`.
+        let rule = JaPrh::from_options(&json!({
+            "terms": [{ "expected": "全角", "pattern": "ぜんかく" }]
+        }));
+        let diags = diagnose(&rule, "これはぜんかくです。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!(diags[0].fixes[0].replacement, "全角");
+    }
+
+    #[test]
+    fn no_terms_configured_is_a_no_op() {
+        assert!(diagnose(&JaPrh::new(), "Javascript everywhere.\n").is_empty());
+    }
+
+    #[test]
+    fn build_rule_routes_the_terms_option() {
+        let rule = build_rule(
+            ID,
+            &json!({ "terms": [{ "expected": "JavaScript", "patterns": ["Javascript"] }] }),
+            None,
+        )
+        .unwrap();
+        assert_eq!(diagnose(rule.as_ref(), "use Javascript\n").len(), 1);
+    }
+
+    #[test]
+    fn patterns_inside_code_spans_are_left_alone() {
+        // Inline code is a separate node kind (not TEXT), so a pattern inside `code` is not touched.
+        let rule = rule_with(json!([{ "expected": "JavaScript", "patterns": ["Javascript"] }]));
+        assert!(diagnose(&rule, "use `Javascript` here\n").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/ja_prh.rs
+++ b/crates/tzlint_rules/src/rules/ja_prh.rs
@@ -1,17 +1,21 @@
 //! `ja-prh` — terminology / 表記ゆれ checking with autofix, the tzlint counterpart of `prh`.
 //!
-//! Each configured **term** pairs an `expected` spelling with the `patterns` (disallowed
-//! spellings) that should become it: e.g. `{ expected: "JavaScript", patterns: ["Javascript"] }`
-//! or `{ expected: "サーバー", patterns: ["サーバ"] }`. Every pattern occurrence in prose text is
-//! reported with a [`Fix`] that rewrites it to the expected spelling. A match that is **already**
-//! the expected form (e.g. the `サーバ` inside an existing `サーバー`) is left alone, so the rule is
-//! idempotent and never doubles a suffix.
+//! Each configured **term** pairs an `expected` spelling with the disallowed spellings that should
+//! become it. A spelling is either a **literal** (`pattern` / `patterns`, matched verbatim,
+//! case-sensitively) or a **regex** (`regexPatterns`, the prh `/source/flags` form). `expected`
+//! doubles as the replacement: for a regex match it is a *template* whose `$1`-style references
+//! expand to the pattern's capture groups. Every occurrence in prose text is reported with a
+//! [`Fix`] that rewrites it. A literal match already at the start of the expected form (the `サーバ`
+//! inside an existing `サーバー`), and a regex match whose replacement equals the matched text, are
+//! left alone — so the rule is idempotent and never doubles a suffix.
 //!
-//! 0.1.0 takes the term list **inline** from config `options.terms`; loading external `prh` YAML
-//! dictionaries (the `.prh.yml` format) is a follow-up that will parse those files and feed the
-//! same term list. Matching is a literal, case-sensitive substring scan — patterns carry their own
-//! precision. It is a surface rule (no morphology) and JA-scoped (R5).
+//! Terms come **inline** from config `options.terms` (`{ expected, pattern?, patterns?,
+//! regexPatterns? }`); the CLI also feeds terms parsed from external `prh` `.prh.yml` dictionaries
+//! (see `tzlint_core::prh`). Regex matching uses `regex-lite` — linear-time (no ReDoS) and
+//! non-panicking; a pattern it cannot compile (e.g. lookaround) is skipped at construction. It is a
+//! surface rule (no morphology) and JA-scoped (R5).
 
+use regex_lite::{Captures, Regex};
 use serde_json::Value;
 use tzlint_ast::NodeKind;
 use tzlint_ast::morphology::Lang;
@@ -22,8 +26,13 @@ pub const ID: &str = "ja-prh";
 
 /// One terminology entry: the preferred spelling and the spellings that should become it.
 struct Term {
+    /// The preferred spelling. For a regex match it is a replacement *template* (may carry
+    /// `$1`-style capture references); for a literal match it is used verbatim.
     expected: String,
-    patterns: Vec<String>,
+    /// Literal disallowed spellings, matched verbatim and case-sensitively.
+    literals: Vec<String>,
+    /// Regex disallowed spellings (prh `/source/flags`), compiled once at construction.
+    regexes: Vec<Regex>,
 }
 
 /// Flags configured 表記ゆれ / terminology patterns and rewrites them to the expected spelling.
@@ -41,9 +50,11 @@ impl JaPrh {
         }
     }
 
-    /// Construct from config `options`: `terms` is an array of `{ expected, pattern?, patterns? }`,
-    /// where `expected` is the preferred spelling and `pattern` (string) / `patterns` (array) list
-    /// the spellings to rewrite. Entries without a string `expected` are skipped (leniently).
+    /// Construct from config `options`: `terms` is an array of
+    /// `{ expected, pattern?, patterns?, regexPatterns? }`, where `expected` is the preferred
+    /// spelling, `pattern` (string) / `patterns` (array) list literal spellings, and `regexPatterns`
+    /// lists `{ source, ignoreCase?, multiline? }` regular expressions. Entries without a string
+    /// `expected` are skipped, and a regex that does not compile is dropped (both leniently).
     pub fn from_options(options: &Value) -> Self {
         let mut rule = Self::new();
         let Some(entries) = options.get("terms").and_then(Value::as_array) else {
@@ -53,16 +64,21 @@ impl JaPrh {
             let Some(expected) = entry.get("expected").and_then(Value::as_str) else {
                 continue;
             };
-            let mut patterns: Vec<String> = Vec::new();
+            let mut literals: Vec<String> = Vec::new();
             if let Some(single) = entry.get("pattern").and_then(Value::as_str) {
-                patterns.push(single.to_string());
+                literals.push(single.to_string());
             }
             if let Some(many) = entry.get("patterns").and_then(Value::as_array) {
-                patterns.extend(many.iter().filter_map(Value::as_str).map(str::to_string));
+                literals.extend(many.iter().filter_map(Value::as_str).map(str::to_string));
+            }
+            let mut regexes: Vec<Regex> = Vec::new();
+            if let Some(items) = entry.get("regexPatterns").and_then(Value::as_array) {
+                regexes.extend(items.iter().filter_map(compile_regex));
             }
             rule.terms.push(Term {
                 expected: expected.to_string(),
-                patterns,
+                literals,
+                regexes,
             });
         }
         rule
@@ -85,7 +101,8 @@ impl Rule for JaPrh {
         let text = node.text();
 
         for term in &self.terms {
-            for pattern in &term.patterns {
+            // Literal patterns: a verbatim, case-sensitive substring scan.
+            for pattern in &term.literals {
                 // A pattern equal to (or contained inside) the expected form would loop; skip the
                 // degenerate equal case and let the "already expected" check below handle the rest.
                 if pattern.is_empty() || *pattern == term.expected {
@@ -117,7 +134,135 @@ impl Rule for JaPrh {
                     );
                 }
             }
+
+            // Regex patterns: each match's replacement is the `expected` template with its `$N`
+            // capture references expanded. A zero-width match, or one whose replacement already
+            // equals the matched text, is left alone (idempotent).
+            for regex in &term.regexes {
+                for caps in regex.captures_iter(text) {
+                    let Some(whole) = caps.get(0) else { continue };
+                    if whole.start() == whole.end() {
+                        continue;
+                    }
+                    let replacement = expand_template(&term.expected, &caps);
+                    if replacement == whole.as_str() {
+                        continue;
+                    }
+                    let span = tzlint_ast::Span::new(
+                        base.saturating_add(whole.start() as u32),
+                        base.saturating_add(whole.end() as u32),
+                    );
+                    cx.report_with_fixes(
+                        span,
+                        message(whole.as_str(), &replacement),
+                        [Fix::replace(span, replacement)],
+                    );
+                }
+            }
         }
+    }
+}
+
+/// Compile one `regexPatterns` entry (`{ source, ignoreCase?, multiline? }`) into a [`Regex`], or
+/// `None` when it has no non-empty string `source` or the source is not a valid `regex-lite`
+/// expression (e.g. it uses lookaround/backreferences, which neither `regex-lite` nor `regex`
+/// support). Skipping such a pattern keeps the rest of the dictionary working — best-effort prh
+/// migration.
+fn compile_regex(item: &Value) -> Option<Regex> {
+    let source = item.get("source").and_then(Value::as_str)?;
+    if source.is_empty() {
+        return None;
+    }
+    let ignore_case = item
+        .get("ignoreCase")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let multiline = item
+        .get("multiline")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    // `regex-lite` honors the `(?i)` / `(?m)` inline flag group at the start of a pattern.
+    let mut pattern = String::new();
+    if ignore_case || multiline {
+        pattern.push_str("(?");
+        if ignore_case {
+            pattern.push('i');
+        }
+        if multiline {
+            pattern.push('m');
+        }
+        pattern.push(')');
+    }
+    pattern.push_str(source);
+    Regex::new(&pattern).ok()
+}
+
+/// Expand a prh replacement template against a regex match: `$0`..`$N` and `${N}` are replaced by
+/// the corresponding capture group (an absent group expands to empty), `$$` is a literal `$`, and
+/// any other `$`-sequence is kept verbatim.
+fn expand_template(template: &str, caps: &Captures) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut chars = template.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '$' {
+            out.push(c);
+            continue;
+        }
+        match chars.peek() {
+            Some('$') => {
+                chars.next();
+                out.push('$');
+            }
+            Some('{') => {
+                chars.next();
+                let mut digits = String::new();
+                while chars.peek().is_some_and(char::is_ascii_digit) {
+                    if let Some(d) = chars.next() {
+                        digits.push(d);
+                    }
+                }
+                let closed = chars.peek() == Some(&'}');
+                if closed {
+                    chars.next();
+                }
+                match (closed, digits.parse::<usize>()) {
+                    (true, Ok(n)) => push_group(&mut out, caps, n),
+                    _ => {
+                        // Malformed `${…}`: keep the consumed text verbatim.
+                        out.push('$');
+                        out.push('{');
+                        out.push_str(&digits);
+                        if closed {
+                            out.push('}');
+                        }
+                    }
+                }
+            }
+            Some(d) if d.is_ascii_digit() => {
+                let mut digits = String::new();
+                while chars.peek().is_some_and(char::is_ascii_digit) {
+                    if let Some(d) = chars.next() {
+                        digits.push(d);
+                    }
+                }
+                match digits.parse::<usize>() {
+                    Ok(n) => push_group(&mut out, caps, n),
+                    Err(_) => {
+                        out.push('$');
+                        out.push_str(&digits);
+                    }
+                }
+            }
+            _ => out.push('$'),
+        }
+    }
+    out
+}
+
+/// Append capture group `n` (the whole match for `0`) to `out`, or nothing when it did not match.
+fn push_group(out: &mut String, caps: &Captures, n: usize) {
+    if let Some(m) = caps.get(n) {
+        out.push_str(m.as_str());
     }
 }
 
@@ -213,5 +358,61 @@ mod tests {
         // Inline code is a separate node kind (not TEXT), so a pattern inside `code` is not touched.
         let rule = rule_with(json!([{ "expected": "JavaScript", "patterns": ["Javascript"] }]));
         assert!(diagnose(&rule, "use `Javascript` here\n").is_empty());
+    }
+
+    #[test]
+    fn rewrites_a_regex_pattern_with_a_capture_template() {
+        // The canonical prh form: a regex pattern whose `expected` is a `$1` capture template.
+        let rule = rule_with(json!([{
+            "expected": "（$1）",
+            "regexPatterns": [{ "source": "\\(([^)]+)\\)" }]
+        }]));
+        let diags = diagnose(&rule, "これは(補足)です。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!(diags[0].fixes.len(), 1);
+        assert_eq!(diags[0].fixes[0].replacement, "（補足）");
+    }
+
+    #[test]
+    fn the_i_flag_matches_case_insensitively() {
+        let rule = rule_with(json!([{
+            "expected": "JavaScript",
+            "regexPatterns": [{ "source": "javascript", "ignoreCase": true }]
+        }]));
+        let diags = diagnose(&rule, "I love JAVASCRIPT today.\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!(diags[0].fixes[0].replacement, "JavaScript");
+    }
+
+    #[test]
+    fn a_regex_match_already_in_expected_form_is_not_flagged() {
+        // The replacement equals the matched text → no-op, so it must not be reported (idempotent).
+        let rule = rule_with(json!([{
+            "expected": "$1",
+            "regexPatterns": [{ "source": "(foo)" }]
+        }]));
+        assert!(diagnose(&rule, "foo bar\n").is_empty());
+    }
+
+    #[test]
+    fn an_uncompilable_regex_is_skipped() {
+        // regex-lite rejects lookaround; the pattern is dropped at construction (no panic, no diag).
+        let rule = rule_with(json!([{
+            "expected": "X",
+            "regexPatterns": [{ "source": "(?=x)" }]
+        }]));
+        assert!(diagnose(&rule, "xxx\n").is_empty());
+    }
+
+    #[test]
+    fn literal_and_regex_patterns_coexist_on_one_term() {
+        let rule = rule_with(json!([{
+            "expected": "JavaScript",
+            "patterns": ["Javascript"],
+            "regexPatterns": [{ "source": "java-script", "ignoreCase": true }]
+        }]));
+        let diags = diagnose(&rule, "use Javascript and JAVA-SCRIPT.\n");
+        assert_eq!(diags.len(), 2, "{diags:?}");
+        assert!(diags.iter().all(|d| d.fixes[0].replacement == "JavaScript"));
     }
 }

--- a/crates/tzlint_rules/src/rules/ja_prh.rs
+++ b/crates/tzlint_rules/src/rules/ja_prh.rs
@@ -415,4 +415,56 @@ mod tests {
         assert_eq!(diags.len(), 2, "{diags:?}");
         assert!(diags.iter().all(|d| d.fixes[0].replacement == "JavaScript"));
     }
+
+    #[test]
+    fn the_i_and_m_flags_compile_together() {
+        // Both flags fold into a leading `(?im)` group at compile time; the pattern still rewrites.
+        let rule = rule_with(json!([{
+            "expected": "JavaScript",
+            "regexPatterns": [{ "source": "javascript", "ignoreCase": true, "multiline": true }]
+        }]));
+        let diags = diagnose(&rule, "use JavaScript or javascript here.\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!(diags[0].fixes[0].replacement, "JavaScript");
+    }
+
+    #[test]
+    fn a_zero_width_regex_match_is_left_alone() {
+        // A pattern that can match the empty string must not emit empty, zero-width rewrites.
+        let rule = rule_with(json!([{
+            "expected": "x",
+            "regexPatterns": [{ "source": "a*" }]
+        }]));
+        assert!(diagnose(&rule, "bbb\n").is_empty());
+    }
+
+    #[test]
+    fn expand_template_covers_every_dollar_form() {
+        // Two indexed groups: `$0` = "foo-bar", `$1` = "foo", `$2` = "bar".
+        let re = Regex::new(r"(\w+)-(\w+)").unwrap();
+        let caps = re.captures("foo-bar").unwrap();
+
+        // Bare `$N`, the braced `${N}`, and `$0` (the whole match).
+        assert_eq!(expand_template("$1", &caps), "foo");
+        assert_eq!(expand_template("${2}", &caps), "bar");
+        assert_eq!(expand_template("$0", &caps), "foo-bar");
+        assert_eq!(expand_template("[${1}/$2]", &caps), "[foo/bar]");
+        // An absent group expands to nothing, in either form.
+        assert_eq!(expand_template("a${9}b", &caps), "ab");
+        assert_eq!(expand_template("a$9b", &caps), "ab");
+        // `$$` is a literal dollar.
+        assert_eq!(expand_template("$$1", &caps), "$1");
+        // Malformed `${…}` — unterminated, or non-numeric — is kept verbatim.
+        assert_eq!(expand_template("${1", &caps), "${1");
+        assert_eq!(expand_template("${x}", &caps), "${x}");
+        assert_eq!(expand_template("${}", &caps), "${}");
+        // A `$` not followed by a digit/brace/`$` is kept verbatim, trailing one included.
+        assert_eq!(expand_template("$x", &caps), "$x");
+        assert_eq!(expand_template("a$", &caps), "a$");
+        // An index that overflows `usize` is kept literally rather than panicking.
+        assert_eq!(
+            expand_template("$99999999999999999999999999", &caps),
+            "$99999999999999999999999999"
+        );
+    }
 }

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod ja_no_mixed_period;
 pub mod ja_no_redundant_expression;
+pub mod ja_prh;
 pub mod max_kanji_continuous_len;
 pub mod max_ten;
 pub mod no_double_negative_ja;

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -54,6 +54,24 @@
   `language` also **scopes** which rules run: a JA-only rule (e.g. `sentence-length`, `max-ten`,
   `no-doubled-joshi`) runs only on Japanese documents, and when `language` is unset only the
   language-neutral rules run — so set `language: ja` (or extend a `ja-*` preset) to lint Japanese.
+- **`ja-prh` terminology dictionaries:** the `ja-prh` rule reads terms two ways, which combine. An
+  inline list under `options.terms` (`{ expected, pattern?, patterns?, regexPatterns? }`), and a
+  list of external [`prh`](https://github.com/prh/prh) `.prh.yml` files under `options.dictionaries`
+  (paths resolved relative to the config file):
+
+  ```json
+  { "rules": { "ja-prh": { "options": {
+      "dictionaries": ["./prh/web.yml", "./prh/tech.yml"],
+      "terms": [{ "expected": "JavaScript", "patterns": ["Javascript"] }]
+  } } } }
+  ```
+
+  Each dictionary's `version` / `imports` / `rules` are honored: a rule's `expected` is the
+  replacement (a `$1`-style template for a regex match), and a `pattern` written `/source/flags` is
+  a regex. Regex matching uses a small, ReDoS-free engine; a pattern it cannot compile (e.g.
+  lookaround) is skipped, and `specs` / `regexpMustEmpty` / `options.wordBoundary` are not yet
+  applied. A dictionary that cannot be read or parsed is reported on stderr and skipped (lint still
+  runs). Dictionaries are loaded at `lint`/`fix` time, not for `tzlint rules`.
 - **JSON Schema:** a Draft 2020-12 schema is published as `tzlint_core::CONFIG_SCHEMA`
   (`$id` `https://tsuzulint.dev/schema/config/v1.json`) for editor completion/validation and
   CLI emission. It describes the **JSON-level** contract and is intentionally stricter than the

--- a/docs/migration-from-textlint.md
+++ b/docs/migration-from-textlint.md
@@ -9,4 +9,18 @@ preset naming close to `textlint-rule-preset-ja-technical-writing`.
 **Intentional divergence:** config filename `.tzlintrc.*` (closer to `.textlintrc`); rules
 are authored against the Rust PDK (no binary rule-API compatibility).
 
+## `prh` terminology dictionaries
+
+Existing `prh` `.prh.yml` dictionaries (as used by `textlint-rule-prh`) load directly into the
+`ja-prh` rule — point at them from `rules.ja-prh.options.dictionaries` (see the
+[config reference](config-reference.md)). The dictionary's `version`, `imports`, and `rules`
+(`expected` + `pattern`/`patterns`) are read; `expected` is the replacement and may use `$1`-style
+capture references for a regex (`/source/flags`) pattern.
+
+Limitations to be aware of when migrating: matching uses a smaller regex engine
+(`regex-lite`), so Unicode-property classes (`\p{…}`) and lookaround/backreferences are
+unsupported — a pattern using them is skipped rather than failing the load (Japanese matched as
+literals is unaffected). The prh `specs`, `regexpMustEmpty`, and `options.wordBoundary` fields are
+parsed but not yet applied.
+
 Migration notes (config keys, rule-name mapping) filled in as rules land.


### PR DESCRIPTION
Third of the **0.1.0 4-PR stack** — based on `feat/0.1.0-ja-style-rules`. The `prh` counterpart for terminology / 表記ゆれ, with `.prh.yml` dictionary import.

### Included
- **`ja-prh` rule (R8)** — the first autofix built-in: each term pairs an `expected` spelling with the `patterns` to rewrite to it (e.g. `Javascript` → `JavaScript`), reported with a `Fix`. Idempotent. JA-scoped.
- **prh `.prh.yml` parser (`tzlint_core::prh`)** — a pure parser into a neutral term model (`version` / `imports` / `rules`), classifying each pattern as literal or `/source/flags` regex.
- **Regex + `$N` capture templates** — the rule matches regex patterns (the canonical prh form `expected: （$1）`) via **`regex-lite`** (zero deps, ReDoS-free, non-panicking — keeps the wasm artifact lean). Lookaround/backreferences and `\p{…}` are unsupported and such patterns are skipped.
- **CLI dictionary import** — `rules.ja-prh.options.dictionaries` reads `.prh.yml` files through the `Host` (relative to the config dir), follows `imports` recursively (cycle-guarded), and folds the terms into the rule. The rule stays pure; only the CLI does I/O.

Existing textlint/`prh` dictionaries drop in directly. See `docs/config-reference.md` and `docs/migration-from-textlint.md`. `just check` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 日本語の表記ゆれ検出・自動修正ルール「ja-prh」を追加しました。  
  * 設定内のインライン辞書と外部の .prh.yml 辞書を併用可能。リテラル／正規表現パターンに対応し、置換テンプレート（$1 等）で修正文を生成します。
* **動作変更**
  * 辞書は lint/fix 実行時に読み込みます（ルール一覧表示では読み込まれません）。
* **ドキュメント**
  * 設定手順と移行ガイドを追記（正規表現機能の制約を明記）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->