### PR TITLE
chore(release): bump workspace to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,21 +2319,21 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "tzlint_abi"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "tzlint_ast",
 ]
 
 [[package]]
 name = "tzlint_ast"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "rkyv",
 ]
 
 [[package]]
 name = "tzlint_cli"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "glob",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "tzlint_core"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "blake3",
  "jsonschema",
@@ -2364,14 +2364,14 @@ dependencies = [
 
 [[package]]
 name = "tzlint_lsp"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "tzlint_core",
 ]
 
 [[package]]
 name = "tzlint_morphology_native"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "lindera",
  "lindera-dictionary",
@@ -2385,14 +2385,14 @@ dependencies = [
 
 [[package]]
 name = "tzlint_pdk"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "tzlint_ast",
 ]
 
 [[package]]
 name = "tzlint_rules"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "regex-lite",
  "serde_json",
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "tzlint_wasm"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "blake3",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.0"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.94" # MSRV policy: latest stable − 2 (matches wasmtime's "last 3 stables"); bump each Rust release. Develop on latest stable.
 license = "Apache-2.0"

--- a/crates/tzlint_abi/Cargo.toml
+++ b/crates/tzlint_abi/Cargo.toml
@@ -12,4 +12,4 @@ description = "TsuzuLint plugin ABI: host + guest sides, bytecheck boundaries, i
 workspace = true
 
 [dependencies]
-tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+tzlint_ast = { path = "../tzlint_ast", version = "0.1.0" }

--- a/crates/tzlint_cli/Cargo.toml
+++ b/crates/tzlint_cli/Cargo.toml
@@ -19,19 +19,19 @@ path = "src/main.rs"
 # The lint pipeline: parser, engine, autofix, config (+ discovery), document cache, the
 # position mapper, and the centralized `Host` I/O boundary (the CLI does all of its file
 # access through `Host`, never raw `std::fs` — enforced by clippy + the io-guard CI job).
-tzlint_core = { path = "../tzlint_core", version = "0.0.0" }
+tzlint_core = { path = "../tzlint_core", version = "0.1.0" }
 # The diagnostic model and `Rule` trait the engine works in terms of.
-tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.1.0" }
 # The built-in rule registry (`builtin_rules`/`RULE_IDS`) the config selects from.
-tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
+tzlint_rules = { path = "../tzlint_rules", version = "0.1.0" }
 # `to_archive`/`access` (the parse → archive → lint bridge for the no-cache path) and `Span`.
-tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+tzlint_ast = { path = "../tzlint_ast", version = "0.1.0" }
 # The native morphology backend: `LinderaProvider`, wired into a `MorphologyRegistry` when the
 # config names a dictionary. This edge finally links a real tokenizer into the binary. It is
 # depended on by its capability name (`tzlint_morphology_native`), so the underlying backend
 # library stays an internal detail and the io-guard tripwire — which rejects the bare token in any
 # non-backend manifest — is satisfied here.
-tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0" }
+tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.1.0" }
 # Argument parsing (derive API).
 clap = { workspace = true }
 # Blocking HTTPS client for `CliHost::fetch` — the CLI's network-egress boundary for dictionary

--- a/crates/tzlint_core/Cargo.toml
+++ b/crates/tzlint_core/Cargo.toml
@@ -12,8 +12,8 @@ description = "TsuzuLint core: parser + lint engine + config + cache + centraliz
 workspace = true
 
 [dependencies]
-tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
-tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
+tzlint_ast = { path = "../tzlint_ast", version = "0.1.0" }
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.1.0" }
 markdown = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -14,7 +14,8 @@
 //! diagnostics — its 256-bit collision resistance makes that infeasible.
 //!
 //! **Versioning:** the parser/transform/engine versions below are hand-bumped consts, *not*
-//! `CARGO_PKG_VERSION` (the workspace is pinned `0.0.0`, so it carries no signal). Bump the
+//! `CARGO_PKG_VERSION` — the key must turn over on *behavior* changes, not on every release, so
+//! a version bump that does not alter linting never needlessly invalidates the cache. Bump the
 //! relevant const whenever the corresponding behavior changes (see each const's doc).
 //!
 //! **Scope:** only the in-memory cache exists; persistence is deferred to the CLI (M1g),

--- a/crates/tzlint_lsp/Cargo.toml
+++ b/crates/tzlint_lsp/Cargo.toml
@@ -12,4 +12,4 @@ description = "TsuzuLint LSP server (scaffold only in v1; full build is a later 
 workspace = true
 
 [dependencies]
-tzlint_core = { path = "../tzlint_core", version = "0.0.0" }
+tzlint_core = { path = "../tzlint_core", version = "0.1.0" }

--- a/crates/tzlint_morphology_native/Cargo.toml
+++ b/crates/tzlint_morphology_native/Cargo.toml
@@ -14,9 +14,9 @@ workspace = true
 [dependencies]
 # The frozen MorphologyV1 data model the provider fills (MorphologyBuilder, Token, FeatureKey,
 # Tagset, Lang) and Span/NodeId. `no_std`, ABI-frozen — shared with the wasm-facing crates.
-tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+tzlint_ast = { path = "../tzlint_ast", version = "0.1.0" }
 # The `MorphologyProvider` trait this crate implements (and `MorphologyError`).
-tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.1.0" }
 # The morphological analyzer. NATIVE-ONLY by construction: this crate has no dependency edge from
 # the wasm-facing crates (ast/pdk/core), so cargo never resolves lindera for the `wasm32` build,
 # and the crate's `lib.rs` is `#![cfg(not(target_arch = "wasm32"))]` as a second guard. MIT.
@@ -30,7 +30,7 @@ lindera-dictionary = "4.0.0"
 # The wasm-clean, lindera-free dictionary-container codec (`tzlint_core::dict::container`) used to
 # split the decompressed blob into component byte ranges. A native-only edge (core never depends on
 # this crate, so there is no cycle and the wasm graph is untouched).
-tzlint_core = { path = "../tzlint_core", version = "0.0.0" }
+tzlint_core = { path = "../tzlint_core", version = "0.1.0" }
 # Packaging-only (behind the `package` feature): re-serialize a loaded dictionary's components back
 # to their on-disk byte forms when BUILDING a distributable container. `serde_json` re-emits
 # `metadata.json`; `rkyv` re-emits the `char_def.bin`/`unk.bin` archives. Both are already in the
@@ -62,4 +62,4 @@ required-features = ["embed-ipadic"]
 # The morphology rule under test (`NoDoubledJoshi`) for the end-to-end firing test: a real lindera
 # provider, wired through `tzlint_core::lint_document`, must make the rule fire. Test-only — there is
 # no production edge from this backend crate to the rules crate.
-tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
+tzlint_rules = { path = "../tzlint_rules", version = "0.1.0" }

--- a/crates/tzlint_pdk/Cargo.toml
+++ b/crates/tzlint_pdk/Cargo.toml
@@ -12,4 +12,4 @@ description = "TsuzuLint rule-author SDK: macros, types, and a rule test harness
 workspace = true
 
 [dependencies]
-tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+tzlint_ast = { path = "../tzlint_ast", version = "0.1.0" }

--- a/crates/tzlint_rules/Cargo.toml
+++ b/crates/tzlint_rules/Cargo.toml
@@ -16,8 +16,8 @@ workspace = true
 # need `tzlint_ast` only for `NodeKind`/`Span`. They deliberately do NOT depend on `tzlint_core`
 # (the engine): rules are pure visitors, and keeping the dep out avoids a cycle once `tzlint_core`
 # wires the registry. `serde_json` parses rule options leniently.
-tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
-tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.1.0" }
+tzlint_ast = { path = "../tzlint_ast", version = "0.1.0" }
 serde_json = { workspace = true }
 # `ja-prh` regex patterns (prh `/source/flags`). A tiny, zero-dependency, ReDoS-free, non-panicking
 # engine — see the workspace dependency note for why `regex-lite` over the full `regex` here.
@@ -27,4 +27,4 @@ regex-lite = { workspace = true }
 # Test-only: the parser + engine, used to run a rule end-to-end over markdown (see
 # `src/test_support.rs`). A dev-dependency — never part of the normal graph — so it does not
 # create a cycle even once `tzlint_core` references the rule registry.
-tzlint_core = { path = "../tzlint_core", version = "0.0.0" }
+tzlint_core = { path = "../tzlint_core", version = "0.1.0" }

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -18,17 +18,17 @@ workspace = true
 [dependencies]
 # The lint pipeline (parser/engine/config/`lint_document`), the morphology registry seam, and the
 # `Host`-free `decompress_dictionary` the full build uses to verify a JS-supplied dictionary blob.
-tzlint_core = { path = "../tzlint_core", version = "0.0.0" }
+tzlint_core = { path = "../tzlint_core", version = "0.1.0" }
 # Diagnostics, the `Rule` trait, severities.
-tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
+tzlint_pdk = { path = "../tzlint_pdk", version = "0.1.0" }
 # The built-in rules (`RULE_IDS`/`build_rule`) the linter resolves the active set from.
-tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
+tzlint_rules = { path = "../tzlint_rules", version = "0.1.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
 serde = { workspace = true }
 serde_json = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
-tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }
+tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.1.0", optional = true }
 # `blake3::Hash::from_hex` decodes the dictionary pin — pulled ONLY by the `morphology` feature
 # (the lean artifact never decodes a pin). Already linked transitively via `tzlint_core`, so this
 # adds no weight to the full build; it just lets the binding name `blake3` directly.


### PR DESCRIPTION
Final PR of the **0.1.0 4-PR stack** — based on `feat/0.1.0-prh`. Merges **last**, once every 0.1.0 change is in.

Flips `workspace.package.version` `0.0.0` → `0.1.0` and propagates the bump to every internal path-dependency pin (all crates inherit via `version.workspace = true`). Rewords the cache-versioning note in `tzlint_core::cache` (the workspace is no longer pinned `0.0.0`).

Pure mechanical bump; no runtime behavior change. The version reflects a ready release rather than a starting point — which is why it lands after the feature PRs, not before them. `just check` green; `tzlint --version` reports `0.1.0`.
