### PR TITLE
⚡ Bolt: optimize RuleId allocations with Arc<str>

### DIFF
--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -1,6 +1,7 @@
 //! The diagnostic model rules emit and the engine aggregates.
 
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use tzlint_ast::Span;
@@ -11,12 +12,12 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
     pub fn new(id: impl Into<String>) -> Self {
-        RuleId(id.into())
+        RuleId(id.into().into())
     }
     /// The id as a string slice.
     pub fn as_str(&self) -> &str {
@@ -32,13 +33,13 @@ impl core::fmt::Display for RuleId {
 
 impl From<&str> for RuleId {
     fn from(s: &str) -> Self {
-        RuleId(s.into())
+        RuleId(Arc::from(s))
     }
 }
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(Arc::from(s))
     }
 }
 


### PR DESCRIPTION
💡 What: Replaced the `String` wrapper in `RuleId` with `Arc<str>` to optimize cloning.
🎯 Why: `RuleId` is frequently used as a key in `BTreeMap`s for rule configurations and cache lookups, and is cloned often during linting diagnostics. Each clone of a `String` incurs an O(n) allocation overhead. Wrapping it in an `Arc<str>` reduces this cost to an O(1) atomic reference increment.
📊 Impact: Eliminates expensive string cloning for rule identifiers, improving performance during parsing and diagnostic generation.
🔬 Measurement: Verify by running `cargo test --workspace` to ensure all functionality is preserved, and `cargo clippy --workspace --all-targets -- -D warnings` to ensure no linting regressions. The performance impact should manifest as lower memory pressure and fewer allocations.

---
*PR created automatically by Jules for task [17581311494440019089](https://jules.google.com/task/17581311494440019089) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 内部的なメモリ効率の最適化を実施しました。ユーザーに対する機能変更や動作の変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->