### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix predictable temporary file names

### DIFF
--- a/crates/tzlint_core/src/io.rs
+++ b/crates/tzlint_core/src/io.rs
@@ -181,8 +181,6 @@ mod native {
     use std::fs::{File, OpenOptions};
     use std::io::{Read, Write};
     use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     /// A [`Host`](super::Host) backed by the real filesystem (`std::fs`). The default for the
     /// native CLI and LSP.
@@ -352,21 +350,22 @@ mod native {
         }
     }
 
-    /// A unique sibling temp path `<name>.tzlint-tmp.<pid>.<counter>.<nanos>` (same directory,
-    /// so the rename stays on one filesystem). pid + a process-wide counter + the clock make
-    /// the name hard to pre-guess; `O_EXCL` (in [`TempFile::create`]) is the actual guard.
+    /// A unique sibling temp path `<name>.tzlint-tmp.<random1>.<random2>` (same directory,
+    /// so the rename stays on one filesystem).
+    /// Using `std::collections::hash_map::RandomState` gives unpredictable names,
+    /// and `O_EXCL` (in [`TempFile::create`]) is the actual guard.
     fn tmp_sibling(path: &Path) -> PathBuf {
-        static COUNTER: AtomicU64 = AtomicU64::new(0);
-        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let pid = std::process::id();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_nanos());
+        use std::collections::hash_map::RandomState;
+        use std::hash::{BuildHasher, Hasher};
+
+        let r1 = RandomState::new().build_hasher().finish();
+        let r2 = RandomState::new().build_hasher().finish();
+
         let mut name = path
             .file_name()
             .map(|s| s.to_os_string())
             .unwrap_or_default();
-        name.push(format!(".tzlint-tmp.{pid}.{n}.{nanos}"));
+        name.push(format!(".tzlint-tmp.{r1:016x}.{r2:016x}"));
         path.with_file_name(name)
     }
 

--- a/crates/tzlint_core/src/io.rs
+++ b/crates/tzlint_core/src/io.rs
@@ -358,6 +358,9 @@ mod native {
         use std::collections::hash_map::RandomState;
         use std::hash::{BuildHasher, Hasher};
 
+        // `RandomState::new()` seeds each hasher with fresh random keys, re-seeded
+        // per call. Calling `finish()` with no bytes written returns a value derived
+        // solely from those keys — an unpredictable per-call value, so `r1 != r2`.
         let r1 = RandomState::new().build_hasher().finish();
         let r2 = RandomState::new().build_hasher().finish();
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix predictable temporary file names

- 🚨 Severity: MEDIUM
- 💡 Vulnerability: The temporary file names used for atomic writes in `tmp_sibling` were partially predictable, as they relied on `SystemTime::now()` and `process::id()` combined with a simple atomic counter.
- 🎯 Impact: While `O_EXCL` prevents following symlinks or clobbering existing files, predictable temporary file paths weaken defense in depth and could theoretically lead to localized Denial of Service if an attacker pre-creates the predicted names.
- 🔧 Fix: Replaced the time/PID logic with `std::collections::hash_map::RandomState` to generate highly unpredictable hex strings. This securely sources entropy from the OS's PRNG without requiring external crates like `rand`.
- ✅ Verification: Ran tests locally to verify temp files are successfully created, used, and dropped.

---
*PR created automatically by Jules for task [15224181409482508040](https://jules.google.com/task/15224181409482508040) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リファクタリング

* ファイルの原子的書き込み操作における内部メカニズムを改善し、システムの堅牢性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->