### PR TITLE
🦀 Ferris: [perf] Use Arc<str> for RuleId

### DIFF
--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -11,12 +11,13 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(alloc::sync::Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
     pub fn new(id: impl Into<String>) -> Self {
-        RuleId(id.into())
+        let s: String = id.into();
+        RuleId(s.into())
     }
     /// The id as a string slice.
     pub fn as_str(&self) -> &str {
@@ -38,7 +39,7 @@ impl From<&str> for RuleId {
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(s.into())
     }
 }
 


### PR DESCRIPTION
💡 Improvement: Changed the backing type of `RuleId` from `String` to `alloc::sync::Arc<str>`. Updated `From` and `new` implementations to properly construct the `Arc<str>`.
🦀 Why: Linter rule IDs are immutable strings that are frequently cloned (e.g., when attaching them to diagnostics or caching results). Using `Arc<str>` turns an O(N) heap allocation during cloning into an O(1) atomic reference count increment, significantly improving performance without sacrificing thread safety or trait derivations like Eq and Hash.
🔍 Verification: Ran `cargo clippy --workspace` and `cargo test --workspace` to ensure no compile errors or broken tests.

---
*PR created automatically by Jules for task [3141902922473657497](https://jules.google.com/task/3141902922473657497) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタ**
  * 内部パフォーマンス改善を実施しました。既存の公開メソッドの動作に変わりはありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->