### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix predictable temp file names

### DIFF
--- a/crates/tzlint_core/src/io.rs
+++ b/crates/tzlint_core/src/io.rs
@@ -179,10 +179,10 @@ pub trait Host {
 mod native {
     use super::{DirEntry, EntryKind, Host, IoError, Path};
     use std::fs::{File, OpenOptions};
+    use std::hash::{BuildHasher, Hasher};
     use std::io::{Read, Write};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::hash::{BuildHasher, Hasher};
 
     /// A [`Host`](super::Host) backed by the real filesystem (`std::fs`). The default for the
     /// native CLI and LSP.

--- a/crates/tzlint_core/src/io.rs
+++ b/crates/tzlint_core/src/io.rs
@@ -182,7 +182,7 @@ mod native {
     use std::io::{Read, Write};
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::hash::{BuildHasher, Hasher};
 
     /// A [`Host`](super::Host) backed by the real filesystem (`std::fs`). The default for the
     /// native CLI and LSP.
@@ -359,14 +359,16 @@ mod native {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         let pid = std::process::id();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_nanos());
+        // Use RandomState for secure unpredictability of the temp file name, preventing
+        // predictable temp file vulnerabilities.
+        let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
+        hasher.write_u64(n); // Perturb with the local sequence just in case
+        let rand_val = hasher.finish();
         let mut name = path
             .file_name()
             .map(|s| s.to_os_string())
             .unwrap_or_default();
-        name.push(format!(".tzlint-tmp.{pid}.{n}.{nanos}"));
+        name.push(format!(".tzlint-tmp.{pid}.{n}.{rand_val:016x}"));
         path.with_file_name(name)
     }
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Predictable temporary file generation logic in `crates/tzlint_core/src/io.rs`. The code used a combination of `SystemTime::now()` (ns), Process ID (PID), and an atomic counter. These elements are highly predictable, leading to CWE-377 (Insecure Temporary File), which allows attackers to conduct symlink attacks or file squatting.
🎯 Impact: Attackers could predict file names and pre-create malicious symlinks to trick the program into overwriting critical files or expose data.
🔧 Fix: Removed `SystemTime` and implemented `std::collections::hash_map::RandomState` to seed a hash function and generate a secure 64-bit random value, adding unpredictability to the temporary file names. This approach introduces entropy without requiring third-party crates like `rand`.
✅ Verification: Ran `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`. Code builds fine without clippy errors or regression test failures.

---
*PR created automatically by Jules for task [9270012609451881493](https://jules.google.com/task/9270012609451881493) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 一時ファイル名の生成方法を強化し、時間由来の予測可能な命名を廃止してよりランダムで一意な識別子を付与するように変更しました。これにより、一時ファイル名の予測や衝突に起因する脆弱性リスクを低減します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->