### PR TITLE
🎓 Scholar: blake3 usage improvement

### DIFF
--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -76,28 +76,13 @@ impl CacheKey {
 
     /// Lowercase hex encoding (64 chars). Used as the key in the on-disk cache file.
     pub fn to_hex(&self) -> String {
-        let mut hex = String::with_capacity(64);
-        for byte in &self.0 {
-            // `from_digit` is infallible for radix 16 and a nibble (0..=15); the fallback is
-            // unreachable and keeps this panic-free.
-            hex.push(char::from_digit((byte >> 4) as u32, 16).unwrap_or('0'));
-            hex.push(char::from_digit((byte & 0x0f) as u32, 16).unwrap_or('0'));
-        }
-        hex
+        blake3::Hash::from(self.0).to_hex().to_string()
     }
 
     /// Parse a 64-char lowercase-hex digest (as produced by [`to_hex`](CacheKey::to_hex)) back
     /// into a key, or `None` if it is not exactly 64 ASCII hex characters.
     pub fn from_hex(hex: &str) -> Option<CacheKey> {
-        if hex.len() != 64 || !hex.is_ascii() {
-            return None;
-        }
-        let mut bytes = [0u8; 32];
-        for (i, byte) in bytes.iter_mut().enumerate() {
-            // `hex` is ASCII and 64 long, so each 2-char window is in range and on a boundary.
-            *byte = u8::from_str_radix(&hex[2 * i..2 * i + 2], 16).ok()?;
-        }
-        Some(CacheKey(bytes))
+        blake3::Hash::from_hex(hex).ok().map(|h| CacheKey(*h.as_bytes()))
     }
 }
 

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -82,7 +82,9 @@ impl CacheKey {
     /// Parse a 64-char lowercase-hex digest (as produced by [`to_hex`](CacheKey::to_hex)) back
     /// into a key, or `None` if it is not exactly 64 ASCII hex characters.
     pub fn from_hex(hex: &str) -> Option<CacheKey> {
-        blake3::Hash::from_hex(hex).ok().map(|h| CacheKey(*h.as_bytes()))
+        blake3::Hash::from_hex(hex)
+            .ok()
+            .map(|h| CacheKey(*h.as_bytes()))
     }
 }
 

--- a/crates/tzlint_core/src/dict.rs
+++ b/crates/tzlint_core/src/dict.rs
@@ -88,15 +88,7 @@ impl From<UrlPolicyError> for DictError {
 
 /// The hash-addressed cache filename for a dictionary pinned to `hash`: lowercase hex + `.dict`.
 fn cache_file_name(hash: &[u8; 32]) -> String {
-    let mut name = String::with_capacity(64 + ".dict".len());
-    for byte in hash {
-        // `from_digit` is infallible for radix 16 and a nibble (0..=15); the fallback is
-        // unreachable and keeps this panic-free (same idiom as `CacheKey::to_hex`).
-        name.push(char::from_digit(u32::from(byte >> 4), 16).unwrap_or('0'));
-        name.push(char::from_digit(u32::from(byte & 0x0f), 16).unwrap_or('0'));
-    }
-    name.push_str(".dict");
-    name
+    format!("{}.dict", blake3::Hash::from(*hash).to_hex())
 }
 
 /// Provision the dictionary pinned to `pinned_hash`, returning its decompressed bytes.


### PR DESCRIPTION
📚 Source: https://docs.rs/blake3/latest/blake3/struct.Hash.html
💡 Insight: `blake3` provides native `to_hex()` and `from_hex()` functions which are highly optimized. We were manually doing bitwise loops to get characters.
🛠️ Change: Replaced the manual loops in `tzlint_core::cache::CacheKey::to_hex`, `from_hex`, and `tzlint_core::dict::cache_file_name`.
✨ Benefit: Efficiency and Safety gain (leveraging library built-ins instead of custom boilerplate code).

---
*PR created automatically by Jules for task [7468768807515734686](https://jules.google.com/task/7468768807515734686) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * キャッシュキーの16進文字列変換処理を簡略化しました。キャッシュファイル名生成のロジックも最適化され、処理がより効率的になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->