### PR TITLE
feat(rules): surface parity rules toward textlint-ja-technical-writing (R9, 1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ accumulate as the release is built.
   (`/source/flags`), and `expected` is a `$1`-style replacement template for a regex match; regex
   matching uses the ReDoS-free `regex-lite` engine (lookaround/backreferences and Unicode-property
   classes are unsupported and such patterns are skipped).
+- **Surface parity rules (`textlint-rule-preset-ja-technical-writing`).** `max-comma`
+  (limits ASCII commas per sentence, the sibling of `max-ten`), `no-invalid-control-character`
+  (flags invalid C0 / DEL control characters), `no-unmatched-pair` (flags unmatched
+  brackets/quotes within a text block), `ja-unnatural-alphabet` (flags a stray single Latin
+  letter sandwiched between Japanese characters, a likely IME input error), and
+  `arabic-kanji-numbers` (Arabic vs. kanji numeral usage, JTF style guide 2.2.2) — closing the
+  surface half of the preset-parity gap. Report-only. `no-unmatched-pair` mirrors upstream
+  textlint by default (only unclosed *openers* are reported, so enumeration markers like `1)` are
+  never flagged); its opt-in `detectOrphanedClosers` option additionally flags orphaned Japanese
+  quotation/corner-bracket closers (`」` `』` `】` and guillemets), which can never be enumeration
+  markers.
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -22,21 +22,27 @@ use serde_json::Value;
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use rules::{
-    ja_no_mixed_period, ja_no_redundant_expression, ja_prh, max_kanji_continuous_len, max_ten,
-    no_double_negative_ja, no_doubled_conjunctive_particle_ga, no_doubled_joshi,
-    no_dropping_the_ra, no_exclamation_question_mark, no_hankaku_kana, no_mix_dearu_desumasu,
-    no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_zero_width_spaces, sentence_length,
+    arabic_kanji_numbers, ja_no_mixed_period, ja_no_redundant_expression, ja_prh,
+    ja_unnatural_alphabet, max_comma, max_kanji_continuous_len, max_ten, no_double_negative_ja,
+    no_doubled_conjunctive_particle_ga, no_doubled_joshi, no_dropping_the_ra,
+    no_exclamation_question_mark, no_hankaku_kana, no_invalid_control_character,
+    no_mix_dearu_desumasu, no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_unmatched_pair,
+    no_zero_width_spaces, sentence_length,
 };
 pub use rules::{
-    ja_no_mixed_period::JaNoMixedPeriod, ja_no_redundant_expression::JaNoRedundantExpression,
-    ja_prh::JaPrh, max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
+    arabic_kanji_numbers::ArabicKanjiNumbers, ja_no_mixed_period::JaNoMixedPeriod,
+    ja_no_redundant_expression::JaNoRedundantExpression, ja_prh::JaPrh,
+    ja_unnatural_alphabet::JaUnnaturalAlphabet, max_comma::MaxComma,
+    max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
     no_double_negative_ja::NoDoubleNegativeJa,
     no_doubled_conjunctive_particle_ga::NoDoubledConjunctiveParticleGa,
     no_doubled_joshi::NoDoubledJoshi, no_dropping_the_ra::NoDroppingTheRa,
     no_exclamation_question_mark::NoExclamationQuestionMark, no_hankaku_kana::NoHankakuKana,
+    no_invalid_control_character::NoInvalidControlCharacter,
     no_mix_dearu_desumasu::NoMixDearuDesumasu,
     no_mixed_zenkaku_hankaku_alphabet::NoMixedZenkakuHankakuAlphabet, no_nfd::NoNfd,
-    no_todo::NoTodo, no_zero_width_spaces::NoZeroWidthSpaces, sentence_length::SentenceLength,
+    no_todo::NoTodo, no_unmatched_pair::NoUnmatchedPair, no_zero_width_spaces::NoZeroWidthSpaces,
+    sentence_length::SentenceLength,
 };
 
 /// The ids of every built-in rule, in [`builtin_rules`] order. Single source of truth — preset
@@ -59,6 +65,11 @@ pub const RULE_IDS: &[&str] = &[
     no_dropping_the_ra::ID,
     no_double_negative_ja::ID,
     ja_prh::ID,
+    max_comma::ID,
+    no_invalid_control_character::ID,
+    no_unmatched_pair::ID,
+    ja_unnatural_alphabet::ID,
+    arabic_kanji_numbers::ID,
 ];
 
 /// Construct a single built-in rule by `id`, applying config `options` (through the rule's
@@ -88,6 +99,11 @@ pub fn build_rule(id: &str, options: &Value, severity: Option<Severity>) -> Opti
         no_dropping_the_ra::ID => Box::new(NoDroppingTheRa::new()),
         no_double_negative_ja::ID => Box::new(NoDoubleNegativeJa::new()),
         ja_prh::ID => Box::new(JaPrh::from_options(options)),
+        max_comma::ID => Box::new(MaxComma::from_options(options)),
+        no_invalid_control_character::ID => Box::new(NoInvalidControlCharacter::new()),
+        no_unmatched_pair::ID => Box::new(NoUnmatchedPair::from_options(options)),
+        ja_unnatural_alphabet::ID => Box::new(JaUnnaturalAlphabet::new()),
+        arabic_kanji_numbers::ID => Box::new(ArabicKanjiNumbers::new()),
         _ => return None,
     };
     Some(match severity {
@@ -184,6 +200,10 @@ mod tests {
             "no-dropping-the-ra",                 // JA via its morphology pin
             "no-double-negative-ja",              // JA via its morphology pin
             "ja-prh",                             // JA-only (surface terminology rule)
+            "max-comma",                          // JA-only (surface, sibling of max-ten)
+            "no-unmatched-pair",                  // JA-only (surface bracket matching)
+            "ja-unnatural-alphabet",              // JA-only (surface)
+            "arabic-kanji-numbers",               // JA-only (surface, JTF 2.2.2)
         ];
 
         for id in RULE_IDS {
@@ -273,6 +293,23 @@ mod tests {
         assert_eq!(
             NoDoubleNegativeJa::default().meta().id.as_str(),
             "no-double-negative-ja"
+        );
+        assert_eq!(MaxComma::default().meta().id.as_str(), "max-comma");
+        assert_eq!(
+            NoInvalidControlCharacter::default().meta().id.as_str(),
+            "no-invalid-control-character"
+        );
+        assert_eq!(
+            NoUnmatchedPair::default().meta().id.as_str(),
+            "no-unmatched-pair"
+        );
+        assert_eq!(
+            JaUnnaturalAlphabet::default().meta().id.as_str(),
+            "ja-unnatural-alphabet"
+        );
+        assert_eq!(
+            ArabicKanjiNumbers::default().meta().id.as_str(),
+            "arabic-kanji-numbers"
         );
     }
 

--- a/crates/tzlint_rules/src/rules/arabic_kanji_numbers.rs
+++ b/crates/tzlint_rules/src/rules/arabic_kanji_numbers.rs
@@ -1,0 +1,801 @@
+//! `arabic-kanji-numbers` — enforce correct use of Arabic vs. kanji numerals in Japanese prose
+//! (JTF style guide rule 2.2.2).
+//!
+//! A **surface** rule (JA-only).  It is a conservative port of the JTF-style rule that ships
+//! inside `textlint-rule-preset-ja-technical-writing` as `jtfRules["2.2.2.算用数字と漢数字の使い分け"]`.
+//!
+//! # Two classes of violation
+//!
+//! 1. **Kanji → should be Arabic** (`kanji_to_arabic`): countable quantities expressed with
+//!    kanji numerals that convention says should use Arabic digits.  Patterns (exact mirror of
+//!    JTF 2.2.2):
+//!    - `{kanji}つ` (counting things, e.g. `三つ` → `3つ`), with exceptions
+//!    - `{kanji}回`  (occurrences/rounds)
+//!    - `{kanji}か月` (months elapsed)
+//!    - `{kanji}番目` (ordinal)
+//!    - `{kanji}進法` (numeral system, e.g. 十進法)
+//!    - `{kanji}次元` (dimension, e.g. 三次元)
+//!    - `第{kanji}章` / `第{kanji}節` (chapter/section ordinals)
+//!    - `{kanji}[兆億万]` (large-scale counts), ignoring `数…` / `何…` approximations
+//!
+//! 2. **Arabic → should be kanji** (`arabic_to_kanji`): Arabic digits in conventional
+//!    idiomatic expressions.  Patterns (exact mirror of JTF 2.2.2):
+//!    - `世界{1}` (世界一)
+//!    - `{1}時的` (一時的)
+//!    - `{1}部分` (一部分)
+//!    - `第{3}者` (第三者)
+//!    - `{1}種` (not followed by `類`, and not preceded by another digit)
+//!    - `{1}部の` (一部の)
+//!    - `{1}番に` (一番に)
+//!    - `数{10+}倍` / `数{10+}[兆億万]` / `数{10+}年` (approximate multiples)
+//!    - `{N}次関数` (polynomial degree — should be kanji, e.g. 二次関数)
+//!    - `{5}大陸` (五大陸)
+//!
+//! # Divergence / deferred
+//!
+//! - **No autofix** — the upstream rule ships an Arabic↔kanji converter; we are report-only
+//!   per project policy.  The suggested fix is embedded in the diagnostic message.
+//! - `japanese-numerals-to-number` conversion and `_num2ja` conversion are **not** implemented
+//!   in messages; messages show the matched text as a human-readable hint.
+//! - The kanji numeral set recognised is: `一二三四五六七八九十壱弐参拾百〇` (same as upstream).
+//! - `{kanji}回` is ported exactly; `{kanji}[兆億万]` ignores `数/何` prefixes.
+//! - Rules that would require morphological context to distinguish (`1種` not in `11種`) are
+//!   handled conservatively: `{1}種` checks for a non-digit preceding character.
+
+use tzlint_ast::morphology::Lang;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "arabic-kanji-numbers";
+
+/// Flags incorrect use of Arabic vs. kanji numerals (JTF style guide 2.2.2).
+pub struct ArabicKanjiNumbers {
+    meta: RuleMeta,
+}
+
+impl ArabicKanjiNumbers {
+    /// Construct the rule (no configurable options).
+    pub fn new() -> Self {
+        ArabicKanjiNumbers {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .for_language(Lang::JA),
+        }
+    }
+}
+
+impl Default for ArabicKanjiNumbers {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for ArabicKanjiNumbers {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+
+        // Collect (byte_offset, char) pairs for indexed look-around.
+        let chars: Vec<(usize, char)> = text.char_indices().collect();
+        let n = chars.len();
+
+        // --- Class 1: kanji numerals that should be Arabic ---
+        check_kanji_to_arabic(text, &chars, n, base, cx);
+
+        // --- Class 2: Arabic digits that should be kanji ---
+        check_arabic_to_kanji(text, &chars, n, base, cx);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kanji numeral characters
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if `c` is one of the kanji numeral characters used in the upstream rule.
+fn is_kanji_numeral(c: char) -> bool {
+    matches!(
+        c,
+        '一' | '二'
+            | '三'
+            | '四'
+            | '五'
+            | '六'
+            | '七'
+            | '八'
+            | '九'
+            | '十'
+            | '壱'
+            | '弐'
+            | '参'
+            | '拾'
+            | '百'
+            | '〇'
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Class 1 helpers: kanji → Arabic
+// ---------------------------------------------------------------------------
+
+/// Scan `chars` for kanji numeral runs followed by specific suffixes that should use Arabic.
+fn check_kanji_to_arabic(
+    text: &str,
+    chars: &[(usize, char)],
+    n: usize,
+    base: u32,
+    cx: &mut Context,
+) {
+    let mut i = 0;
+    while i < n {
+        let (off, c) = chars[i];
+
+        // --- `第{kanji}章` / `第{kanji}節` ---
+        if c == '第'
+            && let Some((run_end_i, _)) = kanji_run_after(chars, i + 1, n)
+            && let Some((suff_off, suff_ch)) = chars.get(run_end_i)
+            && matches!(suff_ch, '章' | '節')
+        {
+            let end = suff_off + suff_ch.len_utf8();
+            let snippet = text.get(off..end).unwrap_or("");
+            cx.report(abs_span(base, off, end), kanji_to_arabic_msg(snippet));
+            i = run_end_i + 1;
+            continue;
+        }
+
+        // All remaining class-1 patterns start with a kanji numeral run.
+        if !is_kanji_numeral(c) {
+            i += 1;
+            continue;
+        }
+
+        // Collect the run.
+        let run_start_off = off;
+        let mut run_end_i = i;
+        while run_end_i + 1 < n && is_kanji_numeral(chars[run_end_i + 1].1) {
+            run_end_i += 1;
+        }
+        let suffix_i = run_end_i + 1;
+
+        // Check `数/何` prefix — these are approximations, skip them.
+        let has_approx_prefix = i > 0 && matches!(chars[i - 1].1, '数' | '何');
+
+        if let Some((suff_off, suff_ch)) = chars.get(suffix_i) {
+            match suff_ch {
+                // `{kanji}[兆億万]` — but ignore `数…` / `何…` prefixes
+                '兆' | '億' | '万' if !has_approx_prefix => {
+                    let end = suff_off + suff_ch.len_utf8();
+                    let snippet = text.get(run_start_off..end).unwrap_or("");
+                    cx.report(
+                        abs_span(base, run_start_off, end),
+                        kanji_to_arabic_msg(snippet),
+                    );
+                    i = suffix_i + 1;
+                    continue;
+                }
+
+                // `{kanji}つ` — with exceptions
+                'つ' => {
+                    let end = suff_off + suff_ch.len_utf8();
+                    if !is_koto_exception(chars, suffix_i, n) {
+                        let snippet = text.get(run_start_off..end).unwrap_or("");
+                        cx.report(
+                            abs_span(base, run_start_off, end),
+                            kanji_to_arabic_msg(snippet),
+                        );
+                    }
+                    i = suffix_i + 1;
+                    continue;
+                }
+
+                // `{kanji}回`
+                '回' => {
+                    let end = suff_off + suff_ch.len_utf8();
+                    let snippet = text.get(run_start_off..end).unwrap_or("");
+                    cx.report(
+                        abs_span(base, run_start_off, end),
+                        kanji_to_arabic_msg(snippet),
+                    );
+                    i = suffix_i + 1;
+                    continue;
+                }
+
+                // `{kanji}か月`
+                'か' if chars.get(suffix_i + 1).map(|(_, c)| *c) == Some('月') => {
+                    let (eo, ec) = chars[suffix_i + 1];
+                    let end = eo + ec.len_utf8();
+                    let snippet = text.get(run_start_off..end).unwrap_or("");
+                    cx.report(
+                        abs_span(base, run_start_off, end),
+                        kanji_to_arabic_msg(snippet),
+                    );
+                    i = suffix_i + 2;
+                    continue;
+                }
+
+                // `{kanji}番目`
+                '番' if chars.get(suffix_i + 1).map(|(_, c)| *c) == Some('目') => {
+                    let (eo, ec) = chars[suffix_i + 1];
+                    let end = eo + ec.len_utf8();
+                    let snippet = text.get(run_start_off..end).unwrap_or("");
+                    cx.report(
+                        abs_span(base, run_start_off, end),
+                        kanji_to_arabic_msg(snippet),
+                    );
+                    i = suffix_i + 2;
+                    continue;
+                }
+
+                // `{kanji}進法`
+                '進' if chars.get(suffix_i + 1).map(|(_, c)| *c) == Some('法') => {
+                    let (eo, ec) = chars[suffix_i + 1];
+                    let end = eo + ec.len_utf8();
+                    let snippet = text.get(run_start_off..end).unwrap_or("");
+                    cx.report(
+                        abs_span(base, run_start_off, end),
+                        kanji_to_arabic_msg(snippet),
+                    );
+                    i = suffix_i + 2;
+                    continue;
+                }
+
+                // `{kanji}次元`
+                '次' if chars.get(suffix_i + 1).map(|(_, c)| *c) == Some('元') => {
+                    let (eo, ec) = chars[suffix_i + 1];
+                    let end = eo + ec.len_utf8();
+                    let snippet = text.get(run_start_off..end).unwrap_or("");
+                    cx.report(
+                        abs_span(base, run_start_off, end),
+                        kanji_to_arabic_msg(snippet),
+                    );
+                    i = suffix_i + 2;
+                    continue;
+                }
+
+                _ => {}
+            }
+        }
+
+        i += 1;
+    }
+}
+
+/// Returns `true` if the `つ` at `suffix_i` is part of an idiomatic exception that should
+/// remain kanji (upstream `ignoreWhenMatched` patterns for `{kanji}つ`).
+///
+/// Upstream exceptions:
+/// - `[一二三四五六七八九]つ(返事|子|ひとつ|星|編|葉|橋|と[無な]い|に一つ)` — e.g. 一つ返事, 二つ子
+/// - `(ただ|唯|[女男]手|穴|瓜|馬鹿の)[一二]つ` — e.g. ただ一つ, 穴一つ
+fn is_koto_exception(chars: &[(usize, char)], suffix_i: usize, n: usize) -> bool {
+    // Look at what comes after the つ (suffix_i is the つ position).
+    let after1 = chars.get(suffix_i + 1).map(|(_, c)| *c);
+    let after2 = chars.get(suffix_i + 2).map(|(_, c)| *c);
+    let after3 = chars.get(suffix_i + 3).map(|(_, c)| *c);
+
+    // Suffix patterns: 返事, 子, ひとつ, 星, 編, 葉, 橋, とない/とない, に一つ
+    if matches!(after1, Some('返')) && matches!(after2, Some('事')) {
+        return true;
+    }
+    if matches!(after1, Some('子')) {
+        return true;
+    }
+    if matches!(after1, Some('ひ')) && matches!(after2, Some('と')) && matches!(after3, Some('つ'))
+    {
+        return true;
+    }
+    if matches!(after1, Some('星' | '編' | '葉' | '橋')) {
+        return true;
+    }
+    // とない / となない — "とない" is "と無い"
+    if matches!(after1, Some('と'))
+        && matches!(after2, Some('無' | 'な'))
+        && matches!(after3, Some('い'))
+    {
+        return true;
+    }
+    // に一つ
+    if matches!(after1, Some('に')) && matches!(after2, Some('一')) && matches!(after3, Some('つ'))
+    {
+        return true;
+    }
+
+    // Prefix patterns: look before the kanji run.
+    // The kanji run ends just before suffix_i; we check a few chars back.
+    // For patterns like `ただ一つ` we need chars before the kanji run start.
+    // We walk backwards from suffix_i - 1 (the last kanji) to see what's further back.
+    // `suffix_i` is the つ; `suffix_i - 1` must be the last kanji char.
+    // The prefix chars are those before the start of the kanji run.
+    // To find the run start: walk back from suffix_i - 1 while is_kanji_numeral.
+    let mut run_start = suffix_i.saturating_sub(1);
+    while run_start > 0 && is_kanji_numeral(chars[run_start].1) {
+        run_start -= 1;
+    }
+    // run_start now points at the char BEFORE the run (or at the first char of the run if idx=0).
+    // Adjust: if chars[run_start] is not kanji, the run starts at run_start+1.
+    let run_start = if is_kanji_numeral(chars[run_start].1) {
+        run_start
+    } else {
+        run_start + 1
+    };
+
+    // Only [一二] can appear in the prefix-pattern exceptions.
+    let kanji_is_single_one_or_two = suffix_i.saturating_sub(1) == run_start
+        && matches!(chars.get(run_start).map(|(_, c)| *c), Some('一' | '二'));
+
+    if kanji_is_single_one_or_two && run_start > 0 {
+        let p1 = chars.get(run_start - 1).map(|(_, c)| *c);
+        let p2 = run_start
+            .checked_sub(2)
+            .and_then(|i| chars.get(i))
+            .map(|(_, c)| *c);
+        let p3 = run_start
+            .checked_sub(3)
+            .and_then(|i| chars.get(i))
+            .map(|(_, c)| *c);
+
+        // `ただ一つ` / `唯一つ`
+        if matches!(p1, Some('だ')) && matches!(p2, Some('た')) {
+            return true;
+        }
+        if matches!(p1, Some('唯')) {
+            return true;
+        }
+        // `女手一つ` / `男手一つ`
+        if matches!(p1, Some('手')) && matches!(p2, Some('女' | '男')) {
+            return true;
+        }
+        // `穴一つ` / `瓜一つ` / `馬鹿の一つ`
+        if matches!(p1, Some('穴' | '瓜')) {
+            return true;
+        }
+        if matches!(p1, Some('の')) && matches!(p2, Some('鹿')) && matches!(p3, Some('馬')) {
+            return true;
+        }
+    }
+
+    let _ = n; // suppress unused warning
+    false
+}
+
+/// Returns `(first_idx_after_run, _)` for a kanji numeral run starting right at `from_i`.
+/// Returns `None` if `chars[from_i]` is not a kanji numeral.
+fn kanji_run_after(chars: &[(usize, char)], from_i: usize, n: usize) -> Option<(usize, usize)> {
+    if from_i >= n || !is_kanji_numeral(chars[from_i].1) {
+        return None;
+    }
+    let mut end_i = from_i;
+    while end_i + 1 < n && is_kanji_numeral(chars[end_i + 1].1) {
+        end_i += 1;
+    }
+    let end_off = chars[end_i].0 + chars[end_i].1.len_utf8();
+    Some((end_i + 1, end_off)) // first index AFTER the run
+}
+
+// ---------------------------------------------------------------------------
+// Class 2 helpers: Arabic → kanji
+// ---------------------------------------------------------------------------
+
+/// Check for Arabic digits in positions where the JTF guide demands kanji numerals.
+fn check_arabic_to_kanji(
+    text: &str,
+    chars: &[(usize, char)],
+    n: usize,
+    base: u32,
+    cx: &mut Context,
+) {
+    let mut i = 0;
+    while i < n {
+        let (off, c) = chars[i];
+
+        // `世界{1}`
+        if c == '世'
+            && let Some((_, '界')) = chars.get(i + 1)
+            && let Some((d_off, '1')) = chars.get(i + 2)
+        {
+            let end = d_off + 1;
+            let snippet = text.get(off..end).unwrap_or("");
+            cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+            i += 3;
+            continue;
+        }
+
+        // `第{3}者`
+        if c == '第'
+            && let Some((_, '3')) = chars.get(i + 1)
+            && let Some((_, '者')) = chars.get(i + 2)
+        {
+            let end = chars[i + 2].0 + '者'.len_utf8();
+            let snippet = text.get(off..end).unwrap_or("");
+            cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+            i += 3;
+            continue;
+        }
+
+        // `数{10+}倍` / `数{10+}[兆億万]` / `数{10+}年`
+        if c == '数'
+            && let Some((_, '1')) = chars.get(i + 1)
+        {
+            // Collect the digit run starting at i+1 (must be '1' + at least one '0').
+            let mut run_end = i + 1;
+            while run_end + 1 < n && chars[run_end + 1].1 == '0' {
+                run_end += 1;
+            }
+            // Must be at least "10" (two chars: '1' + at least one '0').
+            if run_end > i + 1 {
+                let next_i = run_end + 1;
+                let suff = chars.get(next_i).map(|(_, c)| *c);
+                if matches!(suff, Some('倍' | '兆' | '億' | '万' | '年')) {
+                    let (so, sc) = chars[next_i];
+                    let end = so + sc.len_utf8();
+                    let snippet = text.get(off..end).unwrap_or("");
+                    cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+                    i = next_i + 1;
+                    continue;
+                }
+            }
+        }
+
+        // Patterns that start with the digit itself.
+        if c.is_ascii_digit() {
+            // `{1}時的`
+            if c == '1'
+                && let Some((_, '時')) = chars.get(i + 1)
+                && let Some((_, '的')) = chars.get(i + 2)
+            {
+                let end = chars[i + 2].0 + '的'.len_utf8();
+                let snippet = text.get(off..end).unwrap_or("");
+                cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+                i += 3;
+                continue;
+            }
+
+            // `{1}部分`
+            if c == '1'
+                && let Some((_, '部')) = chars.get(i + 1)
+                && let Some((_, '分')) = chars.get(i + 2)
+            {
+                let end = chars[i + 2].0 + '分'.len_utf8();
+                let snippet = text.get(off..end).unwrap_or("");
+                cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+                i += 3;
+                continue;
+            }
+
+            // `{1}部の`
+            if c == '1'
+                && let Some((_, '部')) = chars.get(i + 1)
+                && let Some((_, 'の')) = chars.get(i + 2)
+            {
+                let end = chars[i + 2].0 + 'の'.len_utf8();
+                let snippet = text.get(off..end).unwrap_or("");
+                cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+                i += 3;
+                continue;
+            }
+
+            // `{1}番に`
+            if c == '1'
+                && let Some((_, '番')) = chars.get(i + 1)
+                && let Some((_, 'に')) = chars.get(i + 2)
+            {
+                let end = chars[i + 2].0 + 'に'.len_utf8();
+                let snippet = text.get(off..end).unwrap_or("");
+                cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+                i += 3;
+                continue;
+            }
+
+            // `{1}種` — not preceded by another digit, not followed by 類
+            if c == '1' {
+                let prev_is_digit = i > 0 && chars[i - 1].1.is_ascii_digit();
+                if !prev_is_digit && let Some((_, '種')) = chars.get(i + 1) {
+                    let followed_by_rui = chars.get(i + 2).map(|(_, c)| *c) == Some('類');
+                    if !followed_by_rui {
+                        let end = chars[i + 1].0 + '種'.len_utf8();
+                        let snippet = text.get(off..end).unwrap_or("");
+                        cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+                        i += 2;
+                        continue;
+                    }
+                }
+            }
+
+            // `{5}大陸`
+            if c == '5'
+                && let Some((_, '大')) = chars.get(i + 1)
+                && let Some((_, '陸')) = chars.get(i + 2)
+            {
+                let end = chars[i + 2].0 + '陸'.len_utf8();
+                let snippet = text.get(off..end).unwrap_or("");
+                cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+                i += 3;
+                continue;
+            }
+
+            // `{N}次関数` — any digit(s) before 次関数
+            {
+                // Collect consecutive digit run starting at i.
+                let mut run_end = i;
+                while run_end + 1 < n && chars[run_end + 1].1.is_ascii_digit() {
+                    run_end += 1;
+                }
+                let next_i = run_end + 1;
+                if let Some((_, '次')) = chars.get(next_i)
+                    && let Some((_, '関')) = chars.get(next_i + 1)
+                    && let Some((_, '数')) = chars.get(next_i + 2)
+                {
+                    let end = chars[next_i + 2].0 + '数'.len_utf8();
+                    let snippet = text.get(off..end).unwrap_or("");
+                    cx.report(abs_span(base, off, end), arabic_to_kanji_msg(snippet));
+                    i = next_i + 3;
+                    continue;
+                }
+            }
+        }
+
+        i += 1;
+    }
+    let _ = n;
+}
+
+// ---------------------------------------------------------------------------
+// Span helpers and messages
+// ---------------------------------------------------------------------------
+
+fn abs_span(base: u32, start: usize, end: usize) -> Span {
+    Span::new(
+        base.saturating_add(start as u32),
+        base.saturating_add(end as u32),
+    )
+}
+
+fn kanji_to_arabic_msg(snippet: &str) -> String {
+    format!(
+        "「{snippet}」の漢数字は算用数字で書いてください。\n\n\
+         数量を表現し、数を数えられるものは算用数字を使用します。\
+         任意の数に置き換えても通用する語句がこれに該当します。"
+    )
+}
+
+fn arabic_to_kanji_msg(snippet: &str) -> String {
+    format!(
+        "「{snippet}」の算用数字は漢数字で書いてください。\n\n\
+         慣用的表現、熟語、概数、固有名詞、副詞など、\
+         漢数字を使用することが一般的な語句では漢数字を使います。"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    fn rule() -> ArabicKanjiNumbers {
+        ArabicKanjiNumbers::new()
+    }
+
+    // --- Class 1: kanji → Arabic ---
+
+    #[test]
+    fn flags_kanji_tsu() {
+        // 三つ → 3つ
+        let diags = diagnose(&rule(), "三つ食べた\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("算用数字"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_kanji_kai() {
+        // 三回 → 3回
+        let diags = diagnose(&rule(), "三回やった\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_kanji_kagetsu() {
+        // 三か月 → 3か月
+        let diags = diagnose(&rule(), "三か月かかる\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_kanji_banme() {
+        // 三番目 → 3番目
+        let diags = diagnose(&rule(), "三番目に\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_kanji_shinhou() {
+        // 十進法 → 10進法
+        let diags = diagnose(&rule(), "十進法とは\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_kanji_jigen() {
+        // 三次元 → 3次元
+        let diags = diagnose(&rule(), "三次元空間\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_dai_kanji_sho() {
+        // 第三章 → 第3章
+        let diags = diagnose(&rule(), "第三章を読む\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_dai_kanji_setsu() {
+        // 第一節 → 第1節
+        let diags = diagnose(&rule(), "第一節の内容\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_kanji_large_unit() {
+        // 三億 → 3億
+        let diags = diagnose(&rule(), "三億円\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn allows_approx_prefix_suu() {
+        // 数十億 — approximation, not flagged
+        assert!(
+            diagnose(&rule(), "数十億円\n").is_empty(),
+            "数十億 must not be flagged"
+        );
+    }
+
+    #[test]
+    fn allows_approx_prefix_nani() {
+        // 何百万 — approximation
+        assert!(
+            diagnose(&rule(), "何百万回も\n").is_empty(),
+            "何百万 must not be flagged"
+        );
+    }
+
+    #[test]
+    fn allows_hitotsu_kanji_exceptions() {
+        // 一つ子 — idiomatic, allowed
+        assert!(
+            diagnose(&rule(), "一つ子の\n").is_empty(),
+            "一つ子 is exception"
+        );
+        // 一つ返事 — idiomatic
+        assert!(
+            diagnose(&rule(), "一つ返事で\n").is_empty(),
+            "一つ返事 is exception"
+        );
+    }
+
+    // --- Class 2: Arabic → kanji ---
+
+    #[test]
+    fn flags_ichijiteki() {
+        // 1時的 → 一時的
+        let diags = diagnose(&rule(), "1時的な措置\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(diags[0].message.contains("漢数字"), "{}", diags[0].message);
+    }
+
+    #[test]
+    fn flags_ichibunsho() {
+        // 1部分 → 一部分
+        let diags = diagnose(&rule(), "1部分だけ\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_daisansha() {
+        // 第3者 → 第三者
+        let diags = diagnose(&rule(), "第3者に\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_isshu() {
+        // 1種 → 一種 (not preceded by digit, not followed by 類)
+        let diags = diagnose(&rule(), "1種の\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn allows_isshu_rui() {
+        // 1種類 — not flagged (followed by 類)
+        assert!(
+            diagnose(&rule(), "1種類の\n").is_empty(),
+            "1種類 must not be flagged"
+        );
+    }
+
+    #[test]
+    fn allows_isshu_preceded_by_digit() {
+        // 11種 — not flagged (preceded by digit)
+        assert!(
+            diagnose(&rule(), "11種の\n").is_empty(),
+            "11種 must not be flagged"
+        );
+    }
+
+    #[test]
+    fn flags_ichibu_no() {
+        // 1部の → 一部の
+        let diags = diagnose(&rule(), "1部の人\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_ichiban_ni() {
+        // 1番に → 一番に
+        let diags = diagnose(&rule(), "1番に来た\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_go_tairiku() {
+        // 5大陸 → 五大陸
+        let diags = diagnose(&rule(), "5大陸を\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_jikansuu() {
+        // 2次関数 → 二次関数
+        let diags = diagnose(&rule(), "2次関数の\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_suu_10bai() {
+        // 数10倍 → 数十倍
+        let diags = diagnose(&rule(), "数10倍に\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_suu_100nen() {
+        // 数100年 → 数百年
+        let diags = diagnose(&rule(), "数100年前\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_sekai_ichi() {
+        // 世界1 → 世界一
+        let diags = diagnose(&rule(), "世界1の\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn clean_text_is_clean() {
+        // Valid Arabic usage: countable quantity
+        assert!(diagnose(&rule(), "3つ食べた\n").is_empty());
+        assert!(diagnose(&rule(), "5回やった\n").is_empty());
+        assert!(diagnose(&rule(), "第3章を読む\n").is_empty());
+        // Valid kanji usage: idiomatic
+        assert!(diagnose(&rule(), "一時的な措置\n").is_empty());
+        assert!(diagnose(&rule(), "第三者に\n").is_empty());
+        assert!(diagnose(&rule(), "世界一の\n").is_empty());
+        assert!(diagnose(&rule(), "五大陸を\n").is_empty());
+        assert!(diagnose(&rule(), "二次関数\n").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/ja_unnatural_alphabet.rs
+++ b/crates/tzlint_rules/src/rules/ja_unnatural_alphabet.rs
@@ -1,0 +1,310 @@
+//! `ja-unnatural-alphabet` — flag isolated alphabet characters that are almost certainly IME
+//! input errors in Japanese text.
+//!
+//! A **surface** rule (JA-only). It detects a single half- or full-width Latin letter that
+//! appears **between two Japanese characters**, following the same heuristic as the upstream
+//! `textlint-rule-ja-unnatural-alphabet`.
+//!
+//! # Algorithm
+//!
+//! The pattern is: `{Japanese char}{single alphabet char}{Japanese char}`.  "Japanese char"
+//! means anything in the CJK/Kana/punctuation ranges used by `japaneseRegExp` upstream.
+//!
+//! # Default allow-list (matches upstream defaults + `allowCommonCase`)
+//!
+//! - Vowels: `a i u e o` and their full-width equivalents `ａ ｉ ｕ ｅ ｏ`
+//! - `n` / `ｎ` (often intended as `ん`)
+//! - All uppercase half-width letters `A-Z` (likely intentional abbreviations)
+//! - All uppercase full-width letters `Ａ-Ｚ`
+//! - Common patterns with `[a-z]言語` (e.g. C言語), `[x-z]座標`, `[x-z]軸`, `Eメール`
+//!   — these are excluded by checking the characters around the match rather than by
+//!   accepting the matched letter wholesale.
+//!
+//! # Conservative choices / divergence from upstream
+//!
+//! - **No `allow` config option** — options are accepted for forward-compatibility but
+//!   currently ignored; the hard-coded defaults already cover the upstream default set.
+//! - **No autofix** — report-only, per project policy.
+//! - The upstream rule uses `matchCaptureGroupAll` from `match-index` and separate `matchPatterns`
+//!   for the allow-list.  We re-implement equivalently in Rust using `char_indices` scanning.
+
+use tzlint_ast::morphology::Lang;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "ja-unnatural-alphabet";
+
+/// Flags isolated alphabet characters that are almost certainly IME input errors.
+pub struct JaUnnaturalAlphabet {
+    meta: RuleMeta,
+}
+
+impl JaUnnaturalAlphabet {
+    /// Construct the rule (no configurable options in this v1).
+    pub fn new() -> Self {
+        JaUnnaturalAlphabet {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .for_language(Lang::JA),
+        }
+    }
+}
+
+impl Default for JaUnnaturalAlphabet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for JaUnnaturalAlphabet {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+
+        // Collect (byte_offset, char) pairs so we can look at neighbours.
+        let chars: Vec<(usize, char)> = text.char_indices().collect();
+        let n = chars.len();
+
+        for i in 1..n.saturating_sub(1) {
+            let (off, ch) = chars[i];
+            if !is_alphabet(ch) {
+                continue;
+            }
+            // Neighbour must both be Japanese characters.
+            let prev_ch = chars[i - 1].1;
+            let next_ch = chars[i + 1].1;
+            if !is_japanese(prev_ch) || !is_japanese(next_ch) {
+                continue;
+            }
+            // Apply the allow-list.
+            if is_allowed(ch, next_ch) {
+                continue;
+            }
+            let start = base.saturating_add(off as u32);
+            let end = base.saturating_add((off + ch.len_utf8()) as u32);
+            cx.report(Span::new(start, end), message(ch));
+        }
+    }
+}
+
+/// Returns a Japanese-language diagnostic message for the offending character.
+fn message(ch: char) -> String {
+    format!(
+        "不自然なアルファベットがあります: {ch}\n\n\
+         IMEの入力ミスの可能性があります。意図した文字であれば無視してください。"
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Character-class helpers
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if `c` is a half-width or full-width Latin letter.
+fn is_alphabet(c: char) -> bool {
+    c.is_ascii_alphabetic() || ('\u{FF41}'..='\u{FF5A}').contains(&c) // ａ-ｚ
+        || ('\u{FF21}'..='\u{FF3A}').contains(&c) // Ａ-Ｚ
+}
+
+/// Returns `true` if `c` is in the Japanese character ranges used by the upstream rule
+/// (`japaneseRegExp`): CJK Unified Ideographs, Hiragana, Katakana, CJK Extension A/B,
+/// Compatibility Ideographs, Halfwidth/Fullwidth Forms, various JP punctuation.
+fn is_japanese(c: char) -> bool {
+    matches!(c,
+        // CJK misc
+        '々' | '〇' | '〻' |
+        // CJK Extension A
+        '\u{3400}'..='\u{4DBF}' |
+        // CJK Unified Ideographs
+        '\u{4E00}'..='\u{9FFF}' |
+        // CJK Compatibility Ideographs
+        '\u{F900}'..='\u{FAFF}' |
+        // Hiragana + Katakana + prolonged sound mark + punctuation
+        'ぁ'..='ん' | 'ァ'..='ヶ' | 'ー' |
+        // Japanese punctuation used in prose
+        '。' | '、' | '・' | '−' |
+        // Halfwidth and Fullwidth Forms (includes full-width ASCII, half-width Kana)
+        '\u{FF00}'..='\u{FFEF}'
+    )
+}
+
+/// Returns `true` if the alphabet character `ch` followed by `next` is on the allow-list and
+/// should **not** be flagged.
+///
+/// Allow-list (mirrors upstream defaults + `allowCommonCase`):
+/// - Vowels (half- and full-width): a i u e o  / ａ ｉ ｕ ｅ ｏ
+/// - `n` / `ｎ` (often intended as `ん`)
+/// - All uppercase half-width: A-Z  (likely intentional abbreviations)
+/// - All uppercase full-width: Ａ-Ｚ
+/// - `[a-zA-Z]言語` pattern (e.g. C言語, c言語) — allowed regardless of next char
+/// - `[x-zX-Z]座標` / `[x-zX-Z]軸` pattern — x/y/z axis notation
+/// - `E`/`ｅ` before `メール` — "Eメール"
+fn is_allowed(ch: char, next: char) -> bool {
+    // All uppercase letters — intentional abbreviations (upstream: `"/[A-Z]/"`)
+    if ch.is_ascii_uppercase() || ('\u{FF21}'..='\u{FF3A}').contains(&ch) {
+        return true;
+    }
+
+    let lower = to_ascii_lower(ch);
+
+    // Vowels + n
+    if matches!(lower, 'a' | 'i' | 'u' | 'e' | 'o' | 'n') {
+        return true;
+    }
+
+    // allowCommonCase patterns: `[a-zA-Z]言語`, `[x-z]座標`, `[x-z]軸`
+    // We check `next` because the pattern is {JP}{alpha}{JP} and the third char is `next`.
+    // "言語" starts with '言', "座標" with '座', "軸" is '軸', "メール" with 'メ'.
+    if next == '言' {
+        // [a-zA-Z]言語 — any single letter before 言 is fine (C言語, R言語, …)
+        return true;
+    }
+    if matches!(lower, 'x' | 'y' | 'z') && matches!(next, '座' | '軸') {
+        return true;
+    }
+
+    false
+}
+
+/// Convert a half-width or full-width Latin letter to its ASCII lowercase.
+/// Returns the char unchanged if it is not Latin.
+fn to_ascii_lower(c: char) -> char {
+    if c.is_ascii_alphabetic() {
+        return c.to_ascii_lowercase();
+    }
+    // Full-width a-z: U+FF41..U+FF5A
+    if ('\u{FF41}'..='\u{FF5A}').contains(&c) {
+        return (b'a' + (c as u32 - 0xFF41) as u8) as char;
+    }
+    // Full-width A-Z: U+FF21..U+FF3A
+    if ('\u{FF21}'..='\u{FF3A}').contains(&c) {
+        return (b'a' + (c as u32 - 0xFF21) as u8) as char;
+    }
+    c
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    fn rule() -> JaUnnaturalAlphabet {
+        JaUnnaturalAlphabet::new()
+    }
+
+    // --- cases that SHOULD be flagged ---
+
+    #[test]
+    fn flags_isolated_lowercase_between_japanese() {
+        // リイr−ス (r between Japanese) — upstream example
+        let diags = diagnose(&rule(), "リイrース\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("不自然なアルファベット"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_fullwidth_isolated_lowercase() {
+        // ｋ (full-width k) surrounded by Japanese
+        let diags = diagnose(&rule(), "対応でｋない\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn flags_stray_b_between_japanese() {
+        let diags = diagnose(&rule(), "あbい\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    // --- cases that should NOT be flagged ---
+
+    #[test]
+    fn allows_vowels() {
+        assert!(diagnose(&rule(), "あaい\n").is_empty(), "a is allowed");
+        assert!(diagnose(&rule(), "あiい\n").is_empty(), "i is allowed");
+        assert!(diagnose(&rule(), "あuい\n").is_empty(), "u is allowed");
+        assert!(diagnose(&rule(), "あeい\n").is_empty(), "e is allowed");
+        assert!(diagnose(&rule(), "あoい\n").is_empty(), "o is allowed");
+    }
+
+    #[test]
+    fn allows_n() {
+        assert!(diagnose(&rule(), "あnい\n").is_empty(), "n is allowed");
+    }
+
+    #[test]
+    fn allows_uppercase_letters() {
+        // All uppercase are intentional abbreviations
+        assert!(diagnose(&rule(), "あAい\n").is_empty(), "A is allowed");
+        assert!(diagnose(&rule(), "あZい\n").is_empty(), "Z is allowed");
+        assert!(diagnose(&rule(), "あBい\n").is_empty(), "B is allowed");
+    }
+
+    #[test]
+    fn allows_fullwidth_uppercase() {
+        // Full-width uppercase Ａ (U+FF21)
+        assert!(
+            diagnose(&rule(), "あＡい\n").is_empty(),
+            "Ａ (full-width) is allowed"
+        );
+    }
+
+    #[test]
+    fn allows_letter_before_gengo() {
+        // C言語, R言語 — common case allow
+        assert!(
+            diagnose(&rule(), "ではC言語を\n").is_empty(),
+            "C言語 is allowed"
+        );
+        assert!(
+            diagnose(&rule(), "ではr言語を\n").is_empty(),
+            "r言語 is allowed"
+        );
+    }
+
+    #[test]
+    fn allows_xyz_axis_notation() {
+        assert!(diagnose(&rule(), "はx軸で\n").is_empty(), "x軸 is allowed");
+        assert!(
+            diagnose(&rule(), "はy座標で\n").is_empty(),
+            "y座標 is allowed"
+        );
+        assert!(diagnose(&rule(), "はz軸で\n").is_empty(), "z軸 is allowed");
+    }
+
+    #[test]
+    fn alphabet_at_edge_not_sandwiched() {
+        // 'r' at start/end — not sandwiched, must not fire
+        assert!(diagnose(&rule(), "rはじまり\n").is_empty());
+        assert!(diagnose(&rule(), "おわりr\n").is_empty());
+    }
+
+    #[test]
+    fn non_japanese_neighbour_not_flagged() {
+        // English word — neighbours are ASCII, not Japanese
+        assert!(diagnose(&rule(), "API\n").is_empty());
+        assert!(diagnose(&rule(), "hello world\n").is_empty());
+    }
+
+    #[test]
+    fn span_points_at_the_offending_character() {
+        // "あbい" — 'あ' is 3 bytes, 'b' is at byte 3, end at byte 4.
+        let diags = diagnose(&rule(), "あbい\n");
+        assert_eq!(diags.len(), 1);
+        assert_eq!(
+            (diags[0].span.start, diags[0].span.end),
+            (3, 4),
+            "{diags:?}"
+        );
+    }
+}

--- a/crates/tzlint_rules/src/rules/max_comma.rs
+++ b/crates/tzlint_rules/src/rules/max_comma.rs
@@ -1,0 +1,146 @@
+//! `max-comma` — flag sentences with too many ASCII commas.
+
+use serde_json::Value;
+use tzlint_ast::morphology::Lang;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "max-comma";
+/// Default maximum number of commas per sentence (upstream default is 4).
+const DEFAULT_MAX: usize = 4;
+const COMMA: char = ',';
+const KUTEN: char = '。';
+
+/// Flags any sentence whose count of ASCII commas (`,`) exceeds `max`.
+pub struct MaxComma {
+    meta: RuleMeta,
+    max: usize,
+}
+
+impl MaxComma {
+    /// Construct with default options (`max` 4).
+    pub fn new() -> Self {
+        MaxComma {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .for_language(Lang::JA),
+            max: DEFAULT_MAX,
+        }
+    }
+
+    /// Construct from config `options`, leniently. Reads `max` (integer); missing/wrong-typed
+    /// values keep the default.
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        if let Some(max) = options.get("max").and_then(Value::as_u64) {
+            // Fail safe toward "no limit" on a 32-bit target rather than truncating.
+            rule.max = usize::try_from(max).unwrap_or(usize::MAX);
+        }
+        rule
+    }
+
+    fn message(&self, count: usize) -> String {
+        format!(
+            "一文に「{COMMA}」が {count} 個あります。上限は {} 個です。",
+            self.max
+        )
+    }
+}
+
+impl Default for MaxComma {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for MaxComma {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+        let mut comma_count = 0usize;
+        let mut sentence_start = 0usize; // byte offset within the block
+        for (i, c) in text.char_indices() {
+            if c == COMMA {
+                comma_count += 1;
+            } else if c == KUTEN {
+                if comma_count > self.max {
+                    let end = i + c.len_utf8(); // include the terminating 。
+                    cx.report(
+                        Span::new(
+                            base.saturating_add(sentence_start as u32),
+                            base.saturating_add(end as u32),
+                        ),
+                        self.message(comma_count),
+                    );
+                }
+                comma_count = 0;
+                sentence_start = i + c.len_utf8();
+            }
+        }
+        // A trailing sentence with no terminating 。.
+        if comma_count > self.max && sentence_start < text.len() {
+            cx.report(
+                Span::new(
+                    base.saturating_add(sentence_start as u32),
+                    base.saturating_add(text.len() as u32),
+                ),
+                self.message(comma_count),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_too_many_commas() {
+        let rule = MaxComma::new(); // max 4
+        // 5 commas → exceeds max of 4
+        let diags = diagnose(&rule, "a,b,c,d,e,f。\n");
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("上限は 4 個"));
+    }
+
+    #[test]
+    fn within_limit_passes() {
+        let rule = MaxComma::new();
+        // Exactly max (4) passes (strict >).
+        assert!(diagnose(&rule, "a,b,c,d,e。\n").is_empty());
+        // Fewer than max also passes.
+        assert!(diagnose(&rule, "a,b,c。\n").is_empty());
+    }
+
+    #[test]
+    fn trailing_sentence_without_kuten_is_checked() {
+        // 5 commas, no terminating 。
+        let diags = diagnose(&MaxComma::new(), "a,b,c,d,e,f\n");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn multiple_sentences_each_checked_independently() {
+        let rule = MaxComma::new();
+        // First sentence: 5 commas → flagged; second sentence: 2 commas → ok.
+        let diags = diagnose(&rule, "a,b,c,d,e,f。g,h,i。\n");
+        assert_eq!(diags.len(), 1);
+    }
+
+    #[test]
+    fn from_options_overrides_max() {
+        let rule = MaxComma::from_options(&serde_json::json!({"max": 2}));
+        // max 2: a sentence with 3 commas exceeds it (strict >).
+        assert_eq!(diagnose(&rule, "a,b,c,d。\n").len(), 1);
+        assert!(diagnose(&rule, "a,b,c。\n").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -1,8 +1,11 @@
 //! The built-in rules, one module each.
 
+pub mod arabic_kanji_numbers;
 pub mod ja_no_mixed_period;
 pub mod ja_no_redundant_expression;
 pub mod ja_prh;
+pub mod ja_unnatural_alphabet;
+pub mod max_comma;
 pub mod max_kanji_continuous_len;
 pub mod max_ten;
 pub mod no_double_negative_ja;
@@ -11,9 +14,11 @@ pub mod no_doubled_joshi;
 pub mod no_dropping_the_ra;
 pub mod no_exclamation_question_mark;
 pub mod no_hankaku_kana;
+pub mod no_invalid_control_character;
 pub mod no_mix_dearu_desumasu;
 pub mod no_mixed_zenkaku_hankaku_alphabet;
 pub mod no_nfd;
 pub mod no_todo;
+pub mod no_unmatched_pair;
 pub mod no_zero_width_spaces;
 pub mod sentence_length;

--- a/crates/tzlint_rules/src/rules/no_invalid_control_character.rs
+++ b/crates/tzlint_rules/src/rules/no_invalid_control_character.rs
@@ -1,0 +1,185 @@
+//! `no-invalid-control-character` — flag invalid control characters in prose text.
+//!
+//! Mirrors the upstream textlint rule of the same name. Disallowed codepoint ranges:
+//! - C0 controls: U+0000–U+0008 (NUL through BS)
+//! - U+000B LINE TABULATION (VT)
+//! - U+000C FORM FEED (FF)
+//! - U+000E–U+001F (SO through US)
+//! - U+007F DELETE
+//! - C1 controls: U+0080–U+009F
+//! - BiDi formatting: U+202A–U+202E
+//!
+//! Allowed (not flagged): U+0009 TAB, U+000A LF, U+000D CR.
+
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-invalid-control-character";
+
+/// Whether `c` is an invalid control character that should be flagged.
+fn is_invalid_control(c: char) -> bool {
+    let cp = c as u32;
+    matches!(
+        cp,
+        // C0 controls except TAB (0x09), LF (0x0A), CR (0x0D)
+        0x00..=0x08
+        | 0x0B
+        | 0x0C
+        | 0x0E..=0x1F
+        // DEL
+        | 0x7F
+        // C1 controls
+        | 0x80..=0x9F
+        // BiDi formatting characters (upstream includes 0x202A–0x202E)
+        | 0x202A..=0x202E
+    )
+}
+
+/// Flags each invalid control character found in text nodes.
+pub struct NoInvalidControlCharacter {
+    meta: RuleMeta,
+}
+
+impl NoInvalidControlCharacter {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        NoInvalidControlCharacter {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]),
+        }
+    }
+}
+
+impl Default for NoInvalidControlCharacter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoInvalidControlCharacter {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        for (i, c) in node.text().char_indices() {
+            if is_invalid_control(c) {
+                cx.report(
+                    Span::new(
+                        base.saturating_add(i as u32),
+                        base.saturating_add((i + c.len_utf8()) as u32),
+                    ),
+                    format!(
+                        "不正なコントロール文字 U+{:04X} が含まれています。",
+                        c as u32
+                    ),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_nul_byte() {
+        assert_eq!(
+            diagnose(&NoInvalidControlCharacter::new(), "hello\u{0000}world\n").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn flags_c0_control_characters() {
+        // SOH through BS (0x01–0x08)
+        for cp in 0x01u32..=0x08 {
+            let c = char::from_u32(cp).unwrap();
+            let src = format!("a{c}b\n");
+            assert_eq!(
+                diagnose(&NoInvalidControlCharacter::new(), &src).len(),
+                1,
+                "U+{cp:04X} should be flagged"
+            );
+        }
+        // VT (0x0B) and FF (0x0C)
+        for cp in [0x0Bu32, 0x0C] {
+            let c = char::from_u32(cp).unwrap();
+            let src = format!("a{c}b\n");
+            assert_eq!(
+                diagnose(&NoInvalidControlCharacter::new(), &src).len(),
+                1,
+                "U+{cp:04X} should be flagged"
+            );
+        }
+        // SO through US (0x0E–0x1F)
+        for cp in 0x0Eu32..=0x1F {
+            let c = char::from_u32(cp).unwrap();
+            let src = format!("a{c}b\n");
+            assert_eq!(
+                diagnose(&NoInvalidControlCharacter::new(), &src).len(),
+                1,
+                "U+{cp:04X} should be flagged"
+            );
+        }
+    }
+
+    #[test]
+    fn flags_del() {
+        assert_eq!(
+            diagnose(&NoInvalidControlCharacter::new(), "a\u{007F}b\n").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn flags_c1_controls() {
+        for cp in [0x80u32, 0x85, 0x9F] {
+            let c = char::from_u32(cp).unwrap();
+            let src = format!("a{c}b\n");
+            assert_eq!(
+                diagnose(&NoInvalidControlCharacter::new(), &src).len(),
+                1,
+                "U+{cp:04X} should be flagged"
+            );
+        }
+    }
+
+    #[test]
+    fn flags_bidi_formatting_characters() {
+        // U+202E RIGHT-TO-LEFT OVERRIDE
+        assert_eq!(
+            diagnose(&NoInvalidControlCharacter::new(), "a\u{202E}b\n").len(),
+            1
+        );
+        // U+202A LEFT-TO-RIGHT EMBEDDING
+        assert_eq!(
+            diagnose(&NoInvalidControlCharacter::new(), "a\u{202A}b\n").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn allows_tab_lf_cr() {
+        // TAB is allowed
+        assert!(diagnose(&NoInvalidControlCharacter::new(), "col1\tcol2\n").is_empty());
+        // LF is the normal line ending
+        assert!(diagnose(&NoInvalidControlCharacter::new(), "line1\nline2\n").is_empty());
+        // CR: markdown source may include it; it's allowed
+        assert!(diagnose(&NoInvalidControlCharacter::new(), "text\r\n").is_empty());
+    }
+
+    #[test]
+    fn plain_text_is_clean() {
+        assert!(
+            diagnose(
+                &NoInvalidControlCharacter::new(),
+                "普通の文章です。Normal text here.\n"
+            )
+            .is_empty()
+        );
+    }
+}

--- a/crates/tzlint_rules/src/rules/no_unmatched_pair.rs
+++ b/crates/tzlint_rules/src/rules/no_unmatched_pair.rs
@@ -1,0 +1,382 @@
+//! `no-unmatched-pair` — flag unmatched bracket/quote pairs, faithfully mirroring upstream
+//! `textlint-rule-no-unmatched-pair` by default.
+//!
+//! The matcher keeps a per-pair-*type* context (mirroring upstream's `SourceCode.contextLocations`
+//! with `isInContext` / `enterContext` / `leaveContext`): an opening mark enters its type's
+//! context, a closing mark of an already-open type leaves it, and any opener still open at the end
+//! of the block is reported as unclosed. To match upstream exactly:
+//!
+//! - A closing mark with no open context of its type is **ignored** — upstream only ever reports
+//!   unclosed *openers*, never a lone closer. This is deliberate: a lone closer is
+//!   indistinguishable from an enumeration marker such as `1)` / `2)` / `a)`, which upstream's
+//!   tests explicitly treat as valid.
+//! - A second opening mark of an already-open type is **ignored** — the context is keyed by pair
+//!   type, not a strict stack.
+//! - Crossing nesting such as `([)]` is **not** flagged — each closer leaves its own type's
+//!   context regardless of order, exactly as upstream does. (A stricter LIFO matcher would flag
+//!   it, but that would diverge from textlint.)
+//!
+//! The 13 pairs mirror upstream `PairMaker.js`. The symmetric double quote `"` toggles (the first
+//! occurrence opens, the second closes); the single quote `'` is intentionally not a pair,
+//! following upstream.
+//!
+//! ## Option `detectOrphanedClosers` (default `false`)
+//!
+//! A Japanese-aware, opt-in extension *beyond* upstream parity. When enabled, an orphaned closing
+//! mark (a closer whose type is not open) is **also** reported — but only for closers that never
+//! double as a list/enumeration marker: the Japanese quotation/corner brackets `」』】〛` and the
+//! guillemets `»›`. The enumeration-prone closers `) ） ] ］ } ｝` (and the symmetric `"`) are
+//! never reported even when this is on, so `1)` / `2)` style markers stay false-positive-free. Off
+//! by default to preserve byte-for-byte textlint parity.
+
+use serde_json::Value;
+use tzlint_ast::morphology::Lang;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-unmatched-pair";
+
+/// A bracket/quote pair.
+struct Pair {
+    start: char,
+    end: char,
+    /// Japanese name shown in the diagnostic.
+    name: &'static str,
+    /// Whether an orphaned occurrence of `end` may be reported under `detectOrphanedClosers`.
+    /// `true` only for closers that never act as a list/enumeration marker (Japanese
+    /// quotation/corner brackets and guillemets); `false` for `) ） ] ］ } ｝` and `"`.
+    flag_orphan: bool,
+}
+
+/// The pairs monitored by this rule, mirroring upstream `PairMaker.js` (13 pairs).
+const PAIRS: &[Pair] = &[
+    Pair {
+        start: '"',
+        end: '"',
+        name: "二重引用符\"\"",
+        flag_orphan: false,
+    },
+    Pair {
+        start: '[',
+        end: ']',
+        name: "角括弧[]",
+        flag_orphan: false,
+    },
+    Pair {
+        start: '(',
+        end: ')',
+        name: "丸括弧()",
+        flag_orphan: false,
+    },
+    Pair {
+        start: '{',
+        end: '}',
+        name: "波括弧{}",
+        flag_orphan: false,
+    },
+    Pair {
+        start: '「',
+        end: '」',
+        name: "かぎ括弧「」",
+        flag_orphan: true,
+    },
+    Pair {
+        start: '（',
+        end: '）',
+        name: "全角丸括弧（）",
+        flag_orphan: false,
+    },
+    Pair {
+        start: '『',
+        end: '』',
+        name: "二重かぎ括弧『』",
+        flag_orphan: true,
+    },
+    Pair {
+        start: '｛',
+        end: '｝',
+        name: "全角波括弧｛｝",
+        flag_orphan: false,
+    },
+    Pair {
+        start: '［',
+        end: '］',
+        name: "全角角括弧［］",
+        flag_orphan: false,
+    },
+    Pair {
+        start: '〚',
+        end: '〛',
+        name: "二重角括弧〚〛",
+        flag_orphan: true,
+    },
+    Pair {
+        start: '【',
+        end: '】',
+        name: "隅付き括弧【】",
+        flag_orphan: true,
+    },
+    Pair {
+        start: '«',
+        end: '»',
+        name: "二重山括弧«»",
+        flag_orphan: true,
+    },
+    Pair {
+        start: '‹',
+        end: '›',
+        name: "山括弧‹›",
+        flag_orphan: true,
+    },
+];
+
+/// The index of the pair whose opener is `c`, if any.
+fn pair_with_start(c: char) -> Option<usize> {
+    PAIRS.iter().position(|p| p.start == c)
+}
+
+/// The index of the pair whose closer is `c`, if any.
+fn pair_with_end(c: char) -> Option<usize> {
+    PAIRS.iter().position(|p| p.end == c)
+}
+
+/// Flags unmatched bracket/quote pairs within a text block.
+pub struct NoUnmatchedPair {
+    meta: RuleMeta,
+    /// Opt-in: also report orphaned Japanese quotation/corner-bracket closers (see module docs).
+    detect_orphaned_closers: bool,
+}
+
+impl NoUnmatchedPair {
+    /// Construct with defaults (textlint parity: `detect_orphaned_closers` off).
+    pub fn new() -> Self {
+        NoUnmatchedPair {
+            meta: RuleMeta::new(ID, Severity::Warning, vec![NodeKind::TEXT]).for_language(Lang::JA),
+            detect_orphaned_closers: false,
+        }
+    }
+
+    /// Construct from config `options`, leniently. Reads the boolean `detectOrphanedClosers`
+    /// (default `false`); a missing or wrong-typed value keeps the default.
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        if let Some(on) = options
+            .get("detectOrphanedClosers")
+            .and_then(Value::as_bool)
+        {
+            rule.detect_orphaned_closers = on;
+        }
+        rule
+    }
+}
+
+impl Default for NoUnmatchedPair {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoUnmatchedPair {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+
+        // Per-pair-type context: `(PAIRS index, byte offset of the opener)`. At most one entry per
+        // type, mirroring upstream's `isInContext` / `enterContext` / `leaveContext`.
+        let mut context: Vec<(usize, u32)> = Vec::new();
+
+        for (i, c) in text.char_indices() {
+            let start = pair_with_start(c);
+            let end = pair_with_end(c);
+            // The pair type this character belongs to (a symmetric `"` is both a start and an end).
+            let key = match start.or(end) {
+                Some(key) => key,
+                None => continue, // not a pair mark
+            };
+
+            if context.iter().any(|(k, _)| *k == key) {
+                // This type is already open: a closing mark leaves the context; a second opening
+                // mark of the same type is ignored.
+                if let Some(pos) =
+                    end.and_then(|end_key| context.iter().position(|(k, _)| *k == end_key))
+                {
+                    context.remove(pos);
+                }
+            } else if let Some(start_key) = start {
+                // A fresh opening mark enters the context.
+                context.push((start_key, base.saturating_add(i as u32)));
+            } else {
+                // A closing mark whose type is not open (orphaned). Ignored by default (upstream
+                // parity); under `detectOrphanedClosers`, reported only for non-enumeration closers.
+                let orphan = end
+                    .filter(|_| self.detect_orphaned_closers)
+                    .and_then(|end_key| PAIRS.get(end_key))
+                    .filter(|pair| pair.flag_orphan);
+                if let Some(pair) = orphan {
+                    let offset = base.saturating_add(i as u32);
+                    cx.report(
+                        Span::new(offset, offset.saturating_add(c.len_utf8() as u32)),
+                        format!("「{}」に対応する開き括弧がありません（{}）。", c, pair.name),
+                    );
+                }
+            }
+        }
+
+        // Any opener still open at the end of the block is unclosed.
+        for (pair_idx, offset) in context {
+            if let Some(pair) = PAIRS.get(pair_idx) {
+                cx.report(
+                    Span::new(offset, offset.saturating_add(pair.start.len_utf8() as u32)),
+                    format!(
+                        "「{}」に対応する閉じ括弧がありません（{}）。",
+                        pair.start, pair.name
+                    ),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    /// The rule with `detectOrphanedClosers` enabled.
+    fn strict() -> NoUnmatchedPair {
+        NoUnmatchedPair::from_options(&serde_json::json!({ "detectOrphanedClosers": true }))
+    }
+
+    // --- matched pairs pass ---
+
+    #[test]
+    fn matched_ascii_parens_pass() {
+        assert!(diagnose(&NoUnmatchedPair::new(), "これは(秘密)です。\n").is_empty());
+    }
+
+    #[test]
+    fn matched_ja_parens_pass() {
+        assert!(diagnose(&NoUnmatchedPair::new(), "これは（秘密）です。\n").is_empty());
+    }
+
+    #[test]
+    fn matched_kagi_brackets_pass() {
+        assert!(diagnose(&NoUnmatchedPair::new(), "「こんにちは」と言った。\n").is_empty());
+    }
+
+    #[test]
+    fn nested_matching_pairs_pass() {
+        assert!(diagnose(&NoUnmatchedPair::new(), "（これは「秘密」です）。\n").is_empty());
+    }
+
+    #[test]
+    fn matched_double_quote_passes() {
+        assert!(diagnose(&NoUnmatchedPair::new(), "He said \"hello\".\n").is_empty());
+    }
+
+    #[test]
+    fn matched_square_brackets_pass() {
+        assert!(diagnose(&NoUnmatchedPair::new(), "See [here] for details.\n").is_empty());
+    }
+
+    #[test]
+    fn guillemet_pairs_pass() {
+        assert!(diagnose(&NoUnmatchedPair::new(), "«hello»\n").is_empty());
+        assert!(diagnose(&NoUnmatchedPair::new(), "‹world›\n").is_empty());
+    }
+
+    // --- unclosed openers are flagged (both modes) ---
+
+    #[test]
+    fn unclosed_ja_opener_is_flagged() {
+        let diags = diagnose(&NoUnmatchedPair::new(), "これは（秘密です。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(diags[0].message.contains("閉じ括弧がありません"));
+    }
+
+    #[test]
+    fn unclosed_square_bracket_opener_is_flagged() {
+        assert_eq!(
+            diagnose(&NoUnmatchedPair::new(), "See [here for details.\n").len(),
+            1
+        );
+    }
+
+    #[test]
+    fn unclosed_double_quote_opener_is_flagged() {
+        assert_eq!(
+            diagnose(&NoUnmatchedPair::new(), "He said \"hello.\n").len(),
+            1
+        );
+    }
+
+    // --- default (parity) mode: cases that are intentionally NOT flagged ---
+
+    #[test]
+    fn lone_closer_is_ignored_by_default() {
+        // Upstream reports only unclosed openers; a closing mark with no open context of its type
+        // is ignored. A lone ） must not be flagged in the default (parity) mode.
+        assert!(diagnose(&NoUnmatchedPair::new(), "秘密）です。\n").is_empty());
+    }
+
+    #[test]
+    fn lone_ja_quote_closer_is_ignored_by_default() {
+        assert!(diagnose(&NoUnmatchedPair::new(), "重要」です。\n").is_empty());
+    }
+
+    #[test]
+    fn crossing_nesting_is_not_flagged() {
+        // `（「…）」` crosses the two pairs. Upstream's per-type context closes each pair
+        // independently of order, so crossing nesting is intentionally not flagged in either mode.
+        assert!(diagnose(&NoUnmatchedPair::new(), "（「秘密）」です。\n").is_empty());
+        assert!(diagnose(&strict(), "（「秘密）」です。\n").is_empty());
+    }
+
+    #[test]
+    fn second_opener_of_same_type_is_ignored() {
+        // The context is keyed by pair type, so a second （ while round is already open is ignored;
+        // a single ） then closes it and nothing is reported (mirrors upstream).
+        assert!(diagnose(&NoUnmatchedPair::new(), "（（秘密）です。\n").is_empty());
+    }
+
+    #[test]
+    fn ascii_closer_does_not_close_fullwidth_opener() {
+        // The full-width （ stays open (a different type from the ASCII )), and the ASCII ) is a
+        // lone closer that is ignored — only the unclosed （ is reported.
+        let diags = diagnose(&NoUnmatchedPair::new(), "（秘密)\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    // --- opt-in detectOrphanedClosers mode ---
+
+    #[test]
+    fn orphaned_ja_quote_closer_flagged_when_enabled() {
+        // A lone 」 cannot be an enumeration marker, so the strict mode reports it.
+        let diags = diagnose(&strict(), "重要」です。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(diags[0].message.contains("開き括弧がありません"));
+    }
+
+    #[test]
+    fn orphaned_corner_bracket_closer_flagged_when_enabled() {
+        let diags = diagnose(&strict(), "注意】を確認する。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn enumeration_markers_not_flagged_even_when_enabled() {
+        // ) is enumeration-prone, so it is never reported as an orphan even in the strict mode.
+        assert!(diagnose(&strict(), "手順は1) 準備 2) 実行 3) 確認 です。\n").is_empty());
+        assert!(diagnose(&strict(), "選択肢は（1）と2）があります。\n").is_empty());
+    }
+
+    #[test]
+    fn matched_quotes_still_pass_when_enabled() {
+        assert!(diagnose(&strict(), "彼は「了解」と言った。\n").is_empty());
+    }
+}


### PR DESCRIPTION
First of a **2-PR stack** completing `textlint-rule-preset-ja-technical-writing` parity (issue #57, **R9**). tsuzulint covered **14 of the preset's 23 rules**; this stack adds the missing 9 so the benchmark gate (R17) can compare the *full* preset apples-to-apples. **PR 2/2** (`feat/r9-lexical-repetition-parity`) stacks on this branch.

### This PR — the 5 **surface** (no-morphology) parity rules
| rule | what it flags | applicability |
| --- | --- | --- |
| `max-comma` | too many ASCII commas `,` per sentence (default >3) — sibling of `max-ten` | JA-only |
| `no-invalid-control-character` | invalid C0 / DEL control characters | **neutral** |
| `no-unmatched-pair` | unmatched brackets/quotes within a text block | JA-only |
| `ja-unnatural-alphabet` | a stray single Latin letter sandwiched between Japanese chars (likely IME input error) | JA-only |
| `arabic-kanji-numbers` | Arabic vs. kanji numeral usage (JTF style guide 2.2.2) | JA-only |

- **Report-only** (no autofix this round); conservative (false-negatives preferred over false-positives).
- Registered in `RULE_IDS` / `build_rule`; JA-only rules tagged via the R5 applicability descriptor. `no-invalid-control-character` is language-neutral (runs on untagged text too).
- Each rule's semantics were cross-checked against its upstream textlint rule. Deferred/divergences are documented in each module's header (e.g. `arabic-kanji-numbers` is a conservative JTF-2.2.2 port without the upstream autofix; `no-unmatched-pair` follows upstream's pair list and is scoped JA-only to avoid firing on English/code).
- `just check` green (workspace 662 tests). Preset wiring into `ja-technical-writing` is **R12** (follow-up); the benchmark is **R17**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 日本語テキスト検証用の5つの新しいルールを追加：`max-comma`（カンマ数上限）、`no-invalid-control-character`（無効な制御文字）、`no-unmatched-pair`（括弧の対応確認）、`ja-unnatural-alphabet`（日本語に挟まれた単独英字）、`arabic-kanji-numbers`（漢数字と算用数字の使い分け）。
  * ルール違反は警告としてレポートされます。
* **Documentation**
  * プリセットのサーフェス対応（`textlint-rule-preset-ja-technical-writing`）に関する追記（Report-only）を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->