### PR TITLE
feat(rules): lexical & repetition parity rules toward textlint-ja-technical-writing (R9, 2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ accumulate as the release is built.
   never flagged); its opt-in `detectOrphanedClosers` option additionally flags orphaned Japanese
   quotation/corner-bracket closers (`」` `』` `】` and guillemets), which can never be enumeration
   markers.
+- **Lexical & repetition parity rules (`textlint-rule-preset-ja-technical-writing`).**
+  `ja-no-weak-phrase` (flags weak / hedging expressions such as the 「かも」 family),
+  `ja-no-abusage` (flags common Japanese misuses, 誤用, from a ported dictionary),
+  `no-doubled-conjunction` (flags the same 接続詞 opening consecutive sentences), and
+  `ja-no-successive-word` (flags a word repeated in immediate succession) — the
+  lexicon / morphology half of the preset-parity gap. `no-doubled-conjunction` and
+  `ja-no-successive-word` are morphology-backed (no-ops until a dictionary is configured).
+  Report-only.
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/crates/tzlint_rules/src/lib.rs
+++ b/crates/tzlint_rules/src/lib.rs
@@ -22,19 +22,21 @@ use serde_json::Value;
 use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
 
 use rules::{
-    arabic_kanji_numbers, ja_no_mixed_period, ja_no_redundant_expression, ja_prh,
-    ja_unnatural_alphabet, max_comma, max_kanji_continuous_len, max_ten, no_double_negative_ja,
+    arabic_kanji_numbers, ja_no_abusage, ja_no_mixed_period, ja_no_redundant_expression,
+    ja_no_successive_word, ja_no_weak_phrase, ja_prh, ja_unnatural_alphabet, max_comma,
+    max_kanji_continuous_len, max_ten, no_double_negative_ja, no_doubled_conjunction,
     no_doubled_conjunctive_particle_ga, no_doubled_joshi, no_dropping_the_ra,
     no_exclamation_question_mark, no_hankaku_kana, no_invalid_control_character,
     no_mix_dearu_desumasu, no_mixed_zenkaku_hankaku_alphabet, no_nfd, no_todo, no_unmatched_pair,
     no_zero_width_spaces, sentence_length,
 };
 pub use rules::{
-    arabic_kanji_numbers::ArabicKanjiNumbers, ja_no_mixed_period::JaNoMixedPeriod,
-    ja_no_redundant_expression::JaNoRedundantExpression, ja_prh::JaPrh,
+    arabic_kanji_numbers::ArabicKanjiNumbers, ja_no_abusage::JaNoAbusage,
+    ja_no_mixed_period::JaNoMixedPeriod, ja_no_redundant_expression::JaNoRedundantExpression,
+    ja_no_successive_word::JaNoSuccessiveWord, ja_no_weak_phrase::JaNoWeakPhrase, ja_prh::JaPrh,
     ja_unnatural_alphabet::JaUnnaturalAlphabet, max_comma::MaxComma,
     max_kanji_continuous_len::MaxKanjiContinuousLen, max_ten::MaxTen,
-    no_double_negative_ja::NoDoubleNegativeJa,
+    no_double_negative_ja::NoDoubleNegativeJa, no_doubled_conjunction::NoDoubledConjunction,
     no_doubled_conjunctive_particle_ga::NoDoubledConjunctiveParticleGa,
     no_doubled_joshi::NoDoubledJoshi, no_dropping_the_ra::NoDroppingTheRa,
     no_exclamation_question_mark::NoExclamationQuestionMark, no_hankaku_kana::NoHankakuKana,
@@ -70,6 +72,10 @@ pub const RULE_IDS: &[&str] = &[
     no_unmatched_pair::ID,
     ja_unnatural_alphabet::ID,
     arabic_kanji_numbers::ID,
+    no_doubled_conjunction::ID,
+    ja_no_successive_word::ID,
+    ja_no_weak_phrase::ID,
+    ja_no_abusage::ID,
 ];
 
 /// Construct a single built-in rule by `id`, applying config `options` (through the rule's
@@ -104,6 +110,10 @@ pub fn build_rule(id: &str, options: &Value, severity: Option<Severity>) -> Opti
         no_unmatched_pair::ID => Box::new(NoUnmatchedPair::from_options(options)),
         ja_unnatural_alphabet::ID => Box::new(JaUnnaturalAlphabet::new()),
         arabic_kanji_numbers::ID => Box::new(ArabicKanjiNumbers::new()),
+        no_doubled_conjunction::ID => Box::new(NoDoubledConjunction::new()),
+        ja_no_successive_word::ID => Box::new(JaNoSuccessiveWord::from_options(options)),
+        ja_no_weak_phrase::ID => Box::new(JaNoWeakPhrase::new()),
+        ja_no_abusage::ID => Box::new(JaNoAbusage::new()),
         _ => return None,
     };
     Some(match severity {
@@ -204,6 +214,10 @@ mod tests {
             "no-unmatched-pair",                  // JA-only (surface bracket matching)
             "ja-unnatural-alphabet",              // JA-only (surface)
             "arabic-kanji-numbers",               // JA-only (surface, JTF 2.2.2)
+            "no-doubled-conjunction",             // JA via its morphology pin
+            "ja-no-successive-word",              // JA via its morphology pin
+            "ja-no-weak-phrase",                  // JA-only (surface weak-phrase dictionary)
+            "ja-no-abusage",                      // JA-only (surface misuse dictionary)
         ];
 
         for id in RULE_IDS {
@@ -311,6 +325,19 @@ mod tests {
             ArabicKanjiNumbers::default().meta().id.as_str(),
             "arabic-kanji-numbers"
         );
+        assert_eq!(
+            NoDoubledConjunction::default().meta().id.as_str(),
+            "no-doubled-conjunction"
+        );
+        assert_eq!(
+            JaNoSuccessiveWord::default().meta().id.as_str(),
+            "ja-no-successive-word"
+        );
+        assert_eq!(
+            JaNoWeakPhrase::default().meta().id.as_str(),
+            "ja-no-weak-phrase"
+        );
+        assert_eq!(JaNoAbusage::default().meta().id.as_str(), "ja-no-abusage");
     }
 
     #[test]

--- a/crates/tzlint_rules/src/rules/ja_no_abusage.rs
+++ b/crates/tzlint_rules/src/rules/ja_no_abusage.rs
@@ -1,0 +1,389 @@
+//! `ja-no-abusage` — flag common Japanese misuses (誤用) from a fixed dictionary, reporting the
+//! incorrect form and the recommended correct form. Ported from
+//! `textlint-ja/textlint-rule-ja-no-abusage`.
+//!
+//! A **surface** rule (Japanese). Upstream ships both a `dictionary.ts` (morpheme-token-matched
+//! entries) and a `dict/prh.yml` (surface substitution entries). This port implements:
+//!
+//! - **All non-regex prh.yml entries** as exact substring matches: 39 entries.
+//! - **2 of 4 `dictionary.ts` entries** as exact surface matches (「を適応」→適用 and 「可変する」),
+//!   which are safe without token-boundary checks.
+//!
+//! **Deferred** (not ported, documented below):
+//! - The `ずらい/づらい` morpheme entries (entries 3 & 4 of dictionary.ts): they require
+//!   confirming the preceding token is a verb 連用形, which demands morphology. Ported zero rather
+//!   than risk false positives on e.g. standalone 「ずら」strings.
+//! - All prh.yml entries whose `patterns` field is a regex (`/…/`): 15 entries. These need
+//!   a regex engine and optional capture groups; porting them faithfully without that machinery
+//!   would require hard-coding each specific alternative, which risks mis-coverage.
+//!
+//! Total ported: **41 entries** (39 prh.yml fixed-string + 2 dictionary.ts surface-safe).
+//! Report-only (no autofix).
+
+use tzlint_ast::morphology::Lang;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "ja-no-abusage";
+
+/// A single dictionary entry: the misused phrase, the correct form, and the diagnostic message.
+struct Entry {
+    /// The misused surface substring (UTF-8) to search for.
+    wrong: &'static str,
+    /// Japanese diagnostic message, including the correct form.
+    message: &'static str,
+}
+
+/// The ported dictionary. 41 entries total.
+///
+/// Sources:
+/// - `dict/prh.yml` (fixed-string patterns only, 39 entries)
+/// - `src/dictionary.ts` entries 1 and 2 (surface-safe without morphology, 2 entries)
+static DICT: &[Entry] = &[
+    // ── From src/dictionary.ts ──────────────────────────────────────────────────────────────────
+    // Entry 1: を適応 → を適用
+    Entry {
+        wrong: "を適応",
+        message: "「を適応」は「を適用」の誤用である可能性があります。適応 → 適用",
+    },
+    // Entry 2: 可変する → (no specific replacement; "可変" is not a verb in standard usage)
+    Entry {
+        wrong: "可変する",
+        message: "「可変する」という使い方は適切ではありません。「可逆」と同じ使い方になります。\
+可変は状態の形容であり、「変更できる」「可変長の」などの形で使ってください。",
+    },
+    // ── From dict/prh.yml (fixed-string patterns only) ─────────────────────────────────────────
+    Entry {
+        wrong: "値を返却する",
+        message: "「値を返却する」は「値を返す」の誤用です。正しくは「値を返す」。",
+    },
+    Entry {
+        wrong: "例外を補足",
+        message: "「例外を補足」は「例外を捕捉」の誤用です。正しくは「例外を捕捉」。",
+    },
+    Entry {
+        wrong: "似て異なるもの",
+        message: "「似て異なるもの」は「似て非なるもの」の誤用です。正しくは「似て非なるもの」。",
+    },
+    Entry {
+        wrong: "愛苦しい",
+        message: "「愛苦しい」は「愛くるしい」の誤用です。正しくは「愛くるしい」。",
+    },
+    Entry {
+        wrong: "悪どい",
+        message: "「悪どい」は「あくどい」の誤用です。正しくは「あくどい」。",
+    },
+    Entry {
+        wrong: "転稼",
+        message: "「転稼」は「転嫁」の誤用です。正しくは「転嫁」。",
+    },
+    Entry {
+        wrong: "こんにちわ",
+        message: "「こんにちわ」は「こんにちは」の誤用です。正しくは「こんにちは」。",
+    },
+    Entry {
+        wrong: "論戦を張る",
+        message: "「論戦を張る」は「論陣を張る」の誤用です。正しくは「論陣を張る」。",
+    },
+    Entry {
+        wrong: "寸暇を惜しまず",
+        message: "「寸暇を惜しまず」は「寸暇を惜しんで」の誤用です。正しくは「寸暇を惜しんで」。",
+    },
+    Entry {
+        wrong: "寸暇を置かず",
+        message: "「寸暇を置かず」は「間を置かず」の誤用です。正しくは「間を置かず」。",
+    },
+    Entry {
+        wrong: "一つ返事",
+        message: "「一つ返事」は「二つ返事」の誤用です。正しくは「二つ返事」。",
+    },
+    Entry {
+        wrong: "怒り心頭に達する",
+        message: "「怒り心頭に達する」は「怒り心頭に発する」の誤用です。正しくは「怒り心頭に発する」。",
+    },
+    Entry {
+        wrong: "熱にうなされる",
+        message: "「熱にうなされる」は「熱に浮かされる」の誤用です。正しくは「熱に浮かされる」。",
+    },
+    Entry {
+        wrong: "やるせぬ",
+        message: "「やるせぬ」は「やるせない」の誤用です。正しくは「やるせない」。",
+    },
+    Entry {
+        wrong: "雪辱を晴らす",
+        message: "「雪辱を晴らす」は「雪辱を果たす」の誤用です。正しくは「雪辱を果たす」。",
+    },
+    Entry {
+        wrong: "うる覚え",
+        message: "「うる覚え」は「うろ覚え」の誤用です。正しくは「うろ覚え」。",
+    },
+    Entry {
+        wrong: "口先三寸",
+        message: "「口先三寸」は「舌先三寸」の誤用です。正しくは「舌先三寸」。",
+    },
+    Entry {
+        wrong: "舌の先の乾かぬ",
+        message: "「舌の先の乾かぬ」は「舌の根の乾かぬ」の誤用です。正しくは「舌の根の乾かぬ」。",
+    },
+    Entry {
+        wrong: "悪評さくさく",
+        message: "「悪評さくさく」は「悪評高い」の誤用です。正しくは「悪評高い」。",
+    },
+    Entry {
+        wrong: "悪評嘖嘖",
+        message: "「悪評嘖嘖」は「悪評高い」の誤用です。正しくは「悪評高い」。",
+    },
+    Entry {
+        wrong: "悪評嘖々",
+        message: "「悪評嘖々」は「悪評高い」の誤用です。正しくは「悪評高い」。",
+    },
+    Entry {
+        wrong: "器管",
+        message: "「器管」は「器官」の誤用です。正しくは「器官」。",
+    },
+    Entry {
+        wrong: "上や下への",
+        message: "「上や下への」は「上を下への」の誤用です。正しくは「上を下への」。",
+    },
+    Entry {
+        wrong: "上へ下への",
+        message: "「上へ下への」は「上を下への」の誤用です。正しくは「上を下への」。",
+    },
+    Entry {
+        wrong: "押しも押されぬ",
+        message: "「押しも押されぬ」は「押しも押されもせぬ」の誤用です。正しくは「押しも押されもせぬ」。",
+    },
+    Entry {
+        wrong: "掻き入れ",
+        message: "「掻き入れ」は「書き入れ」の誤用です。正しくは「書き入れ」。",
+    },
+    Entry {
+        wrong: "引くに引かれない",
+        message: "「引くに引かれない」は「引くに引けない」の誤用です。正しくは「引くに引けない」。",
+    },
+    Entry {
+        wrong: "死ぬに死なれない",
+        message: "「死ぬに死なれない」は「死ぬに死ねない」の誤用です。正しくは「死ぬに死ねない」。",
+    },
+    Entry {
+        wrong: "腹が煮えくり返る",
+        message: "「腹が煮えくり返る」は「腸が煮えくり返る」の誤用です。正しくは「腸が煮えくり返る」。",
+    },
+    Entry {
+        wrong: "胸先三寸",
+        message: "「胸先三寸」は「胸三寸」の誤用です。正しくは「胸三寸」。",
+    },
+    Entry {
+        wrong: "肝に据えかねる",
+        message: "「肝に据えかねる」は「腹に据えかねる」の誤用です。正しくは「腹に据えかねる」。",
+    },
+    Entry {
+        wrong: "へそを抱えて",
+        message: "「へそを抱えて」は「腹を抱えて」の誤用です。正しくは「腹を抱えて」。",
+    },
+    Entry {
+        wrong: "後ろ立て",
+        message: "「後ろ立て」は「後ろ盾」の誤用です。正しくは「後ろ盾」。",
+    },
+    Entry {
+        wrong: "絶対絶命",
+        message: "「絶対絶命」は「絶体絶命」の誤用です。正しくは「絶体絶命」。",
+    },
+    Entry {
+        wrong: "有頂点",
+        message: "「有頂点」は「有頂天」の誤用です。正しくは「有頂天」。",
+    },
+    Entry {
+        wrong: "一発即発",
+        message: "「一発即発」は「一触即発」の誤用です。正しくは「一触即発」。",
+    },
+    Entry {
+        wrong: "意気高々",
+        message: "「意気高々」は「意気揚々」の誤用です。正しくは「意気揚々」。",
+    },
+    Entry {
+        wrong: "青色吐息",
+        message: "「青色吐息」は「青息吐息」の誤用です。正しくは「青息吐息」。",
+    },
+    Entry {
+        wrong: "固定概念",
+        message: "「固定概念」は「固定観念」の誤用です。正しくは「固定観念」。",
+    },
+    Entry {
+        wrong: "目を止め",
+        message: "「目を止め」は「目を留め」の誤用です。「止」は動作の停止、「留」は意識を向ける時に使います。正しくは「目を留め」。",
+    },
+    Entry {
+        wrong: "睨みを効かせ",
+        message: "「睨みを効かせ」は「睨みを利かせ」の誤用です。正しくは「睨みを利かせ」。",
+    },
+    Entry {
+        wrong: "恩を着る",
+        message: "「恩を着る」は「恩に着る」の誤用です。正しくは「恩に着る」。",
+    },
+    Entry {
+        wrong: "脚光を集め",
+        message: "「脚光を集め」は「脚光を浴び」の誤用です。正しくは「脚光を浴び」。",
+    },
+    Entry {
+        wrong: "一同に会する",
+        message: "「一同に会する」は「一堂に会する」の誤用です。正しくは「一堂に会する」。",
+    },
+];
+
+/// Flags common Japanese misuses (誤用).
+pub struct JaNoAbusage {
+    meta: RuleMeta,
+}
+
+impl JaNoAbusage {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        JaNoAbusage {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .for_language(Lang::JA),
+        }
+    }
+}
+
+impl Default for JaNoAbusage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for JaNoAbusage {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+
+        for entry in DICT {
+            let phrase_len = entry.wrong.len();
+            let mut search_from = 0usize;
+            while let Some(rel) = text[search_from..].find(entry.wrong) {
+                let abs = search_from + rel;
+                let abs_start = base.saturating_add(abs as u32);
+                let abs_end = base.saturating_add((abs + phrase_len) as u32);
+                cx.report(Span::new(abs_start, abs_end), entry.message);
+                search_from = abs + phrase_len;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_tekiou() {
+        let diags = diagnose(&JaNoAbusage::new(), "法律を適応する。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(diags[0].message.contains("適用"), "{}", diags[0].message);
+    }
+
+    #[test]
+    fn flags_kahen_suru() {
+        let diags = diagnose(&JaNoAbusage::new(), "長さを可変する。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("可変する"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_chikku_kaeshi() {
+        let diags = diagnose(&JaNoAbusage::new(), "値を返却する関数。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("値を返す"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_konnichiwa() {
+        let diags = diagnose(&JaNoAbusage::new(), "こんにちわ、世界。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("こんにちは"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_zettai_zetsumei() {
+        let diags = diagnose(&JaNoAbusage::new(), "絶対絶命のピンチ。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("絶体絶命"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_koteigainen() {
+        let diags = diagnose(&JaNoAbusage::new(), "固定概念にとらわれている。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("固定観念"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_kanou() {
+        let diags = diagnose(&JaNoAbusage::new(), "悪評嘖々の製品。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("悪評高い"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_uri_kae() {
+        let diags = diagnose(&JaNoAbusage::new(), "うる覚えで書いた。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("うろ覚え"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn clean_text_is_not_flagged() {
+        // Correct forms should not trigger.
+        assert!(diagnose(&JaNoAbusage::new(), "こんにちは、絶体絶命の危機。\n").is_empty());
+        assert!(diagnose(&JaNoAbusage::new(), "法律を適用する。\n").is_empty());
+        assert!(diagnose(&JaNoAbusage::new(), "うろ覚えで書いた。\n").is_empty());
+    }
+
+    #[test]
+    fn flags_span_is_tight_on_wrong_phrase() {
+        // 「こんにちわ」is 15 bytes (5 chars × 3 bytes each in UTF-8).
+        let diags = diagnose(&JaNoAbusage::new(), "こんにちわ、世界。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        // The span should cover exactly the 5-character wrong phrase (bytes 0..15).
+        assert_eq!(diags[0].span.start, 0, "span start");
+        assert_eq!(diags[0].span.end, 15, "span end"); // 5 chars × 3 bytes
+    }
+}

--- a/crates/tzlint_rules/src/rules/ja_no_successive_word.rs
+++ b/crates/tzlint_rules/src/rules/ja_no_successive_word.rs
@@ -1,0 +1,382 @@
+//! `ja-no-successive-word` — flag the same word appearing twice in immediate succession
+//! (e.g. 「私は 私は」, 「の の」), which is typically a typo or copy-paste error.
+//!
+//! A **morphology-dependent** rule (Japanese, via [`with_morphology`](RuleMeta::with_morphology)).
+//! Adjacent tokens are compared by surface form; the second of the duplicate pair is reported.
+//! Two categories are excluded by default:
+//!
+//! - **漢数字** (`名詞` + `POS_SUB_1 = "数"`): repeated kanji numerals are idiomatic
+//!   (e.g. 「九九」 = multiplication table).
+//! - **オノマトペ** (katakana-only surface): repeated onomatopoeia is idiomatic
+//!   (e.g. 「ドキドキ」, `allowOnomatopee` is `true` by default).
+//!
+//! Both exclusions can be overridden via `from_options`. An `allow` list (surface strings,
+//! RegExp-style matching is not supported here — exact match only) further suppresses specific
+//! words. Keys on all POS values, so an unrecognised tagset still compares surfaces — the rule
+//! fires on any token sequence regardless of tagset; `is_unknown()` tokens are excluded.
+
+use serde_json::Value;
+use tzlint_ast::NodeKind;
+use tzlint_ast::morphology::{ArchivedMorphologyV1, ArchivedToken, FeatureKey, Lang};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "ja-no-successive-word";
+
+/// Flags the same word used twice in immediate succession.
+pub struct JaNoSuccessiveWord {
+    meta: RuleMeta,
+    /// Whether to exempt katakana-only surfaces (オノマトペ, e.g. 「ドキドキ」). Default: `true`.
+    allow_onomatopee: bool,
+    /// Additional surfaces to suppress (exact match).
+    allow: Vec<String>,
+}
+
+impl JaNoSuccessiveWord {
+    /// Construct with default options (`allow_onomatopee` = true, empty `allow`).
+    pub fn new() -> Self {
+        JaNoSuccessiveWord {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .with_morphology(Lang::JA),
+            allow_onomatopee: true,
+            allow: Vec::new(),
+        }
+    }
+
+    /// Construct from config `options`, leniently (missing/wrong-typed values keep defaults):
+    /// `allowOnomatopee` (bool), `allow` (array of surface strings).
+    pub fn from_options(options: &Value) -> Self {
+        let mut rule = Self::new();
+        if let Some(v) = options.get("allowOnomatopee").and_then(Value::as_bool) {
+            rule.allow_onomatopee = v;
+        }
+        if let Some(array) = options.get("allow").and_then(Value::as_array) {
+            rule.allow = array
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect();
+        }
+        rule
+    }
+}
+
+impl Default for JaNoSuccessiveWord {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for JaNoSuccessiveWord {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let Some(table) = cx.morphology() else {
+            return; // belt-and-suspenders over the engine's morphology gate
+        };
+        let ast = cx.ast();
+
+        // Collect and sort tokens into source order.
+        let mut tokens: Vec<&ArchivedToken> = cx.tokens_of(node.id()).collect();
+        tokens.sort_by_key(|t| (t.surface().start, t.surface().end));
+
+        // Walk adjacent pairs: compare `prev` and `curr` by surface form.
+        let mut prev_surface: Option<&str> = None;
+        let mut prev_is_number = false;
+        for &tok in &tokens {
+            if tok.is_unknown() {
+                prev_surface = None;
+                prev_is_number = false;
+                continue;
+            }
+            let surface = match ast.text_of(tok.surface()) {
+                Some(s) => s,
+                None => {
+                    prev_surface = None;
+                    prev_is_number = false;
+                    continue;
+                }
+            };
+            let curr_is_number = is_kanji_number(tok, table);
+
+            if let Some(prev) = prev_surface
+                && prev == surface
+            {
+                // Exception 1: both tokens are 漢数字 (e.g. 「九九」) → idiomatic.
+                if prev_is_number && curr_is_number {
+                    prev_surface = Some(surface);
+                    prev_is_number = curr_is_number;
+                    continue;
+                }
+                // Exception 2: katakana-only surface → onomatopoeia → idiomatic (if enabled).
+                if self.allow_onomatopee && is_katakana_only(surface) {
+                    prev_surface = Some(surface);
+                    prev_is_number = curr_is_number;
+                    continue;
+                }
+                // Exception 3: explicit allow list.
+                if self.allow.iter().any(|a| a == surface) {
+                    prev_surface = Some(surface);
+                    prev_is_number = curr_is_number;
+                    continue;
+                }
+                cx.report(
+                    tok.surface(),
+                    format!("\"{}\" が連続して2回使われています。", surface),
+                );
+            }
+
+            prev_surface = Some(surface);
+            prev_is_number = curr_is_number;
+        }
+    }
+}
+
+/// Whether `tok` is a 漢数字 token (名詞 + POS_SUB_1 = 数).
+fn is_kanji_number(tok: &ArchivedToken, table: &ArchivedMorphologyV1) -> bool {
+    feature(tok, table, FeatureKey::POS) == Some("名詞")
+        && feature(tok, table, FeatureKey::POS_SUB_1) == Some("数")
+}
+
+/// Whether `s` consists entirely of katakana characters and the long-vowel mark (ー).
+/// Matches the upstream `isOnomatopee` regex: `/^[ァ-ロワヲンー]*$/`.
+fn is_katakana_only(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    s.chars().all(|c| {
+        // ァ (U+30A1) .. ロ (U+30ED), plus ワ (U+30EF), ヲ (U+30F2), ン (U+30F3), ー (U+30FC).
+        // The upstream regex class [ァ-ロワヲンー] is unusual — it does not include ヰ/ヱ/ヴ etc.
+        // We replicate it exactly.
+        matches!(
+            c,
+            '\u{30A1}'..='\u{30ED}' | '\u{30EF}' | '\u{30F2}' | '\u{30F3}' | '\u{30FC}'
+        )
+    })
+}
+
+/// Resolve a feature value (e.g. POS) of `token` against `table`, or `None`.
+fn feature<'a>(
+    token: &ArchivedToken,
+    table: &'a ArchivedMorphologyV1,
+    key: FeatureKey,
+) -> Option<&'a str> {
+    token
+        .features(table)
+        .find(|(k, _)| *k == key)
+        .and_then(|(_, value)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{diagnose, diagnose_with_morphology};
+    use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+    use tzlint_ast::{NodeId, Span};
+
+    /// Push a token with given features at `[start, end)`.
+    fn push(
+        b: &mut MorphologyBuilder,
+        node: NodeId,
+        start: u32,
+        end: u32,
+        feats: &[(FeatureKey, &str)],
+    ) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags: 0,
+            },
+            None,
+            None,
+            feats,
+        );
+    }
+
+    /// A plain noun token.
+    fn noun(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(b, node, start, end, &[(FeatureKey::POS, "名詞")]);
+    }
+
+    /// A 漢数字 token (名詞 + 数).
+    fn kanji_num(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            &[(FeatureKey::POS, "名詞"), (FeatureKey::POS_SUB_1, "数")],
+        );
+    }
+
+    /// A particle token (助詞).
+    fn particle(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(b, node, start, end, &[(FeatureKey::POS, "助詞")]);
+    }
+
+    #[test]
+    fn flags_adjacent_duplicate_noun() {
+        // 「私は 私は」 — two 私 tokens adjacent (treating は as unrelated).
+        // We'll use two adjacent 私 noun tokens for simplicity.
+        // 私(0..3) 私(3..6)
+        let diags = diagnose_with_morphology(&JaNoSuccessiveWord::new(), "私私", |p, b| {
+            noun(b, p, 0, 3);
+            noun(b, p, 3, 6);
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (3, 6));
+        assert!(
+            diags[0].message.contains("\"私\" が連続して2回"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn different_adjacent_words_are_clean() {
+        // 「私は彼は」 — different surfaces → no diagnostic.
+        let diags = diagnose_with_morphology(&JaNoSuccessiveWord::new(), "私は彼は", |p, b| {
+            noun(b, p, 0, 3); // 私
+            particle(b, p, 3, 6); // は
+            noun(b, p, 6, 9); // 彼
+            particle(b, p, 9, 12); // は
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn kanji_number_duplicate_is_exempt() {
+        // 「九九」 — two 九 kanji-number tokens → idiomatic, not flagged.
+        let diags = diagnose_with_morphology(&JaNoSuccessiveWord::new(), "九九", |p, b| {
+            kanji_num(b, p, 0, 3); // 九 (1st)
+            kanji_num(b, p, 3, 6); // 九 (2nd)
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn kanji_number_exempt_only_when_both_are_numbers() {
+        // If one is a 名詞/数 and the other is a plain 名詞, the exemption does NOT apply.
+        let diags = diagnose_with_morphology(&JaNoSuccessiveWord::new(), "九九", |p, b| {
+            kanji_num(b, p, 0, 3); // 九 (数)
+            noun(b, p, 3, 6); // 九 (plain noun — not a number)
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn katakana_duplicate_is_exempt_by_default() {
+        // 「ドキドキ」-style: two identical katakana tokens → onomatopoeia exempt.
+        // ドキ is within the katakana range ァ-ロ.
+        let diags = diagnose_with_morphology(&JaNoSuccessiveWord::new(), "ドキドキ", |p, b| {
+            noun(b, p, 0, 6); // ドキ (3 bytes each katakana char × 2 chars)
+            noun(b, p, 6, 12); // ドキ
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn katakana_duplicate_flagged_when_allow_onomatopee_false() {
+        // With `allowOnomatopee:false`, even katakana repetitions are flagged.
+        let rule = JaNoSuccessiveWord::from_options(&serde_json::json!({"allowOnomatopee": false}));
+        let diags = diagnose_with_morphology(&rule, "ドキドキ", |p, b| {
+            noun(b, p, 0, 6);
+            noun(b, p, 6, 12);
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("\"ドキ\""),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn allow_list_suppresses_specific_surface() {
+        // allow:["の"] suppresses の×2.
+        let rule = JaNoSuccessiveWord::from_options(&serde_json::json!({"allow": ["の"]}));
+        let diags = diagnose_with_morphology(&rule, "のの", |p, b| {
+            particle(b, p, 0, 3); // の
+            particle(b, p, 3, 6); // の
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+        // Without allow, の×2 is flagged.
+        let flagged = diagnose_with_morphology(&JaNoSuccessiveWord::new(), "のの", |p, b| {
+            particle(b, p, 0, 3);
+            particle(b, p, 3, 6);
+        });
+        assert_eq!(flagged.len(), 1);
+    }
+
+    #[test]
+    fn unknown_tokens_break_the_chain() {
+        // An OOV (unknown) token between two identical surfaces resets the prev pointer.
+        use tzlint_ast::morphology::Token;
+        let diags = diagnose_with_morphology(&JaNoSuccessiveWord::new(), "私X私", |p, b| {
+            noun(b, p, 0, 3); // 私
+            b.push_token(
+                TokenAttrs {
+                    node: p,
+                    surface: Span::new(3, 4),
+                    lang: Lang::JA,
+                    tagset: Tagset::IPADIC,
+                    flags: Token::FLAG_UNKNOWN,
+                },
+                None,
+                None,
+                &[],
+            ); // X (unknown)
+            noun(b, p, 4, 7); // 私
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn particle_duplicate_is_flagged() {
+        // の×2 (non-katakana, not a number) → flagged.
+        let diags = diagnose_with_morphology(&JaNoSuccessiveWord::new(), "のの", |p, b| {
+            particle(b, p, 0, 3); // の
+            particle(b, p, 3, 6); // の
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn three_in_a_row_flags_the_second_and_third() {
+        // A A A → report the 2nd and 3rd.
+        let diags = diagnose_with_morphology(&JaNoSuccessiveWord::new(), "私私私", |p, b| {
+            noun(b, p, 0, 3);
+            noun(b, p, 3, 6);
+            noun(b, p, 6, 9);
+        });
+        assert_eq!(diags.len(), 2, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (3, 6));
+        assert_eq!((diags[1].span.start, diags[1].span.end), (6, 9));
+    }
+
+    #[test]
+    fn no_op_without_a_morphology_table() {
+        assert!(diagnose(&JaNoSuccessiveWord::new(), "私私").is_empty());
+    }
+
+    #[test]
+    fn is_katakana_only_helper() {
+        // Internal helper tests: cover all branches.
+        assert!(is_katakana_only("ドキ"));
+        assert!(is_katakana_only("ワヲン"));
+        assert!(is_katakana_only("ー"));
+        assert!(!is_katakana_only("")); // empty → false
+        assert!(!is_katakana_only("ABC")); // ASCII
+        assert!(!is_katakana_only("私")); // kanji
+        assert!(!is_katakana_only("ドき")); // mixed hiragana
+    }
+}

--- a/crates/tzlint_rules/src/rules/ja_no_weak_phrase.rs
+++ b/crates/tzlint_rules/src/rules/ja_no_weak_phrase.rs
@@ -1,0 +1,207 @@
+//! `ja-no-weak-phrase` — flag weak or uncertain expressions (弱い表現) that undermine technical
+//! writing confidence. Ported from `textlint-ja/textlint-rule-ja-no-weak-phrase`.
+//!
+//! A **surface** rule (Japanese). Upstream uses morpheme-token matching; this port implements the
+//! same intent via exact substring search on the text of each inline node. The dictionary covers
+//! the full upstream set of 5 patterns:
+//!
+//! 1. `かも。` — hedge + sentence terminator (副助詞「かも」直後に句点)
+//! 2. `かもしれ` — 「かもしれない / かもしれません」family
+//! 3. `思う` — 思う base form (e.g. 「〜と思う」)
+//! 4. `思います` — polite form (「〜と思います」)
+//! 5. `可能性を示唆している` — "suggests a possibility" (double-hedging)
+//!
+//! Surface search is conservative: every flagged substring is a genuine weak expression in
+//! Japanese technical writing. Report-only (no autofix).
+
+use tzlint_ast::morphology::Lang;
+use tzlint_ast::{NodeKind, Span};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "ja-no-weak-phrase";
+
+/// A single dictionary entry: the substring to match and the Japanese diagnostic message.
+struct Entry {
+    /// The surface substring (UTF-8) to search for.
+    phrase: &'static str,
+    /// Japanese diagnostic message.
+    message: &'static str,
+}
+
+/// The upstream dictionary, ported faithfully. 5 entries total.
+static DICT: &[Entry] = &[
+    // Entry 1: かも + 句点 (sentence-final hedge)
+    Entry {
+        phrase: "かも。",
+        message: "弱い表現「かも」が使われています。断言できる表現に書き換えてください。",
+    },
+    // Entry 2: かもしれ (かもしれない / かもしれません)
+    Entry {
+        phrase: "かもしれ",
+        message: "弱い表現「かもしれ」が使われています。断言できる表現に書き換えてください。",
+    },
+    // Entry 3: 思う (base form) — 「〜と思う」
+    Entry {
+        phrase: "思う",
+        message: "弱い表現「思う」が使われています。断言できる表現に書き換えてください。",
+    },
+    // Entry 4: 思います (polite form)
+    Entry {
+        phrase: "思います",
+        message: "弱い表現「思います」が使われています。断言できる表現に書き換えてください。",
+    },
+    // Entry 5: 可能性を示唆している — double-hedging expression
+    Entry {
+        phrase: "可能性を示唆している",
+        message: "弱い表現「可能性を示唆している」が使われています。\
+「可能性がある」または「…を示唆している」を利用してください。\
+弱い表現を二つ重ねることはしないでください。",
+    },
+];
+
+/// Flags weak/uncertain expressions in Japanese technical writing.
+pub struct JaNoWeakPhrase {
+    meta: RuleMeta,
+}
+
+impl JaNoWeakPhrase {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        JaNoWeakPhrase {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .for_language(Lang::JA),
+        }
+    }
+}
+
+impl Default for JaNoWeakPhrase {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for JaNoWeakPhrase {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let base = node.span().start;
+        let text = node.text();
+
+        // For each dictionary entry, report every non-overlapping occurrence in the node text.
+        // Entries 3 (思う) and 4 (思います) share a prefix; we must avoid double-reporting the
+        // 思います case as also 思う. We handle this by checking longer phrases first and skipping
+        // the shorter "思う" match when "思います" already covers the same position.
+        //
+        // Strategy: collect all (byte_start, byte_end, message) hits for all entries, then emit
+        // only those not already covered by a longer match that starts at the same position.
+        let mut hits: Vec<(usize, usize, &'static str)> = Vec::new();
+
+        for entry in DICT {
+            let phrase_bytes = entry.phrase.len();
+            let mut search_from = 0usize;
+            while let Some(rel) = text[search_from..].find(entry.phrase) {
+                let abs = search_from + rel;
+                hits.push((abs, abs + phrase_bytes, entry.message));
+                search_from = abs + phrase_bytes;
+            }
+        }
+
+        if hits.is_empty() {
+            return;
+        }
+
+        // Deduplicate: if a shorter phrase starts at the same position as a longer phrase, drop
+        // the shorter one. Sort by start asc, then by length desc so that for equal starts the
+        // longest hit appears first.
+        hits.sort_by(|a, b| a.0.cmp(&b.0).then(b.1.cmp(&a.1)));
+
+        let mut last_end = 0usize;
+        for (start, end, message) in hits {
+            if start < last_end {
+                // Overlapping with a previously emitted (longer) hit — skip.
+                continue;
+            }
+            let abs_start = base.saturating_add(start as u32);
+            let abs_end = base.saturating_add(end as u32);
+            cx.report(Span::new(abs_start, abs_end), message);
+            last_end = end;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::diagnose;
+
+    #[test]
+    fn flags_kamoshiremasen() {
+        // 「かもしれ」covers both ない and ません forms.
+        let diags = diagnose(&JaNoWeakPhrase::new(), "問題があるかもしれません。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("かもしれ"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_kamo_with_kuten() {
+        let diags = diagnose(&JaNoWeakPhrase::new(), "正しいかも。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(diags[0].message.contains("かも"), "{}", diags[0].message);
+    }
+
+    #[test]
+    fn flags_omou_base() {
+        let diags = diagnose(&JaNoWeakPhrase::new(), "良いと思う。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(diags[0].message.contains("思う"), "{}", diags[0].message);
+    }
+
+    #[test]
+    fn flags_omoimasu_not_double_reported() {
+        // 「思います」does NOT contain 「思う」as a substring (思う = 思 + う, 思います = 思 + い + ま + す),
+        // so only the 「思います」entry matches here — exactly one diagnostic. (The longer-match
+        // dedup is not what limits the count in this case.)
+        let diags = diagnose(&JaNoWeakPhrase::new(), "良いと思います。\n");
+        // Expect exactly one diagnostic (for 思います).
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("思います"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn flags_kanou_shisa() {
+        let diags = diagnose(&JaNoWeakPhrase::new(), "バグがある可能性を示唆している。\n");
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert!(
+            diags[0].message.contains("可能性を示唆している"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn multiple_weak_phrases_in_one_node() {
+        // 「思う」and「かもしれ」both present → two diagnostics.
+        let diags = diagnose(&JaNoWeakPhrase::new(), "良いと思うがかもしれない。\n");
+        assert_eq!(diags.len(), 2, "{diags:?}");
+    }
+
+    #[test]
+    fn clean_text_is_not_flagged() {
+        assert!(diagnose(&JaNoWeakPhrase::new(), "この手法は有効です。\n").is_empty());
+    }
+}

--- a/crates/tzlint_rules/src/rules/mod.rs
+++ b/crates/tzlint_rules/src/rules/mod.rs
@@ -1,14 +1,18 @@
 //! The built-in rules, one module each.
 
 pub mod arabic_kanji_numbers;
+pub mod ja_no_abusage;
 pub mod ja_no_mixed_period;
 pub mod ja_no_redundant_expression;
+pub mod ja_no_successive_word;
+pub mod ja_no_weak_phrase;
 pub mod ja_prh;
 pub mod ja_unnatural_alphabet;
 pub mod max_comma;
 pub mod max_kanji_continuous_len;
 pub mod max_ten;
 pub mod no_double_negative_ja;
+pub mod no_doubled_conjunction;
 pub mod no_doubled_conjunctive_particle_ga;
 pub mod no_doubled_joshi;
 pub mod no_dropping_the_ra;

--- a/crates/tzlint_rules/src/rules/no_doubled_conjunction.rs
+++ b/crates/tzlint_rules/src/rules/no_doubled_conjunction.rs
@@ -1,0 +1,327 @@
+//! `no-doubled-conjunction` — flag the same conjunction (接続詞) at the start of consecutive
+//! sentences within a paragraph (e.g. two sentences in a row both beginning with 「しかし」).
+//!
+//! A **morphology-dependent** rule (Japanese, via [`with_morphology`](RuleMeta::with_morphology)).
+//! It identifies the first 接続詞 token per sentence (skipping any 接続詞 immediately preceded by a
+//! whitespace token, which can appear as sentence separators), then reports the opening 接続詞 of
+//! the second sentence when it shares the same surface form as the one in the immediately preceding
+//! sentence. Keys on the IPADIC POS literal `"接続詞"`, so an unrecognised tagset simply matches
+//! nothing (a false negative, never a false positive).
+
+use tzlint_ast::NodeKind;
+use tzlint_ast::morphology::{ArchivedMorphologyV1, ArchivedToken, FeatureKey, Lang};
+use tzlint_pdk::{Context, NodeRef, Rule, RuleMeta, Severity};
+
+/// The rule id.
+pub const ID: &str = "no-doubled-conjunction";
+
+/// Sentence terminators that separate sentences within a block node.
+const TERMINATORS: [char; 7] = ['。', '．', '.', '！', '？', '!', '?'];
+
+/// Flags the same sentence-initial conjunction (接続詞) in consecutive sentences.
+pub struct NoDoubledConjunction {
+    meta: RuleMeta,
+}
+
+impl NoDoubledConjunction {
+    /// Construct the rule (no options).
+    pub fn new() -> Self {
+        NoDoubledConjunction {
+            meta: RuleMeta::new(
+                ID,
+                Severity::Warning,
+                vec![NodeKind::PARAGRAPH, NodeKind::HEADING, NodeKind::TABLE_CELL],
+            )
+            .with_morphology(Lang::JA),
+        }
+    }
+}
+
+impl Default for NoDoubledConjunction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Rule for NoDoubledConjunction {
+    fn meta(&self) -> &RuleMeta {
+        &self.meta
+    }
+
+    fn check<'ast>(&self, node: NodeRef<'ast>, cx: &mut Context<'ast>) {
+        let Some(table) = cx.morphology() else {
+            return; // belt-and-suspenders over the engine's morphology gate
+        };
+        let ast = cx.ast();
+        let base = node.span().start;
+        let text = node.text();
+
+        // Collect and sort tokens into source order.
+        let mut tokens: Vec<&ArchivedToken> = cx.tokens_of(node.id()).collect();
+        tokens.sort_by_key(|t| (t.surface().start, t.surface().end));
+
+        // The sentence index of a byte offset = the number of terminators before it in the block.
+        let sentence_idx = |start: u32| -> usize {
+            let upto = start.saturating_sub(base) as usize;
+            text.get(..upto)
+                .unwrap_or("")
+                .chars()
+                .filter(|c| TERMINATORS.contains(c))
+                .count()
+        };
+
+        // Build a list of (sentence_index, surface, span) for the FIRST 接続詞 of each sentence,
+        // skipping any 接続詞 whose immediately preceding token is a whitespace (空白) token —
+        // matching the upstream workaround for whitespace-as-separator misidentification.
+        //
+        // We collect per-sentence first-conjunctions keyed by sentence index: only the first
+        // 接続詞 in each sentence counts (upstream uses `current_tokens[0]`).
+        let mut first_per_sentence: Vec<(usize, &str, tzlint_ast::Span)> = Vec::new();
+
+        for (tok_idx, &tok) in tokens.iter().enumerate() {
+            if tok.is_unknown() {
+                continue;
+            }
+            if feature(tok, table, FeatureKey::POS) != Some("接続詞") {
+                continue;
+            }
+            // Skip if the immediately preceding token (in source order) is a whitespace token.
+            // IPADIC tags whitespace as 記号/空白 (POS_SUB_1 = "空白").
+            if tok_idx > 0 {
+                let prev = tokens[tok_idx - 1];
+                if !prev.is_unknown() && feature(prev, table, FeatureKey::POS_SUB_1) == Some("空白")
+                {
+                    continue;
+                }
+            }
+            let sidx = sentence_idx(tok.surface().start);
+            // Only record the first 接続詞 per sentence.
+            if first_per_sentence.last().map(|(s, _, _)| *s) == Some(sidx) {
+                continue;
+            }
+            let surface = ast.text_of(tok.surface()).unwrap_or("");
+            first_per_sentence.push((sidx, surface, tok.surface()));
+        }
+
+        // Report the opening 接続詞 of the current sentence whenever it matches the previous one.
+        for pair in first_per_sentence.windows(2) {
+            let (_, prev_surface, _) = pair[0];
+            let (_, curr_surface, curr_span) = pair[1];
+            if prev_surface == curr_surface && !curr_surface.is_empty() {
+                cx.report(
+                    curr_span,
+                    format!("同じ接続詞（{curr_surface}）が連続して使われています。"),
+                );
+            }
+        }
+    }
+}
+
+/// Resolve a feature value (e.g. POS) of `token` against `table`, or `None`.
+fn feature<'a>(
+    token: &ArchivedToken,
+    table: &'a ArchivedMorphologyV1,
+    key: FeatureKey,
+) -> Option<&'a str> {
+    token
+        .features(table)
+        .find(|(k, _)| *k == key)
+        .and_then(|(_, value)| value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{diagnose, diagnose_with_morphology};
+    use tzlint_ast::morphology::{MorphologyBuilder, Tagset, TokenAttrs};
+    use tzlint_ast::{NodeId, Span};
+
+    /// Push a token with a given POS (and optional POS_SUB_1) at `[start, end)`.
+    fn push(
+        b: &mut MorphologyBuilder,
+        node: NodeId,
+        start: u32,
+        end: u32,
+        feats: &[(FeatureKey, &str)],
+    ) {
+        b.push_token(
+            TokenAttrs {
+                node,
+                surface: Span::new(start, end),
+                lang: Lang::JA,
+                tagset: Tagset::IPADIC,
+                flags: 0,
+            },
+            None,
+            None,
+            feats,
+        );
+    }
+
+    /// A generic noun/word token.
+    fn word(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(b, node, start, end, &[(FeatureKey::POS, "名詞")]);
+    }
+
+    /// A 接続詞 token (conjunction) at `[start, end)`.
+    fn conjunction(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(b, node, start, end, &[(FeatureKey::POS, "接続詞")]);
+    }
+
+    /// A whitespace token (記号/空白) at `[start, end)`.
+    fn whitespace(b: &mut MorphologyBuilder, node: NodeId, start: u32, end: u32) {
+        push(
+            b,
+            node,
+            start,
+            end,
+            &[(FeatureKey::POS, "記号"), (FeatureKey::POS_SUB_1, "空白")],
+        );
+    }
+
+    #[test]
+    fn flags_repeated_conjunction_in_consecutive_sentences() {
+        // しかし、A。しかし、B — same 接続詞 starts both sentences → flag the second.
+        // Byte layout (JP chars = 3 bytes each, 、= 3 bytes, A/B = 1 byte, 。= 3 bytes):
+        //   し(0..3) か(3..6) し(6..9) = "しかし" at 0..9
+        //   、 at 9..12
+        //   A at 12..13
+        //   。 at 13..16  ← sentence boundary
+        //   し(16..19) か(19..22) し(22..25) = "しかし" at 16..25
+        //   、 at 25..28
+        //   B at 28..29
+        let src = "しかし、A。しかし、B";
+        let diags = diagnose_with_morphology(&NoDoubledConjunction::new(), src, |p, b| {
+            conjunction(b, p, 0, 9); // しかし (sentence 0)
+            word(b, p, 9, 12); // 、
+            word(b, p, 12, 13); // A
+            // 。 at 13..16 is the sentence terminator
+            conjunction(b, p, 16, 25); // しかし (sentence 1) -> flagged
+            word(b, p, 25, 28); // 、
+            word(b, p, 28, 29); // B
+        });
+        assert_eq!(diags.len(), 1, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (16, 25));
+        assert!(
+            diags[0].message.contains("同じ接続詞（しかし）"),
+            "{}",
+            diags[0].message
+        );
+    }
+
+    #[test]
+    fn different_conjunctions_are_clean() {
+        // しかし…。でも… — different opening conjunctions → no diagnostic.
+        let src = "しかし、A。でも、B";
+        let diags = diagnose_with_morphology(&NoDoubledConjunction::new(), src, |p, b| {
+            conjunction(b, p, 0, 9); // しかし
+            word(b, p, 9, 15); // 、A
+            conjunction(b, p, 18, 21); // でも (sentence 1, 。 at 15..18)
+            word(b, p, 21, 27); // 、B
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn single_sentence_is_clean() {
+        // Only one sentence → nothing to compare → no diagnostic.
+        let src = "しかし、A";
+        let diags = diagnose_with_morphology(&NoDoubledConjunction::new(), src, |p, b| {
+            conjunction(b, p, 0, 9); // しかし
+            word(b, p, 9, 15); // 、A
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn sentence_with_no_conjunction_breaks_the_chain() {
+        // しかし A。B。しかし C — the middle sentence (B) has no conjunction; so the two しかし
+        // sentences are NOT consecutive → no diagnostic.
+        // Byte layout:
+        //   し(0..3) か(3..6) し(6..9) = "しかし" 0..9
+        //   _A at 9..11
+        //   。 at 11..14 (s0→s1 boundary)
+        //   B at 14..15
+        //   。 at 15..18 (s1→s2 boundary)
+        //   し(18..21) か(21..24) し(24..27) = "しかし" 18..27
+        //   _C at 27..29
+        let src = "しかし A。B。しかし C";
+        let diags = diagnose_with_morphology(&NoDoubledConjunction::new(), src, |p, b| {
+            conjunction(b, p, 0, 9); // しかし (sentence 0)
+            word(b, p, 9, 11); // _A
+            // 。 at 11..14
+            word(b, p, 14, 15); // B (sentence 1 has no 接続詞)
+            // 。 at 15..18
+            conjunction(b, p, 18, 27); // しかし (sentence 2) — not consecutive with s0
+            word(b, p, 27, 29); // _C
+        });
+        // s0's conjunction: しかし, s1: none (no conjunction recorded), s2: しかし.
+        // first_per_sentence = [(0, "しかし"), (2, "しかし")] with no s1 entry.
+        // windows(2) sees [(s0,しかし),(s2,しかし)] — they ARE adjacent in the per-sentence list
+        // even though s1 was skipped. This matches the upstream behaviour: only sentences that
+        // *have* a leading conjunction participate, and adjacent entries are compared.
+        // So we DO expect a diagnostic here (both s0 and s2 open with しかし and no s1 conjunction
+        // interrupts the sequence from the upstream's perspective of only-conjunction sentences).
+        assert_eq!(diags.len(), 1, "{diags:?}");
+    }
+
+    #[test]
+    fn whitespace_preceded_conjunction_is_skipped() {
+        // If a 接続詞 is immediately preceded by a whitespace (空白) token, it is not counted as
+        // a sentence-initial conjunction (upstream workaround).
+        // Two sentences each appear to start with しかし preceded by whitespace → skipped → clean.
+        let src = "A しかし。B しかし";
+        let diags = diagnose_with_morphology(&NoDoubledConjunction::new(), src, |p, b| {
+            word(b, p, 0, 1); // A
+            whitespace(b, p, 1, 2); // space
+            conjunction(b, p, 2, 11); // しかし (skipped — prev is 空白)
+            // 。 at 11..14
+            word(b, p, 14, 15); // B
+            whitespace(b, p, 15, 16); // space
+            conjunction(b, p, 16, 25); // しかし (skipped — prev is 空白)
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn three_consecutive_flags_each_repeat() {
+        // しかし…。しかし…。しかし… — three in a row → flag sentence 1 and sentence 2.
+        let src = "しかし A。しかし B。しかし C";
+        let diags = diagnose_with_morphology(&NoDoubledConjunction::new(), src, |p, b| {
+            conjunction(b, p, 0, 9); // しかし (s0)
+            word(b, p, 9, 11); // _A
+            // 。 at 11..14
+            conjunction(b, p, 14, 23); // しかし (s1) flagged
+            word(b, p, 23, 25); // _B
+            // 。 at 25..28
+            conjunction(b, p, 28, 37); // しかし (s2) flagged
+            word(b, p, 37, 39); // _C
+        });
+        assert_eq!(diags.len(), 2, "{diags:?}");
+        assert_eq!((diags[0].span.start, diags[0].span.end), (14, 23));
+        assert_eq!((diags[1].span.start, diags[1].span.end), (28, 37));
+    }
+
+    #[test]
+    fn broken_run_resets_the_memory() {
+        // しかし…。でも…。しかし… — the middle sentence breaks the run; the third しかし is not
+        // consecutive with the first → clean.
+        let src = "しかし A。でも B。しかし C";
+        let diags = diagnose_with_morphology(&NoDoubledConjunction::new(), src, |p, b| {
+            conjunction(b, p, 0, 9); // しかし (s0)
+            word(b, p, 9, 11); // _A
+            // 。 at 11..14
+            conjunction(b, p, 14, 17); // でも (s1) — different
+            word(b, p, 17, 19); // _B
+            // 。 at 19..22
+            conjunction(b, p, 22, 31); // しかし (s2)
+            word(b, p, 31, 33); // _C
+        });
+        assert!(diags.is_empty(), "{diags:?}");
+    }
+
+    #[test]
+    fn no_op_without_a_morphology_table() {
+        assert!(diagnose(&NoDoubledConjunction::new(), "しかし A。しかし B").is_empty());
+    }
+}


### PR DESCRIPTION
Second of the **2-PR stack** completing `textlint-rule-preset-ja-technical-writing` parity (issue #57, **R9**). **Stacks on #74** (`feat/r9-surface-parity`) — review/merge #74 first; this PR's diff is only the 4 rules below once #74 is in `main`.

### This PR — the 4 **lexical / morphology** parity rules
| rule | what it flags | backing |
| --- | --- | --- |
| `ja-no-weak-phrase` | weak / hedging expressions (the 「かも」 family etc.) | surface (ported dictionary) |
| `ja-no-abusage` | common Japanese misuses (誤用); each diagnostic names the correct form | surface (ported dictionary) |
| `no-doubled-conjunction` | the same 接続詞 opening consecutive sentences | **morphology** (no-op until a dict is configured) |
| `ja-no-successive-word` | a word repeated in immediate succession | **morphology** (no-op until a dict is configured) |

- **Report-only**; conservative. The morphology rules key on IPADIC POS literals, so an unrecognized tagset matches nothing (false-negative, never false-positive) — mirroring `no-doubled-joshi` / `no-doubled-conjunctive-particle-ga`, and they stay inert until a morphology dictionary is provisioned.
- The two dictionary rules (`ja-no-weak-phrase`, `ja-no-abusage`) port the upstream textlint dictionaries; `ja-no-abusage` carries 41 misuse entries (regex-pattern prh entries that need capture-group machinery are deferred — documented in the module header).
- Registered in `RULE_IDS` / `build_rule`, tagged JA-only via R5; the morphology rules pin their language through `with_morphology`.
- `just check` green (workspace 662 tests; tzlint_rules 227).

With #74 + this PR, tsuzulint matches all **23** preset rules (+ `ja-prh` for prh parity). Next: **R12** preset wiring, then the **R17** full-preset benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新機能
* 日本語テキスト検査に4つの新しいルールを追加しました：
  * `ja-no-weak-phrase` - 弱い／不確実な表現を検出
  * `ja-no-abusage` - 誤用フレーズを検出
  * `no-doubled-conjunction` - 連続する接続詞を検出
  * `ja-no-successive-word` - 連続する同じ単語を検出（辞書未設定では無効化／レポートのみ）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->