### PR TITLE
🦀 Ferris: Refactor RuleId to Arc<str>

### DIFF
--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -11,12 +11,13 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(alloc::sync::Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
     pub fn new(id: impl Into<String>) -> Self {
-        RuleId(id.into())
+        let s: String = id.into();
+        RuleId(s.into())
     }
     /// The id as a string slice.
     pub fn as_str(&self) -> &str {
@@ -38,7 +39,7 @@ impl From<&str> for RuleId {
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(s.into())
     }
 }
 


### PR DESCRIPTION
🦀 Ferris: Refactor `RuleId` to use `Arc<str>` for O(1) cloning

**💡 Improvement:**
Replaced the internal `String` representation of `RuleId` in `crates/tzlint_pdk/src/diagnostic.rs` with `Arc<str>`.

**🦀 Why:**
`RuleId` serves as a core identifier that is frequently cloned and used as keys within HashMaps and caches across the codebase. Default `String` cloning incurs an O(N) heap allocation overhead. Transitioning to `Arc<str>` is a professional Rust optimization that reduces this cost to an O(1) atomic increment operation. Because `Arc<str>` transparently delegates traits like `Eq`, `Hash`, and `Ord` to the underlying `str`, this optimization comes with zero behavioral regressions and fully preserves the public API, including trait derivations and `as_str()` lookups.

**🔍 Verification:**
1. Ran `cargo clippy --workspace --all-targets -- -D warnings` to verify no warnings or regressions.
2. Executed `cargo test --workspace` confirming all tests continue to pass seamlessly.
3. Cleaned and formatted changes with `cargo fmt`.

---
*PR created automatically by Jules for task [16949269289060522905](https://jules.google.com/task/16949269289060522905) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * 診断モジュールの内部改善を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->