### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via IPv6 transition mechanisms

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -126,7 +126,42 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
     if addr.to_ipv4().is_some_and(ipv4_is_blocked) {
         return true;
     }
+
     let segments = addr.segments();
+
+    // Check embedded IPv4 addresses in transition mechanisms
+    // NAT64 (64:ff9b::/96)
+    if segments[0] == 0x0064
+        && segments[1] == 0xff9b
+        && segments[2] == 0
+        && segments[3] == 0
+        && segments[4] == 0
+        && segments[5] == 0
+    {
+        let ip = Ipv4Addr::new(
+            (segments[6] >> 8) as u8,
+            (segments[6] & 0xff) as u8,
+            (segments[7] >> 8) as u8,
+            (segments[7] & 0xff) as u8,
+        );
+        if ipv4_is_blocked(ip) {
+            return true;
+        }
+    }
+
+    // 6to4 (2002::/16)
+    if segments[0] == 0x2002 {
+        let ip = Ipv4Addr::new(
+            (segments[1] >> 8) as u8,
+            (segments[1] & 0xff) as u8,
+            (segments[2] >> 8) as u8,
+            (segments[2] & 0xff) as u8,
+        );
+        if ipv4_is_blocked(ip) {
+            return true;
+        }
+    }
+
     addr.is_loopback()        // ::1
         || addr.is_unspecified() // ::
         || addr.is_multicast()   // ff00::/8
@@ -244,14 +279,18 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",              // loopback
-            "[::]",               // unspecified
-            "[fc00::1]",          // unique local
-            "[fe80::1]",          // link-local
-            "[ff02::1]",          // multicast
-            "[::ffff:127.0.0.1]", // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",  // IPv4-mapped private
-            "[::127.0.0.1]",      // IPv4-compatible loopback
+            "[::1]",                // loopback
+            "[::]",                 // unspecified
+            "[fc00::1]",            // unique local
+            "[fe80::1]",            // link-local
+            "[ff02::1]",            // multicast
+            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",    // IPv4-mapped private
+            "[::127.0.0.1]",        // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]", // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",  // NAT64 private
+            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The internal URL safety guard `ipv6_is_blocked` failed to validate embedded IPv4 addresses within IPv6 transition networks like NAT64 and 6to4. This allowed an attacker to request internal network targets by packaging an explicitly-blocked IPv4 address (e.g. `127.0.0.1`) inside an IPv6 wrapper (e.g. `[64:ff9b::127.0.0.1]`).
🎯 **Impact:** Potential Server-Side Request Forgery (SSRF) allowing unauthorized dictionary requests targeting private infrastructure, bypassing network boundaries.
🔧 **Fix:** Expanded `ipv6_is_blocked` to extract the embedded IPv4 segments for `64:ff9b::/96` (NAT64) and `2002::/16` (6to4) and route them back into `ipv4_is_blocked()`. Added four new unit tests to enforce coverage against these network targets.
✅ **Verification:** Verified via comprehensive `cargo test --workspace` confirming that SSRF evasion techniques are now actively rejected.

---
*PR created automatically by Jules for task [11518032629423971530](https://jules.google.com/task/11518032629423971530) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * IPv6トランジション機構（NAT64および6to4）を通じて埋め込まれたIPv4アドレスのブロック判定処理を改善しました。ループバックやプライベートアドレスなどに該当する埋め込みIPv4が正しく検出・拒否されるようになります。

* **Tests**
  * IPv6に埋め込まれたIPv4アドレスの検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->