### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via IPv4 transition mechanisms

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -127,6 +127,40 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         return true;
     }
     let segments = addr.segments();
+
+    // Check transition mechanisms that embed an IPv4 address.
+    // 6to4 (2002::/16) embeds the IPv4 address in segments 1 and 2.
+    if segments[0] == 0x2002 {
+        let v4 = Ipv4Addr::new(
+            (segments[1] >> 8) as u8,
+            (segments[1] & 0xff) as u8,
+            (segments[2] >> 8) as u8,
+            (segments[2] & 0xff) as u8,
+        );
+        if ipv4_is_blocked(v4) {
+            return true;
+        }
+    }
+
+    // NAT64 (64:ff9b::/96) embeds the IPv4 address in segments 6 and 7.
+    if segments[0] == 0x0064
+        && segments[1] == 0xff9b
+        && segments[2] == 0
+        && segments[3] == 0
+        && segments[4] == 0
+        && segments[5] == 0
+    {
+        let v4 = Ipv4Addr::new(
+            (segments[6] >> 8) as u8,
+            (segments[6] & 0xff) as u8,
+            (segments[7] >> 8) as u8,
+            (segments[7] & 0xff) as u8,
+        );
+        if ipv4_is_blocked(v4) {
+            return true;
+        }
+    }
+
     addr.is_loopback()        // ::1
         || addr.is_unspecified() // ::
         || addr.is_multicast()   // ff00::/8
@@ -252,6 +286,25 @@ mod tests {
             "[::ffff:127.0.0.1]", // IPv4-mapped loopback
             "[::ffff:10.0.0.1]",  // IPv4-mapped private
             "[::127.0.0.1]",      // IPv4-compatible loopback
+        ] {
+            let url = format!("https://{host}/d.zst");
+            assert!(
+                matches!(
+                    validate_dictionary_url(&url),
+                    Err(UrlPolicyError::BlockedHost(_))
+                ),
+                "expected {host} to be blocked"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_ipv4_transition_mechanisms_with_blocked_addresses() {
+        for host in [
+            "[2002:7f00:0001::]",   // 6to4 mapped 127.0.0.1
+            "[2002:0a00:0001::]",   // 6to4 mapped 10.0.0.1
+            "[64:ff9b::7f00:0001]", // NAT64 mapped 127.0.0.1
+            "[64:ff9b::0a00:0001]", // NAT64 mapped 10.0.0.1
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The dictionary URL validator in `crates/tzlint_core/src/net.rs` suffered from an SSRF bypass. The `ipv6_is_blocked` check used the standard library's `Ipv6Addr::to_ipv4()` method, which only decodes standard IPv4-mapped and IPv4-compatible addresses. It completely ignores embedded IPv4 addresses mapped via other transition mechanisms, specifically `6to4` (`2002::/16`) and `NAT64` (`64:ff9b::/96`).
🎯 **Impact**: An attacker could potentially bypass the SSRF guard and force the backend to fetch an internal restricted IP address (e.g., `127.0.0.1` or `10.0.0.1`) by supplying an IPv6 URL like `https://[2002:7f00:0001::]/dictionary.zst`. This is explicitly dangerous for the configured `validate_dictionary_url` boundary.
🔧 **Fix**: Updated `ipv6_is_blocked` to check the specific 16-bit network segments for the `2002::` and `64:ff9b::` prefixes. If found, the code manually extracts the embedded IPv4 octets and validates them using the existing `ipv4_is_blocked` policy.
✅ **Verification**: Run `cargo test --workspace` to execute the new test cases (`rejects_ipv4_transition_mechanisms_with_blocked_addresses`) in `crates/tzlint_core/src/net.rs` which explicitly verify both `6to4` and `NAT64` encodings mapping to loopback and internal private networks.

---
*PR created automatically by Jules for task [10571605843283681276](https://jules.google.com/task/10571605843283681276) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * IPv4アドレスを埋め込む IPv6 移行メカニズム（6to4、NAT64）を経由したアクセスに対するホストブロック処理を強化しました。

* **テスト**
  * これらのメカニズムを使用したブロック対象アドレスへのアクセスを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->