### PR TITLE
feat(preset): full ja-technical-writing parity with textlint preset (R12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@ accumulate as the release is built.
   lexicon / morphology half of the preset-parity gap. `no-doubled-conjunction` and
   `ja-no-successive-word` are morphology-backed (no-ops until a dictionary is configured).
   Report-only.
+- **Full `ja-technical-writing` preset parity.** The `ja-technical-writing` preset now bundles all
+  23 rules of `textlint-rule-preset-ja-technical-writing` — the surface and lexical/morphology
+  parity rules above join the style rules already shipped — with the upstream `rulesConfig`
+  thresholds copied verbatim (`max-comma` 3, `max-ten` 3, `max-kanji-continuous-len` 6,
+  `sentence-length` 100). The preset also keeps the tsuzulint-original `no-mixed-zenkaku-hankaku-alphabet`,
+  which has no upstream counterpart.
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the

--- a/crates/tzlint_core/src/config/preset.rs
+++ b/crates/tzlint_core/src/config/preset.rs
@@ -86,27 +86,44 @@ fn ja_basic() -> BTreeMap<RuleId, RuleSetting> {
 }
 
 /// The `ja-technical-writing` preset: stricter, with thresholds.
+///
+/// This mirrors the full 23-rule `textlint-rule-preset-ja-technical-writing` composition (its
+/// `rulesConfig` defaults are copied verbatim — `max-comma` 3, `max-ten` 3, `max-kanji-continuous-len`
+/// 6, `sentence-length` 100, the rest enabled), plus one tsuzulint-original surface rule that has no
+/// upstream counterpart: `no-mixed-zenkaku-hankaku-alphabet`. The morphology-backed rules are no-ops
+/// until a dictionary is provisioned (the engine skips morphology rules when there is no tokenizer),
+/// so enabling them here is safe even when `morphology` is unconfigured.
 fn ja_technical_writing() -> BTreeMap<RuleId, RuleSetting> {
     use serde_json::{Value, json};
     [
+        // Surface rules with thresholds (upstream `rulesConfig` values).
         ("sentence-length", on(json!({ "max": 100 }))),
+        ("max-comma", on(json!({ "max": 3 }))),
         ("max-ten", on(json!({ "max": 3 }))),
         ("max-kanji-continuous-len", on(json!({ "max": 6 }))),
-        ("no-hankaku-kana", on(Value::Null)),
-        ("no-mixed-zenkaku-hankaku-alphabet", on(Value::Null)),
+        // Surface rules, enabled with defaults.
+        ("arabic-kanji-numbers", on(Value::Null)),
+        ("ja-no-mixed-period", on(Value::Null)),
         ("no-nfd", on(Value::Null)),
+        ("no-invalid-control-character", on(Value::Null)),
         ("no-zero-width-spaces", on(Value::Null)),
         ("no-exclamation-question-mark", on(Value::Null)),
-        ("ja-no-mixed-period", on(Value::Null)),
-        // Morphology-backed style rules (mirroring textlint's preset-ja-technical-writing): each is
-        // a no-op until a dictionary is provisioned (the engine skips morphology rules when there is
-        // no tokenizer), so enabling them here is safe even when `morphology` is unconfigured.
-        ("no-doubled-joshi", on(Value::Null)),
-        ("no-mix-dearu-desumasu", on(Value::Null)),
-        ("no-doubled-conjunctive-particle-ga", on(Value::Null)),
+        ("no-hankaku-kana", on(Value::Null)),
+        ("ja-no-weak-phrase", on(Value::Null)),
+        ("ja-no-abusage", on(Value::Null)),
         ("ja-no-redundant-expression", on(Value::Null)),
-        ("no-dropping-the-ra", on(Value::Null)),
+        ("ja-unnatural-alphabet", on(Value::Null)),
+        ("no-unmatched-pair", on(Value::Null)),
+        // tsuzulint-original surface rule (no upstream-preset counterpart).
+        ("no-mixed-zenkaku-hankaku-alphabet", on(Value::Null)),
+        // Morphology-backed style rules (a no-op until a dictionary is provisioned).
+        ("no-mix-dearu-desumasu", on(Value::Null)),
+        ("no-doubled-conjunction", on(Value::Null)),
+        ("no-doubled-conjunctive-particle-ga", on(Value::Null)),
         ("no-double-negative-ja", on(Value::Null)),
+        ("no-dropping-the-ra", on(Value::Null)),
+        ("no-doubled-joshi", on(Value::Null)),
+        ("ja-no-successive-word", on(Value::Null)),
     ]
     .into_iter()
     .map(|(id, setting)| (RuleId::from(id), setting))
@@ -146,7 +163,7 @@ fn merge(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::Value;
+    use serde_json::{Value, json};
 
     fn on() -> RuleSetting {
         RuleSetting::On {
@@ -293,6 +310,9 @@ mod tests {
             "ja-no-redundant-expression",
             "no-dropping-the-ra",
             "no-double-negative-ja",
+            // R9 morphology-backed parity rules.
+            "no-doubled-conjunction",
+            "ja-no-successive-word",
         ];
         let technical = Preset::JaTechnicalWriting.rules();
         let basic = Preset::JaBasic.rules();
@@ -305,6 +325,52 @@ mod tests {
                 !basic.contains_key(&RuleId::from(id)),
                 "ja-basic should not bundle the style rule {id}"
             );
+        }
+    }
+
+    #[test]
+    fn ja_technical_writing_has_full_upstream_preset_parity() {
+        // `ja-technical-writing` mirrors the full 23-rule `textlint-rule-preset-ja-technical-writing`
+        // composition. This pins the complete upstream rule set (ids + the threshold values from the
+        // upstream `rulesConfig`), so a dropped or mis-defaulted parity rule fails loudly.
+        let technical = Preset::JaTechnicalWriting.rules();
+
+        // Every rule of the upstream preset, with its upstream-default options where applicable.
+        let upstream: &[(&str, Value)] = &[
+            ("sentence-length", json!({ "max": 100 })),
+            ("max-comma", json!({ "max": 3 })),
+            ("max-ten", json!({ "max": 3 })),
+            ("max-kanji-continuous-len", json!({ "max": 6 })),
+            ("no-mix-dearu-desumasu", Value::Null),
+            ("ja-no-mixed-period", Value::Null),
+            ("arabic-kanji-numbers", Value::Null),
+            ("no-doubled-conjunction", Value::Null),
+            ("no-doubled-conjunctive-particle-ga", Value::Null),
+            ("no-double-negative-ja", Value::Null),
+            ("no-doubled-joshi", Value::Null),
+            ("no-dropping-the-ra", Value::Null),
+            ("no-nfd", Value::Null),
+            ("no-invalid-control-character", Value::Null),
+            ("no-zero-width-spaces", Value::Null),
+            ("no-exclamation-question-mark", Value::Null),
+            ("no-hankaku-kana", Value::Null),
+            ("ja-no-weak-phrase", Value::Null),
+            ("ja-no-successive-word", Value::Null),
+            ("ja-no-abusage", Value::Null),
+            ("ja-no-redundant-expression", Value::Null),
+            ("ja-unnatural-alphabet", Value::Null),
+            ("no-unmatched-pair", Value::Null),
+        ];
+        assert_eq!(upstream.len(), 23, "upstream preset has 23 rules");
+
+        for (id, want_options) in upstream {
+            match technical.get(&RuleId::from(*id)) {
+                Some(RuleSetting::On { options, .. }) => assert_eq!(
+                    options, want_options,
+                    "ja-technical-writing rule {id} should carry the upstream default options"
+                ),
+                other => panic!("ja-technical-writing should enable {id}, got {other:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
## What

Wires the nine **R9** parity rules (merged in #74 / #75) into the `ja-technical-writing` preset, bringing it to **full parity with the 23-rule `textlint-rule-preset-ja-technical-writing`** (Issue #57, sub-step **R12**).

The upstream `rulesConfig` defaults are copied **verbatim** — confirmed against the upstream preset source:

| threshold rule | value |
| --- | --- |
| `sentence-length` | `max: 100` |
| `max-comma` | `max: 3` |
| `max-ten` | `max: 3` |
| `max-kanji-continuous-len` | `max: 6` |

### Newly bundled (the 9 R9 rules)

- **surface:** `max-comma`, `arabic-kanji-numbers`, `no-invalid-control-character`, `ja-no-weak-phrase`, `ja-no-abusage`, `ja-unnatural-alphabet`, `no-unmatched-pair`
- **morphology** (no-op until a dictionary is provisioned): `no-doubled-conjunction`, `ja-no-successive-word`

The preset keeps the tsuzulint-original `no-mixed-zenkaku-hankaku-alphabet`, which has **no upstream-preset counterpart** (documented in the preset doc-comment).

## Tests

- New `ja_technical_writing_has_full_upstream_preset_parity` pins the **complete** upstream rule set (all 23 ids + their threshold options) so a dropped or mis-defaulted parity rule fails loudly.
- `ja_technical_writing_bundles_the_morphology_style_rules` extended with the 2 new morphology rules.
- Cross-crate `presets_only_reference_built_in_rule_ids` already guards every preset id ∈ `RULE_IDS`.
- `just check` green (707 tests, clippy `-D warnings` + fmt clean).

## Notes for R17 (benchmark gate)

Two intentional divergences from the upstream preset, surfaced for the apples-to-apples benchmark:
1. **Extra rule** — `no-mixed-zenkaku-hankaku-alphabet` runs in our preset but is not in upstream's 23.
2. **`no-mix-dearu-desumasu` options** — upstream sets `preferInBody:"ですます" / preferInList:"である" / preferInHeader:"" / strict:false`; we pass defaults (auto-detect majority). The body/list/header distinction is not yet modeled in our rule.

Both will be reconciled (or documented as caveats) when configuring the R17 comparison.

Closes the **R12** sub-step of #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `ja-technical-writing` プリセットを拡充。23個のルールと、より詳細なしきい値設定に対応しました。

* **Tests**
  * プリセットの検証テストを追加し、規則の適用が正確であることを確認。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->