### PR TITLE
🦀 Ferris: Refactor RuleId to use Arc<str> for zero-cost clones

### DIFF
--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -1,6 +1,7 @@
 //! The diagnostic model rules emit and the engine aggregates.
 
 use alloc::string::String;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use tzlint_ast::Span;
@@ -11,12 +12,12 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
     pub fn new(id: impl Into<String>) -> Self {
-        RuleId(id.into())
+        RuleId(Arc::from(id.into().into_boxed_str()))
     }
     /// The id as a string slice.
     pub fn as_str(&self) -> &str {
@@ -32,13 +33,13 @@ impl core::fmt::Display for RuleId {
 
 impl From<&str> for RuleId {
     fn from(s: &str) -> Self {
-        RuleId(s.into())
+        RuleId(Arc::from(s))
     }
 }
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(Arc::from(s.into_boxed_str()))
     }
 }
 


### PR DESCRIPTION
🦀 Ferris has optimized the `RuleId` implementation in `crates/tzlint_pdk/src/diagnostic.rs`.

💡 **Improvement:** `RuleId` now wraps an `Arc<str>` instead of a `String`.
🦀 **Why:** `RuleId` is cloned frequently in hot loops and caches. Relying on an `Arc` converts an `O(N)` heap allocation string deep copy into an `O(1)` zero-cost reference bump, reducing overhead.
🔍 **Verification:** Built without errors using `cargo clippy`, formatting passes, and all workspace tests remain green.

This aligns seamlessly with the `tzlint` performance guideline to avoid allocating identifiers unnecessarily.

---
*PR created automatically by Jules for task [15274261943325449685](https://jules.google.com/task/15274261943325449685) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ルールID（RuleId）の内部メモリ管理を改善し、より効率的なデータ構造に最適化しました。ユーザー向けのインターフェースは変わりません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->