### PR TITLE
⚡ Bolt: Optimize RuleId string allocation

### DIFF
--- a/crates/tzlint_pdk/src/diagnostic.rs
+++ b/crates/tzlint_pdk/src/diagnostic.rs
@@ -11,12 +11,12 @@ use tzlint_ast::Span;
 /// namespaced as `<namespace>/<rule>` (`acme/no-weasel-words`). Ids are a public contract —
 /// greppable, stable, and used verbatim in config keys and the cache key.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct RuleId(String);
+pub struct RuleId(alloc::sync::Arc<str>);
 
 impl RuleId {
     /// Wrap an id string.
     pub fn new(id: impl Into<String>) -> Self {
-        RuleId(id.into())
+        RuleId(id.into().into())
     }
     /// The id as a string slice.
     pub fn as_str(&self) -> &str {
@@ -38,7 +38,7 @@ impl From<&str> for RuleId {
 
 impl From<String> for RuleId {
     fn from(s: String) -> Self {
-        RuleId(s)
+        RuleId(s.into())
     }
 }
 


### PR DESCRIPTION
💡 What: Changed the inner type of `RuleId` from `String` to `alloc::sync::Arc<str>`.
🎯 Why: `RuleId` is used verbatim in configuration keys and cache keys, leading to frequent cloning. Cloning a `String` requires a heap allocation, which creates overhead in hot paths.
📊 Impact: Eliminates a heap allocation every time a `RuleId` is cloned. This speeds up cache key generation and configuration resolution.
🔬 Measurement: Run the test suite and observe identical functional behavior, but reduced allocation count.

---
*PR created automatically by Jules for task [13826764881900309258](https://jules.google.com/task/13826764881900309258) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 内部の最適化処理を実施しました。既存の動作と機能は変わりません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->