### PR TITLE
chore(wasm): decode the dictionary pin via blake3::Hash::from_hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
 name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
+ "blake3",
  "console_error_panic_hook",
  "serde_json",
  "tzlint_core",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -28,6 +28,10 @@ serde_json = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }
+# `blake3::Hash::from_hex` decodes the dictionary pin — pulled ONLY by the `morphology` feature
+# (the lean artifact never decodes a pin). Already linked transitively via `tzlint_core`, so this
+# adds no weight to the full build; it just lets the binding name `blake3` directly.
+blake3 = { workspace = true, optional = true }
 
 # wasm-only glue: the `#[wasm_bindgen]` JS bindings + a panic→console.error hook. Native builds (the
 # unit tests of the `Linter` core) never pull these.
@@ -50,4 +54,4 @@ wasm-bindgen-test = "0.3"
 # so there is no compile-time language axis to split on. Japanese is the language wired today; ko/zh
 # reuse this same build once their dictionaries and rules land. Named for the capability, so a
 # consumer opts in by whether it needs morphology, not by a backend or a language.
-morphology = ["dep:tzlint_morphology_native"]
+morphology = ["dep:tzlint_morphology_native", "dep:blake3"]

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -166,31 +166,18 @@ fn severity_str(severity: Severity) -> &'static str {
     }
 }
 
-/// Decode 64 hex characters into a 32-byte pin, panic-free.
+/// Decode 64 hex characters into a 32-byte pin, panic-free. The parse defers to `blake3`'s own
+/// hex decoder (the crate is already linked here for dictionary-pin verification), mirroring
+/// `tzlint_core`'s config `decode_pin`; the explicit length check keeps the length-specific
+/// message that the JS boundary surfaces.
 #[cfg(feature = "morphology")]
 fn decode_pin(hex: &str) -> Result<[u8; 32], String> {
-    let bytes = hex.as_bytes();
-    if bytes.len() != 64 {
+    if hex.len() != 64 {
         return Err("dictionary pin must be 64 hexadecimal characters".to_string());
     }
-    let mut out = [0u8; 32];
-    for (i, slot) in out.iter_mut().enumerate() {
-        let hi = hex_nibble(bytes[i * 2]).ok_or("dictionary pin has a non-hex character")?;
-        let lo = hex_nibble(bytes[i * 2 + 1]).ok_or("dictionary pin has a non-hex character")?;
-        *slot = (hi << 4) | lo;
-    }
-    Ok(out)
-}
-
-/// The value of one hex digit (`0-9`, `a-f`, `A-F`), or `None`.
-#[cfg(feature = "morphology")]
-fn hex_nibble(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        _ => None,
-    }
+    blake3::Hash::from_hex(hex)
+        .map(|hash| *hash.as_bytes())
+        .map_err(|_| "dictionary pin has a non-hex character".to_string())
 }
 
 /// The `#[wasm_bindgen]` JS bindings — a thin wrapper over [`Linter`], compiled only for `wasm32`.


### PR DESCRIPTION
## What

Replace the hand-rolled hex decoder (`decode_pin` loop + `hex_nibble`) in the wasm bindings (`crates/tzlint_wasm/src/lib.rs`) with `blake3::Hash::from_hex`, mirroring `tzlint_core`'s config `decode_pin` (landed in #85).

## Why it's free

`blake3` is **already linked** in the morphology wasm build — the dictionary pin is "BLAKE3 over the compressed container", verified at `registerDictionary` time. So the new `blake3` dependency is declared **optional and gated to the `morphology` feature**, and adds **no weight** to either artifact:
- **lean** (no morphology) build never references `blake3` (verified: builds without it);
- **morphology** build already pulls `blake3` transitively via `tzlint_core` — this just lets the binding name it directly.

The explicit length check is kept so the JS boundary still surfaces the length-specific error message (`"dictionary pin must be 64 hexadecimal characters"` vs `"dictionary pin has a non-hex character"`).

## Relationship to #83

This is the clean version of the **only non-redundant part of #83**. #83 also re-did `config/model.rs` (already done by the merged #85) and dragged in unrelated `Cargo.lock` version bumps, leaving it `CONFLICTING`. Closing #83 in favor of this.

## Verification

- lean wasm32 build ✅ · morphology wasm32 build ✅ · native rlib tests (8) ✅ · clippy `-D warnings` ✅ · fmt ✅
- `Cargo.lock` change is a single line (`+ "blake3"` under `tzlint_wasm`) — no version churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)