### PR TITLE
🎓 Scholar: [blake3] usage improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
 name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
+ "blake3",
  "console_error_panic_hook",
  "serde_json",
  "tzlint_core",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }
+blake3 = { workspace = true, optional = true }
 
 # wasm-only glue: the `#[wasm_bindgen]` JS bindings + a panic→console.error hook. Native builds (the
 # unit tests of the `Linter` core) never pull these.
@@ -50,4 +51,4 @@ wasm-bindgen-test = "0.3"
 # so there is no compile-time language axis to split on. Japanese is the language wired today; ko/zh
 # reuse this same build once their dictionaries and rules land. Named for the capability, so a
 # consumer opts in by whether it needs morphology, not by a backend or a language.
-morphology = ["dep:tzlint_morphology_native"]
+morphology = ["dep:tzlint_morphology_native", "dep:blake3"]

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -169,28 +169,12 @@ fn severity_str(severity: Severity) -> &'static str {
 /// Decode 64 hex characters into a 32-byte pin, panic-free.
 #[cfg(feature = "morphology")]
 fn decode_pin(hex: &str) -> Result<[u8; 32], String> {
-    let bytes = hex.as_bytes();
-    if bytes.len() != 64 {
+    if hex.len() != 64 {
         return Err("dictionary pin must be 64 hexadecimal characters".to_string());
     }
-    let mut out = [0u8; 32];
-    for (i, slot) in out.iter_mut().enumerate() {
-        let hi = hex_nibble(bytes[i * 2]).ok_or("dictionary pin has a non-hex character")?;
-        let lo = hex_nibble(bytes[i * 2 + 1]).ok_or("dictionary pin has a non-hex character")?;
-        *slot = (hi << 4) | lo;
-    }
-    Ok(out)
-}
-
-/// The value of one hex digit (`0-9`, `a-f`, `A-F`), or `None`.
-#[cfg(feature = "morphology")]
-fn hex_nibble(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        _ => None,
-    }
+    let hash = blake3::Hash::from_hex(hex)
+        .map_err(|_| "dictionary pin has a non-hex character".to_string())?;
+    Ok(*hash.as_bytes())
 }
 
 /// The `#[wasm_bindgen]` JS bindings — a thin wrapper over [`Linter`], compiled only for `wasm32`.


### PR DESCRIPTION
**📚 Source:** `blake3` crate documentation for `Hash::from_hex()`.
**💡 Insight:** Our codebase implemented a custom, manual 64-character hexadecimal decoding loop (`decode_pin` and `hex_nibble`) to parse the BLAKE3 dictionary pin. However, the `blake3` crate provides a built-in `from_hex` method designed precisely for parsing 32-byte hash pins.
**🛠️ Change:** 
- Added `blake3` as an optional dependency to `crates/tzlint_wasm/Cargo.toml` under the `morphology` feature.
- Removed the custom `decode_pin` and `hex_nibble` implementation in `crates/tzlint_wasm/src/lib.rs`.
- Replaced the implementation with `blake3::Hash::from_hex(hex)`.
- Replicated exact error message behavior for backwards compatibility with tests.
**✨ Benefit:** Robustness and Consistency. Utilizing the established library's native hex parsing simplifies the code, removes manual boilerplate logic, and aligns with best practices for handling BLAKE3 pins.

---
*PR created automatically by Jules for task [1585198026043201233](https://jules.google.com/task/1585198026043201233) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ピン文字列のデコード処理を最適化しました。内部の文字解析ロジックがシンプルになり、より効率的に処理されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->