### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF bypass via Teredo IPv6 tunneling

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -125,6 +125,7 @@ fn ipv4_is_blocked(addr: Ipv4Addr) -> bool {
 /// - IPv4-mapped and IPv4-compatible (`::ffff:a.b.c.d` and `::a.b.c.d` via `to_ipv4`)
 /// - NAT64 well-known prefix (`64:ff9b::a.b.c.d` — RFC 6052)
 /// - 6to4 (`2002:abcd:efgh::` — RFC 3056)
+/// - Teredo (`2001:0000::/32` — RFC 4380)
 fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
     if let Some(v4) = addr.to_ipv4() {
         return Some(v4);
@@ -150,6 +151,14 @@ fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
         let b = (segments[1] & 0xff) as u8;
         let c = (segments[2] >> 8) as u8;
         let d = (segments[2] & 0xff) as u8;
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
+    // Teredo (RFC 4380): 2001:0000::/32
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        let a = ((segments[6] >> 8) ^ 0xff) as u8;
+        let b = ((segments[6] & 0xff) ^ 0xff) as u8;
+        let c = ((segments[7] >> 8) ^ 0xff) as u8;
+        let d = ((segments[7] & 0xff) ^ 0xff) as u8;
         return Some(Ipv4Addr::new(a, b, c, d));
     }
     None
@@ -292,6 +301,9 @@ mod tests {
             "[64:ff9b::10.0.0.1]",  // NAT64 private
             "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
             "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
+            "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -289,18 +289,18 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",                // loopback
-            "[::]",                 // unspecified
-            "[fc00::1]",            // unique local
-            "[fe80::1]",            // link-local
-            "[ff02::1]",            // multicast
-            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",    // IPv4-mapped private
-            "[::127.0.0.1]",        // IPv4-compatible loopback
-            "[64:ff9b::127.0.0.1]", // NAT64 loopback
-            "[64:ff9b::10.0.0.1]",  // NAT64 private
-            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
-            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[::1]",                                     // loopback
+            "[::]",                                      // unspecified
+            "[fc00::1]",                                 // unique local
+            "[fe80::1]",                                 // link-local
+            "[ff02::1]",                                 // multicast
+            "[::ffff:127.0.0.1]",                        // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",                         // IPv4-mapped private
+            "[::127.0.0.1]",                             // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]",                      // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",                       // NAT64 private
+            "[2002:7f00:0001::]",                        // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1)


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF bypass via Teredo IPv6 tunneling

*   **Severity:** HIGH
*   **Vulnerability:** The `validate_dictionary_url` function failed to extract embedded IPv4 addresses from Teredo IPv6 addresses (`2001:0000::/32`). This allowed an attacker to bypass the SSRF protection mechanism by encapsulating a forbidden internal IPv4 address (e.g., `127.0.0.1` or `10.0.0.1`) within a Teredo IPv6 address.
*   **Impact:** Attackers could bypass SSRF safeguards and force the application to make HTTP requests to internal IP addresses on restricted networks, potentially interacting with private infrastructure.
*   **Fix:** Updated `extract_ipv4` in `crates/tzlint_core/src/net.rs` to identify Teredo addresses (RFC 4380) and correctly extract the obfuscated internal IPv4 address by XORing the 6th and 7th segments with `0xFF`.
*   **Verification:** Included test coverage checking that `validate_dictionary_url` accurately rejects Teredo loopback, private, and documentation IP addresses. Verified all tests pass via `cargo test --workspace`.

---
*PR created automatically by Jules for task [17949944500996280717](https://jules.google.com/task/17949944500996280717) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Teredo形式のIPv6アドレスから埋め込まれたIPv4アドレスを検出・デコード処理を追加し、関連するTeredo形式アドレスのブロック判定を改善しました。

* **テスト**
  * Teredo形式アドレスのドキュメント用、ループバック、プライベートアドレスのテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->