### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via Teredo IPv6 addresses

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -152,6 +152,17 @@ fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
         let d = (segments[2] & 0xff) as u8;
         return Some(Ipv4Addr::new(a, b, c, d));
     }
+    // Teredo (RFC 4380): 2001:0000::/32
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        // Teredo encodes the IPv4 address in the last 32 bits, XORed with 0xffff
+        let s6 = segments[6] ^ 0xffff;
+        let s7 = segments[7] ^ 0xffff;
+        let a = (s6 >> 8) as u8;
+        let b = (s6 & 0xff) as u8;
+        let c = (s7 >> 8) as u8;
+        let d = (s7 & 0xff) as u8;
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
     None
 }
 
@@ -280,18 +291,20 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",                // loopback
-            "[::]",                 // unspecified
-            "[fc00::1]",            // unique local
-            "[fe80::1]",            // link-local
-            "[ff02::1]",            // multicast
-            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",    // IPv4-mapped private
-            "[::127.0.0.1]",        // IPv4-compatible loopback
-            "[64:ff9b::127.0.0.1]", // NAT64 loopback
-            "[64:ff9b::10.0.0.1]",  // NAT64 private
-            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
-            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[::1]",                                  // loopback
+            "[::]",                                   // unspecified
+            "[fc00::1]",                              // unique local
+            "[fe80::1]",                              // link-local
+            "[ff02::1]",                              // multicast
+            "[::ffff:127.0.0.1]",                     // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",                      // IPv4-mapped private
+            "[::127.0.0.1]",                          // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]",                   // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",                    // NAT64 private
+            "[2002:7f00:0001::]",                     // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",                     // 6to4 private (10.0.0.1)
+            "[2001:0:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:0:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The URL safety guard `validate_dictionary_url` extracted IPv4 addresses from transition-form IPv6 addresses (IPv4-mapped, IPv4-compatible, NAT64, 6to4) to block internal IP addresses correctly, but missed Teredo (RFC 4380) addresses (`2001:0000::/32`). This allowed an SSRF bypass where an attacker could provide a dictionary URL with a Teredo address containing an encapsulated internal IPv4 address (e.g., `127.0.0.1`), bypassing the URL guard.
🎯 Impact: An attacker could perform Server-Side Request Forgery (SSRF) and force the application to fetch internal HTTP resources.
🔧 Fix: Implemented embedded IPv4 extraction for Teredo addresses (RFC 4380) in the `extract_ipv4` function to ensure underlying internal IPs are detected and blocked.
✅ Verification: Tested against Teredo addresses encapsulating loopback and private IPv4 ranges using `RUSTUP_HOME=/tmp/rustup CARGO_HOME=/tmp/cargo cargo test --workspace` which all pass.

---
*PR created automatically by Jules for task [2347528733921286921](https://jules.google.com/task/2347528733921286921) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* Teredo形式のIPv6アドレスに埋め込まれたIPv4アドレスの検出機能を実装
* ループバックおよびプライベートIPv4がTeredo経由で表現された場合も適切にブロック対象として処理されるように改善

## テスト
* Teredo形式の複数のIPv6リテラルに対するテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->