### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via Teredo IPv6 addresses

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -288,18 +288,18 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",                // loopback
-            "[::]",                 // unspecified
-            "[fc00::1]",            // unique local
-            "[fe80::1]",            // link-local
-            "[ff02::1]",            // multicast
-            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",    // IPv4-mapped private
-            "[::127.0.0.1]",        // IPv4-compatible loopback
-            "[64:ff9b::127.0.0.1]", // NAT64 loopback
-            "[64:ff9b::10.0.0.1]",  // NAT64 private
-            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
-            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[::1]",                                     // loopback
+            "[::]",                                      // unspecified
+            "[fc00::1]",                                 // unique local
+            "[fe80::1]",                                 // link-local
+            "[ff02::1]",                                 // multicast
+            "[::ffff:127.0.0.1]",                        // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",                         // IPv4-mapped private
+            "[::127.0.0.1]",                             // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]",                      // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",                       // NAT64 private
+            "[2002:7f00:0001::]",                        // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1)
         ] {

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -152,6 +152,14 @@ fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
         let d = (segments[2] & 0xff) as u8;
         return Some(Ipv4Addr::new(a, b, c, d));
     }
+    // Teredo (RFC 4380): 2001:0000::/32
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        let a = ((segments[6] >> 8) as u8) ^ 0xff;
+        let b = ((segments[6] & 0xff) as u8) ^ 0xff;
+        let c = ((segments[7] >> 8) as u8) ^ 0xff;
+        let d = ((segments[7] & 0xff) as u8) ^ 0xff;
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
     None
 }
 
@@ -292,6 +300,8 @@ mod tests {
             "[64:ff9b::10.0.0.1]",  // NAT64 private
             "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
             "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** SSRF bypass via Teredo IPv6 addresses. `extract_ipv4` was missing parsing for Teredo IPv6 transition addresses (`2001:0000::/32`). Teredo encodes the encapsulated IPv4 address in the last 32 bits by XORing it with `0xFFFF`. Since this was not extracted, a malicious user could bypass the SSRF blocklist and access internal private IPv4 addresses (e.g. `127.0.0.1` or `10.0.0.1`) by passing a carefully crafted Teredo IPv6 address (e.g. `[2001:0000:4136:e378:8000:63bf:f5ff:fffe]`).
🎯 **Impact:** An attacker could access sensitive internal resources or probe the internal network by making the server fetch dictionary URLs pointing to restricted IPs.
🔧 **Fix:** Added extraction logic for the Teredo prefix to decode the IPv4 address by extracting segments 6 and 7 and applying the XOR `^ 0xff` operation.
✅ **Verification:** Verified by unit tests added to `rejects_blocked_ipv6_literals` for both loopback and private IPs via Teredo, ensuring they are blocked. Tests passed via `cargo test --workspace`.

---
*PR created automatically by Jules for task [9847886598641159521](https://jules.google.com/task/9847886598641159521) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Teredo形式のIPv6埋め込みアドレス（RFC 4380）をIPv4として抽出し、ネットワークアドレスの検証時に適切にブロック対象として処理するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->