### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF Teredo bypass

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -125,6 +125,7 @@ fn ipv4_is_blocked(addr: Ipv4Addr) -> bool {
 /// - IPv4-mapped and IPv4-compatible (`::ffff:a.b.c.d` and `::a.b.c.d` via `to_ipv4`)
 /// - NAT64 well-known prefix (`64:ff9b::a.b.c.d` — RFC 6052)
 /// - 6to4 (`2002:abcd:efgh::` — RFC 3056)
+/// - Teredo (`2001:0000::/32` — RFC 4380)
 fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
     if let Some(v4) = addr.to_ipv4() {
         return Some(v4);
@@ -150,6 +151,14 @@ fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
         let b = (segments[1] & 0xff) as u8;
         let c = (segments[2] >> 8) as u8;
         let d = (segments[2] & 0xff) as u8;
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
+    // Teredo (RFC 4380): 2001:0000::/32
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        let a = ((segments[6] ^ 0xffff) >> 8) as u8;
+        let b = ((segments[6] ^ 0xffff) & 0xff) as u8;
+        let c = ((segments[7] ^ 0xffff) >> 8) as u8;
+        let d = ((segments[7] ^ 0xffff) & 0xff) as u8;
         return Some(Ipv4Addr::new(a, b, c, d));
     }
     None
@@ -280,18 +289,20 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",                // loopback
-            "[::]",                 // unspecified
-            "[fc00::1]",            // unique local
-            "[fe80::1]",            // link-local
-            "[ff02::1]",            // multicast
-            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",    // IPv4-mapped private
-            "[::127.0.0.1]",        // IPv4-compatible loopback
-            "[64:ff9b::127.0.0.1]", // NAT64 loopback
-            "[64:ff9b::10.0.0.1]",  // NAT64 private
-            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
-            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[::1]",                                     // loopback
+            "[::]",                                      // unspecified
+            "[fc00::1]",                                 // unique local
+            "[fe80::1]",                                 // link-local
+            "[ff02::1]",                                 // multicast
+            "[::ffff:127.0.0.1]",                        // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",                         // IPv4-mapped private
+            "[::127.0.0.1]",                             // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]",                      // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",                       // NAT64 private
+            "[2002:7f00:0001::]",                        // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1, 80ff^ffff=7f00, fffe^ffff=0001)
+            "[2001:0000:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1, f5ff^ffff=0a00, fffe^ffff=0001)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** SSRF bypass using IPv6 Teredo transition mechanism. Teredo (`2001:0000::/32`) encodes the IPv4 address inside the IPv6 address (XORed with `0xffff` in the last 32 bits), allowing an attacker to bypass loopback/private IPv4 restrictions if the validation logic does not explicitly decode it.
🎯 **Impact:** An attacker could craft a Teredo address to trick the linter's dictionary fetch into requesting internal endpoints, such as `127.0.0.1` or `10.0.0.1`.
🔧 **Fix:** Extracted embedded IPv4 from Teredo addresses (`2001:0000::/32`) in `extract_ipv4` and evaluated them against the existing IPv4 blocklist.
✅ **Verification:** Added dedicated loopback and private test cases. Ran workspace tests, clippy, and rustfmt successfully.

---
*PR created automatically by Jules for task [4236684694700018995](https://jules.google.com/task/4236684694700018995) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Teredo形式で埋め込まれたIPv4アドレスの検出と復号に対応し、ホストのブロック判定精度が向上しました。

* **Tests**
  * Teredo形式のIPv6リテラルに関するテストケースを追加し、ブロック機能の動作確認範囲を拡大しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->