### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -153,7 +153,7 @@ fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
             })
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: serde_json documentation and memory insights
💡 Insight: Constructing an intermediate `serde_json::Value` and calling `.to_string()` has unnecessary overhead from the `Display` trait and allocations. The library provides `serde_json::to_string` to serialize any `Serialize` type directly.
🛠️ Change: Replaced `Value::Array(items).to_string()` with `serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())` in `diagnostics_to_json`.
✨ Benefit: Avoids the intermediate `Value::Array` allocation and the overhead of the `Display` trait implementation, improving serialization performance for diagnostics.

---
*PR created automatically by Jules for task [13165146807967006245](https://jules.google.com/task/13165146807967006245) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 診断結果の JSON 変換処理を改善し、シリアライズに失敗した場合でも空配列 `[]` を返すようになりました。
  * これにより、出力の安定性が向上し、予期しない変換エラーの影響を受けにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->