### PR TITLE
🦀 Ferris: Optimize JSON serialization

### DIFF
--- a/crates/tzlint_cli/src/output.rs
+++ b/crates/tzlint_cli/src/output.rs
@@ -85,7 +85,7 @@ pub fn render_json(writer: &mut dyn Write, reports: &[FileReport]) -> io::Result
         .collect();
 
     // `serde_json` only fails here on an underlying writer error, which is already `io`.
-    serde_json::to_writer_pretty(&mut *writer, &Value::Array(files)).map_err(io::Error::other)?;
+    serde_json::to_writer_pretty(&mut *writer, &files).map_err(io::Error::other)?;
     writeln!(writer)
 }
 
@@ -261,7 +261,7 @@ pub fn render_rule_list_json(writer: &mut dyn Write, infos: &[RuleInfo]) -> io::
             })
         })
         .collect();
-    serde_json::to_writer_pretty(&mut *writer, &Value::Array(rules)).map_err(io::Error::other)?;
+    serde_json::to_writer_pretty(&mut *writer, &rules).map_err(io::Error::other)?;
     writeln!(writer)
 }
 

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -406,8 +406,8 @@ impl DocumentCache {
             "version": CACHE_FILE_VERSION,
             "entries": Value::Object(entries),
         });
-        // `Value`'s `Display` is infallible, so no serialization error to handle here.
-        let text = document.to_string();
+        // `serde_json::to_string` on a `Value` tree is infallible, so no serialization error to handle here.
+        let text = serde_json::to_string(&document).unwrap_or_default();
         if text.len() > limit {
             return Err(CacheError::Io(IoError::TooLarge { limit }));
         }

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -153,7 +153,7 @@ fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
             })
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 Improvement: Replaced `.to_string()` on `serde_json::Value` with `serde_json::to_string()` and removed intermediate `Value::Array` wrappers.
🦀 Why: `serde_json::to_string` avoids the overhead of the `Display` trait implementation and intermediate `Value` allocations, making it more idiomatic and efficient.
🔍 Verification: Run `make test`, `make lint`, and `make fmt-check` (or `cargo test`/`cargo clippy`/`cargo fmt`).

---
*PR created automatically by Jules for task [8752280015941662747](https://jules.google.com/task/8752280015941662747) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON出力の生成方法を見直し、より安定して配列形式のデータを出力できるようになりました。
  * 一部のJSONシリアライズで失敗時のフォールバックが追加され、空のJSON配列が返るようになりました。
  * キャッシュ保存時の文字列化処理を改善し、JSONとしての整合性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->