### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via Teredo IPv6

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -125,6 +125,7 @@ fn ipv4_is_blocked(addr: Ipv4Addr) -> bool {
 /// - IPv4-mapped and IPv4-compatible (`::ffff:a.b.c.d` and `::a.b.c.d` via `to_ipv4`)
 /// - NAT64 well-known prefix (`64:ff9b::a.b.c.d` — RFC 6052)
 /// - 6to4 (`2002:abcd:efgh::` — RFC 3056)
+/// - Teredo (`2001:0000::/32` — RFC 4380)
 fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
     if let Some(v4) = addr.to_ipv4() {
         return Some(v4);
@@ -150,6 +151,14 @@ fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
         let b = (segments[1] & 0xff) as u8;
         let c = (segments[2] >> 8) as u8;
         let d = (segments[2] & 0xff) as u8;
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
+    // Teredo (RFC 4380): 2001:0000::/32 (last 32 bits are obfuscated by XORing with 0xFFFF)
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        let a = ((segments[6] >> 8) ^ 0xff) as u8;
+        let b = ((segments[6] & 0xff) ^ 0xff) as u8;
+        let c = ((segments[7] >> 8) ^ 0xff) as u8;
+        let d = ((segments[7] & 0xff) ^ 0xff) as u8;
         return Some(Ipv4Addr::new(a, b, c, d));
     }
     None
@@ -292,6 +301,8 @@ mod tests {
             "[64:ff9b::10.0.0.1]",  // NAT64 private
             "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
             "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -289,18 +289,18 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",                // loopback
-            "[::]",                 // unspecified
-            "[fc00::1]",            // unique local
-            "[fe80::1]",            // link-local
-            "[ff02::1]",            // multicast
-            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",    // IPv4-mapped private
-            "[::127.0.0.1]",        // IPv4-compatible loopback
-            "[64:ff9b::127.0.0.1]", // NAT64 loopback
-            "[64:ff9b::10.0.0.1]",  // NAT64 private
-            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
-            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[::1]",                                     // loopback
+            "[::]",                                      // unspecified
+            "[fc00::1]",                                 // unique local
+            "[fe80::1]",                                 // link-local
+            "[ff02::1]",                                 // multicast
+            "[::ffff:127.0.0.1]",                        // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",                         // IPv4-mapped private
+            "[::127.0.0.1]",                             // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]",                      // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",                       // NAT64 private
+            "[2002:7f00:0001::]",                        // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1)
         ] {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** SSRF bypass via Teredo IPv6 tunneling. The existing SSRF guard in `extract_ipv4` only parsed NAT64 and 6to4 transition addresses. An attacker could bypass the filter and target blocked internal IPv4 addresses (like `127.0.0.1`) by supplying a Teredo IPv6 equivalent (e.g., `[2001:0000:4136:e378:8000:63bf:80ff:fffe]`).
🎯 **Impact:** An attacker could coax the application into probing internal network infrastructure, accessing private/loopback services, or exfiltrating sensitive internal data via SSRF.
🔧 **Fix:** Added XOR-based extraction logic (`^ 0xff`) for Teredo (`2001:0000::/32`) addresses in `extract_ipv4`, ensuring these obfuscated IPv4 payloads are evaluated against the standard IPv4 blocklist. Also updated the `.jules/sentinel.md` journal with this critical finding.
✅ **Verification:** Added test cases covering loopback and private IPv4 addresses obfuscated within Teredo IPv6 payloads to `rejects_blocked_ipv6_literals`, and verified that `cargo test --workspace` passes cleanly.

---
*PR created automatically by Jules for task [15136837532080203063](https://jules.google.com/task/15136837532080203063) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 一部のIPv6表記から、Teredo経由で復元されるIPv4アドレスを正しく判定するようになりました。
  * これにより、ループバックやプライベート相当の宛先を指すURLは、引き続きブロックされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->