### PR TITLE
🎓 Scholar: [serde_json] usage improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 workspace = true
 
 [dependencies]
+serde = { workspace = true }
 # The lint pipeline (parser/engine/config/`lint_document`), the morphology registry seam, and the
 # `Host`-free `decompress_dictionary` the full build uses to verify a JS-supplied dictionary blob.
 tzlint_core = { path = "../tzlint_core", version = "0.0.0" }

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -139,21 +139,29 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
         .collect()
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticJson<'a> {
+    rule_id: &'a str,
+    severity: &'static str,
+    message: &'a str,
+    start: u32,
+    end: u32,
+}
+
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    let items: Vec<DiagnosticJson> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| DiagnosticJson {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: &d.message,
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde_json/latest/serde_json/macro.json.html
💡 Insight: Building a dynamic `serde_json::Value` (e.g. `serde_json::json!`) and then serializing it allocates an entire intermediate JSON DOM and uses the `Display` trait overhead. Using a strongly-typed struct with `#[derive(serde::Serialize)]` and directly calling `serde_json::to_string(&value)` skips the DOM allocation completely.
🛠️ Change: Added `serde` to Wasm crate, replaced the intermediate `serde_json::json!` DOM allocation in `tzlint_wasm`'s `diagnostics_to_json` with a custom `DiagnosticJson` struct deriving `Serialize` and a direct `serde_json::to_string()` call.
✨ Benefit: This significantly improves serialization speed and reduces heap allocation overhead in the Wasm hot-path.

---
*PR created automatically by Jules for task [6034741036890485209](https://jules.google.com/task/6034741036890485209) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 诊断情報のJSON出力が、より安定した形式で生成されるようになりました。
  * 出力される項目（`ruleId`、`severity`、`message`、`start`、`end`）はこれまで通り維持されています。

* **バグ修正**
  * JSON変換に失敗した場合でも、空の配列として安全に返すようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->