### PR TITLE
⚡ Bolt: Optimize JSON serialization in wasm bindings

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - WASM JS bindings JSON DOM allocation
+**Learning:** Building `serde_json::Value` (JSON DOM) structures inside hot iterators (like WASM binding boundary `diagnostics_to_json`) triggers multiple allocations that can be completely avoided by defining a local struct deriving `serde::Serialize`.
+**Action:** Always define structured types with `#[derive(Serialize)]` instead of `serde_json::json!` and `Value::Array` to stringify collections directly for WASM boundary interactions, avoiding dynamic allocations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -25,6 +25,7 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
 serde_json = { workspace = true }
+serde = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -139,21 +139,29 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
         .collect()
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticJson<'a> {
+    rule_id: &'a str,
+    severity: &'a str,
+    message: &'a str,
+    start: u32,
+    end: u32,
+}
+
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    let items: Vec<DiagnosticJson> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| DiagnosticJson {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: d.message.as_str(),
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Replaced the dynamic `serde_json::json!` object creation and `Value::Array` wrapper in `tzlint_wasm::diagnostics_to_json` with a statically typed `DiagnosticJson` struct that implements `serde::Serialize`. Added `serde` workspace dependency to the wasm crate.
🎯 Why: Building intermediate `serde_json::Value` trees inside an iterator allocates memory per object, per property, and per array element. By serializing a structurally identical typed `Vec<DiagnosticJson>` directly to string, we bypass the JSON DOM allocations entirely.
📊 Impact: Eliminates `O(N)` heap allocations (where N is the number of diagnostics and their fields) on the Wasm/JS boundary hot path, resulting in lower peak memory usage and significantly faster serialization time.
🔬 Measurement: Run the native and JS-based Wasm benchmark suites to observe lower `malloc` calls per document analyzed and reduced GC pressure in the embedding environment. Verified correct string output using `cargo test -p tzlint_wasm`.

---
*PR created automatically by Jules for task [14347412124796992359](https://jules.google.com/task/14347412124796992359) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wasm 経由の診断情報の JSON 出力が、より安定した形式で生成されるようになりました。
  * JSON 変換に失敗した場合でも、空配列を返すフォールバックが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->