### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via Teredo IPv6 addresses

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -152,6 +152,14 @@ fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
         let d = (segments[2] & 0xff) as u8;
         return Some(Ipv4Addr::new(a, b, c, d));
     }
+    // Teredo (RFC 4380): 2001:0000::/32
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        let a = ((segments[6] ^ 0xFFFF) >> 8) as u8;
+        let b = ((segments[6] ^ 0xFFFF) & 0xff) as u8;
+        let c = ((segments[7] ^ 0xFFFF) >> 8) as u8;
+        let d = ((segments[7] ^ 0xFFFF) & 0xff) as u8;
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
     None
 }
 
@@ -280,18 +288,20 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",                // loopback
-            "[::]",                 // unspecified
-            "[fc00::1]",            // unique local
-            "[fe80::1]",            // link-local
-            "[ff02::1]",            // multicast
-            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",    // IPv4-mapped private
-            "[::127.0.0.1]",        // IPv4-compatible loopback
-            "[64:ff9b::127.0.0.1]", // NAT64 loopback
-            "[64:ff9b::10.0.0.1]",  // NAT64 private
-            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
-            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[::1]",                                     // loopback
+            "[::]",                                      // unspecified
+            "[fc00::1]",                                 // unique local
+            "[fe80::1]",                                 // link-local
+            "[ff02::1]",                                 // multicast
+            "[::ffff:127.0.0.1]",                        // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",                         // IPv4-mapped private
+            "[::127.0.0.1]",                             // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]",                      // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",                       // NAT64 private
+            "[2002:7f00:0001::]",                        // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SSRF bypass via Teredo IPv6 addresses (RFC 4380). An attacker can embed loopback or private IPv4 addresses (like 127.0.0.1 or 10.0.0.1) inside an IPv6 Teredo address (2001:0000::/32).
🎯 Impact: The linter can be coaxed into probing internal services or local endpoints due to inadequate validation of IPv4 addresses embedded in Teredo IPv6 transition-form addresses.
🔧 Fix: Explicitly extracted and validated embedded IPv4 addresses from Teredo by XORing the last 32 bits with 0xFFFF.
✅ Verification: Added test cases for Teredo SSRF bypass prevention, executed tests, formatting checks, and clippy with no warnings or errors.

---
*PR created automatically by Jules for task [7216920851204190962](https://jules.google.com/task/7216920851204190962) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 リテラルの判定を改善し、Teredo 形式の埋め込み IPv4 も正しく扱うようになりました。
  * これにより、ローカル/プライベート相当のアドレスが含まれる URL がより確実に拒否されるようになりました。
  * 関連する拒否ケースの検証が追加され、ブロック判定の網羅性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->