### PR TITLE
🦀 Ferris: [refactor] Remove json! macro overhead in WASM boundary serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -25,6 +25,7 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
 serde_json = { workspace = true }
+serde = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -139,21 +139,29 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
         .collect()
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonDiagnostic<'a> {
+    rule_id: &'a str,
+    severity: &'static str,
+    message: &'a str,
+    start: u32,
+    end: u32,
+}
+
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    let items: Vec<JsonDiagnostic> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| JsonDiagnostic {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: d.message.as_str(),
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 Improvement: Replaced the dynamic `serde_json::json!` macro with a `JsonDiagnostic` struct deriving `serde::Serialize` in the `tzlint_wasm` crate.
🦀 Why: Using the `serde_json::json!` macro inside a mapping loop incurs unnecessary allocation overhead by building intermediate `serde_json::Value` objects (the JSON DOM) before stringification. A native struct bypasses this DOM, directly serializing to string, which aligns with Ferris' zero-cost abstraction philosophy and improves performance in the hot-path.
🔎 Verification: Ran `cargo test --workspace` to verify output equivalence. Checked with `cargo clippy --workspace` and `cargo fmt --all --check`.

---
*PR created automatically by Jules for task [8920719082703676397](https://jules.google.com/task/8920719082703676397) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ルール診断の JSON 出力が、より安定した方法で生成されるようになりました。
  * 変換に失敗した場合でも、空の配列を返して処理が継続されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->