### PR TITLE
⚡ Bolt: Avoid JSON DOM allocation in WASM diagnostics serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -25,6 +25,7 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
 serde_json = { workspace = true }
+serde = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -141,19 +141,33 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    // PERFORMANCE OPTIMIZATION (⚡ Bolt):
+    // By using a strongly-typed struct with #[derive(serde::Serialize)] instead of the
+    // serde_json::json! macro, we avoid the heavy overhead of creating an intermediate
+    // dynamic JSON DOM (Value::Object/Value::Array). This significantly reduces heap allocations
+    // and improves serialization speed on the critical WASM execution path.
+    #[derive(serde::Serialize)]
+    struct DiagnosticJson<'a> {
+        #[serde(rename = "ruleId")]
+        rule_id: &'a str,
+        severity: &'static str,
+        message: &'a str,
+        start: u32,
+        end: u32,
+    }
+
+    let items: Vec<DiagnosticJson> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| DiagnosticJson {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: d.message.as_str(),
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Replaced `serde_json::json!` and `Value::Array` with a strongly-typed `#[derive(Serialize)]` struct and direct `serde_json::to_string()` in `tzlint_wasm::diagnostics_to_json`. Added `serde` to `Cargo.toml`.
🎯 Why: To avoid unnecessary JSON DOM heap allocations and `Display` trait overhead during serialization on the performance-critical WASM boundary.
📊 Impact: Significantly reduces memory allocations and improves execution speed when emitting diagnostics to the JS host.
🔬 Measurement: Observe memory footprint and serialization time in WASM execution profiling.

---
*PR created automatically by Jules for task [18271090001111829524](https://jules.google.com/task/18271090001111829524) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 診断結果のJSON出力をより安定した形式で生成するようになりました。
  * 変換に失敗した場合でも、空配列を返すフォールバックが追加され、出力エラーの影響を受けにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->