### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Teredo SSRF bypass

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -152,6 +152,14 @@ fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
         let d = (segments[2] & 0xff) as u8;
         return Some(Ipv4Addr::new(a, b, c, d));
     }
+    // Teredo (RFC 4380): 2001:0000::/32
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        let a = ((segments[6] >> 8) ^ 0xff) as u8;
+        let b = ((segments[6] & 0xff) ^ 0xff) as u8;
+        let c = ((segments[7] >> 8) ^ 0xff) as u8;
+        let d = ((segments[7] & 0xff) ^ 0xff) as u8;
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
     None
 }
 
@@ -280,18 +288,20 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",                // loopback
-            "[::]",                 // unspecified
-            "[fc00::1]",            // unique local
-            "[fe80::1]",            // link-local
-            "[ff02::1]",            // multicast
-            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",    // IPv4-mapped private
-            "[::127.0.0.1]",        // IPv4-compatible loopback
-            "[64:ff9b::127.0.0.1]", // NAT64 loopback
-            "[64:ff9b::10.0.0.1]",  // NAT64 private
-            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
-            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[::1]",                                     // loopback
+            "[::]",                                      // unspecified
+            "[fc00::1]",                                 // unique local
+            "[fe80::1]",                                 // link-local
+            "[ff02::1]",                                 // multicast
+            "[::ffff:127.0.0.1]",                        // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",                         // IPv4-mapped private
+            "[::127.0.0.1]",                             // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]",                      // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",                       // NAT64 private
+            "[2002:7f00:0001::]",                        // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:f5ff:fffe]", // Teredo private (10.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The URL validation logic for dictionaries in `tzlint_core::net::extract_ipv4` was missing parsing for the Teredo IPv6 transition mechanism (`2001:0000::/32`). This allowed malicious loopback or internal network IP addresses to bypass SSRF protections by encoding the IPv4 address within the last 32 bits (XORed with `0xFFFFFFFF`) of a valid Teredo IPv6 address.
🎯 Impact: Attackers could fetch dictionaries from internal microservices or the local loopback adapter by passing a crafted Teredo IPv6 address, potentially leading to unauthorized data exfiltration, port scanning, or internal service exploitation.
🔧 Fix: Updated `extract_ipv4` to explicitly decode Teredo IPv6 addresses following RFC 4380 by un-XORing the last 32 bits and emitting the underlying IPv4 payload, allowing the existing SSRF guardrails (`ipv4_is_blocked`) to correctly reject it.
✅ Verification: Ran `cargo clippy`, `cargo fmt`, and successfully ran `cargo test`, ensuring newly added tests cover Teredo private and loopback address blocking.

---
*PR created automatically by Jules for task [13083071429740877740](https://jules.google.com/task/13083071429740877740) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6リテラル内の埋め込みIPv4の判定を改善し、Teredo形式のアドレスも正しくブロック対象として扱うようになりました。
  * その結果、特定のループバックやプライベート相当のIPv6アドレスが、期待どおり拒否されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->