### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -25,6 +25,7 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
 serde_json = { workspace = true }
+serde = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -14,7 +14,7 @@
 //! its caching (IndexedDB/OPFS) live on the JS side — wasm only verifies the pin and decompresses
 //! the bytes it is handed (reusing the same container/pin pipeline as the CLI).
 
-use serde_json::Value;
+use serde::Serialize;
 use tzlint_core::{
     Config, ConfigFormat, MorphologyRegistry, ProcessorConfig, RegionRules, Registry, RuleSetting,
     lint_document,
@@ -134,26 +134,39 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
         .filter_map(|id| match config.rules.get(&RuleId::from(*id)) {
             Some(RuleSetting::Off) => None,
             Some(RuleSetting::On { severity, options }) => build_rule(id, options, *severity),
-            None => build_rule(id, &Value::Null, None),
+            None => build_rule(id, &serde_json::Value::Null, None),
         })
         .collect()
 }
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    // 🎓 Scholar improvement: Avoid intermediate `serde_json::Value` allocations
+    // See docs: https://docs.rs/serde_json/latest/serde_json/value/enum.Value.html
+    // and https://docs.rs/serde_json/latest/serde_json/fn.to_string.html
+    // "In general, using strongly-typed data structures is faster and has a smaller memory footprint than using Value."
+    #[derive(Serialize)]
+    struct DiagnosticJson<'a> {
+        #[serde(rename = "ruleId")]
+        rule_id: &'a str,
+        severity: &'static str,
+        message: &'a str,
+        start: u32,
+        end: u32,
+    }
+
+    let items: Vec<DiagnosticJson> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| DiagnosticJson {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: &d.message,
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde_json/latest/serde_json/value/enum.Value.html and https://docs.rs/serde_json/latest/serde_json/fn.to_string.html
💡 Insight: Constructing intermediate `serde_json::Value` objects (e.g., via `serde_json::json!`) introduces significant heap allocation and layout overhead compared to direct, strongly-typed serialization.
🛠️ Change: Replaced the dynamic AST intermediate structure (`Value::Array`) in `diagnostics_to_json` (inside `crates/tzlint_wasm/src/lib.rs`) with a custom struct `DiagnosticJson` that leverages `#[derive(serde::Serialize)]`. Added `serde` workspace dependency to support the derive macro.
✨ Benefit: Improved CPU and memory efficiency at the performance-critical WASM serialization boundary by eliminating intermediate JSON-DOM allocations and leveraging Rust's structural serialization.

---
*PR created automatically by Jules for task [15339083018883159045](https://jules.google.com/task/15339083018883159045) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 診断結果のJSON出力がより安定し、予期しない形式のデータでも安全に出力されるようになりました。
  * 出力の生成に失敗した場合でも、空の結果として扱われるようになり、利用時の不具合を減らしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->