### PR TITLE
🦀 Ferris: Replace serde_json::json! in wasm bindings with direct serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -25,6 +25,7 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
 serde_json = { workspace = true }
+serde = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -140,20 +140,29 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
 }
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+#[derive(serde::Serialize)]
+struct DiagnosticJson<'a> {
+    #[serde(rename = "ruleId")]
+    rule_id: &'a str,
+    severity: &'static str,
+    message: &'a str,
+    start: u32,
+    end: u32,
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    let items: Vec<DiagnosticJson> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| DiagnosticJson {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: d.message.as_str(),
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 Improvement: Replace `serde_json::json!` and `Value::Array` with direct `DiagnosticJson` struct serialization in the `tzlint_wasm` codebase.
🦀 Why: Building dynamic `serde_json::Value` objects incurs intermediate JSON DOM allocation overhead. Bypassing it by serializing strongly typed structs is faster and more idiomatic for high-performance Rust, especially in performance-critical code like WASM bindings.
🔍 Verification: Tests pass successfully (`cargo test -p tzlint_wasm`) and linter checks out (`cargo clippy`).

---
*PR created automatically by Jules for task [10557090519658610942](https://jules.google.com/task/10557090519658610942) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 診断情報のJSON出力がより安定しました。
  * 診断一覧の生成に失敗した場合でも、空の配列を返すようになりました。
  * 出力される項目（ルールID、重要度、メッセージ、範囲情報）の形式はそのまま維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->