### PR TITLE
⚡ Bolt: [performance improvement] Replace json! with custom struct for diagnostics serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -25,6 +25,7 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
 serde_json = { workspace = true }
+serde = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -139,21 +139,29 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
         .collect()
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticJson<'a> {
+    rule_id: &'a str,
+    severity: &'a str,
+    message: &'a str,
+    start: u32,
+    end: u32,
+}
+
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    let items: Vec<DiagnosticJson> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| DiagnosticJson {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: d.message.as_str(),
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Replaced the dynamic `serde_json::json!` macro in `crates/tzlint_wasm/src/lib.rs` with a custom struct `DiagnosticJson` that implements `serde::Serialize`.
🎯 Why: The previous implementation created intermediate `serde_json::Value` instances on the heap for each diagnostic result before serializing, which caused unnecessary DOM allocations. The new approach serializes straight from the vector of references, lowering CPU overhead and memory footprint at the WebAssembly boundary.
📊 Impact: Considerably faster JSON serialization of linter outputs within WebAssembly, with reduced memory allocations per linted document.
🔬 Measurement: Profile WASM linter execution (especially on inputs yielding many diagnostics) and observe reduced memory allocations and execution time during the final result serialization step.

---
*PR created automatically by Jules for task [10492679523209883033](https://jules.google.com/task/10492679523209883033) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 診断結果の出力形式がより安定した固定スキーマのJSONになりました。
  * 診断情報に、ルールID・重大度・メッセージ・開始/終了位置が含まれます。

* **バグ修正**
  * JSON生成に失敗した場合でも、空の配列を返すようになり、出力の失敗を避けやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->