### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via Teredo IPv6 transition mechanism

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -152,6 +152,14 @@ fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
         let d = (segments[2] & 0xff) as u8;
         return Some(Ipv4Addr::new(a, b, c, d));
     }
+    // Teredo (RFC 4380): 2001::/32
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        let a = (!segments[6] >> 8) as u8;
+        let b = (!segments[6] & 0xff) as u8;
+        let c = (!segments[7] >> 8) as u8;
+        let d = (!segments[7] & 0xff) as u8;
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
     None
 }
 
@@ -280,18 +288,20 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",                // loopback
-            "[::]",                 // unspecified
-            "[fc00::1]",            // unique local
-            "[fe80::1]",            // link-local
-            "[ff02::1]",            // multicast
-            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",    // IPv4-mapped private
-            "[::127.0.0.1]",        // IPv4-compatible loopback
-            "[64:ff9b::127.0.0.1]", // NAT64 loopback
-            "[64:ff9b::10.0.0.1]",  // NAT64 private
-            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
-            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[::1]",                  // loopback
+            "[::]",                   // unspecified
+            "[fc00::1]",              // unique local
+            "[fe80::1]",              // link-local
+            "[ff02::1]",              // multicast
+            "[::ffff:127.0.0.1]",     // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",      // IPv4-mapped private
+            "[::127.0.0.1]",          // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]",   // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",    // NAT64 private
+            "[2002:7f00:0001::]",     // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",     // 6to4 private (10.0.0.1)
+            "[2001:0000::80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:0000::f5ff:fffe]", // Teredo private (10.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: IPv6 Teredo transition mechanism addresses (2001::/32) obfuscate embedded IPv4 addresses by XORing the last 32 bits with 0xFFFF, allowing loopback and private IPv4 addresses to bypass the blocklist.
🎯 Impact: Attackers could bypass SSRF protections and probe internal services (e.g. 127.0.0.1 or 10.x.x.x) by supplying Teredo-encoded IPv6 addresses.
🔧 Fix: Added explicit parsing and extraction of the obfuscated IPv4 address from the last 32 bits of Teredo IPv6 addresses in net.rs, ensuring they are validated against IPv4 rules.
✅ Verification: Added tests for Teredo loopback and private IPs and verified they are correctly blocked.

---
*PR created automatically by Jules for task [17706019414440962693](https://jules.google.com/task/17706019414440962693) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 リテラルの判定を改善し、Teredo 形式で表現された埋め込み IPv4 も適切にブロックされるようになりました。
  * ループバックやプライベート範囲のアドレスが、期待どおり既存の制限ルールに従って拒否されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->