### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -25,6 +25,7 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
 serde_json = { workspace = true }
+serde = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -139,21 +139,29 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
         .collect()
 }
 
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DiagnosticJson<'a> {
+    rule_id: &'a str,
+    severity: &'static str,
+    message: &'a str,
+    start: u32,
+    end: u32,
+}
+
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    let items: Vec<DiagnosticJson> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| DiagnosticJson {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: d.message.as_str(),
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde_json/latest/serde_json/
💡 Insight: Constructing an intermediate `serde_json::Value` JSON DOM via `json!` macro and serializing it with `.to_string()` (via `Display`) introduces significant allocation overhead. The library documentation suggests directly deriving `serde::Serialize` on a local struct and passing it to `serde_json::to_string()`, which bypasses the DOM allocations.
🛠️ Change: Replaced the `json!` macro usage and `Value::Array` allocation in `tzlint_wasm::diagnostics_to_json` with a local `DiagnosticJson` struct deriving `Serialize`, mapped to `camelCase`. Added `serde` workspace dependency to `tzlint_wasm`.
✨ Benefit: Improved WASM execution speed and reduced memory footprint by avoiding unnecessary intermediate JSON DOM allocations in the performance-critical bindings path.

---
*PR created automatically by Jules for task [1641463376389703180](https://jules.google.com/task/1641463376389703180) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * wasm 経由で返す診断結果の JSON 生成がより安定しました。
  * 診断一覧の出力が、失敗時でも空配列にフォールバックするようになりました。
  * 出力形式を型に基づくシリアライズへ統一し、`ruleId`、`severity`、`message`、`start`、`end` の表示が一貫しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->