### PR TITLE
🦀 Ferris: Use derived Serialize instead of serde_json::json! in Wasm bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.
 tzlint_morphology_native = { path = "../tzlint_morphology_native", version = "0.0.0", optional = true }
+serde = { workspace = true, features = ["derive"] }
 
 # wasm-only glue: the `#[wasm_bindgen]` JS bindings + a panic→console.error hook. Native builds (the
 # unit tests of the `Linter` core) never pull these.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -140,20 +140,29 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
 }
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+use serde::Serialize;
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmDiagnostic<'a> {
+    rule_id: &'a str,
+    severity: &'static str,
+    message: &'a str,
+    start: u32,
+    end: u32,
+}
+
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    let items: Vec<WasmDiagnostic> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| WasmDiagnostic {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: &d.message,
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 Improvement: Replaced the dynamic JSON construction via `serde_json::json!` with a typed structure derived for explicit serialization in `tzlint_wasm`.
🦀 Why: Using the macro dynamically allocates `serde_json::Value` tree nodes, adding considerable overhead in hot paths compared to using explicitly derived struct serialization, which works perfectly under our WebAssembly limitations. A safe fallback via `unwrap_or_else` was adopted to remain fully compliant with project standards regarding `expect`.
🔍 Verification: Checked via `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace`. All validations pass without any issues or panics.

---
*PR created automatically by Jules for task [17312734163326481519](https://jules.google.com/task/17312734163326481519) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 診断情報の JSON 出力がより安定し、シリアライズ失敗時でも空の配列を返すようになりました。
  * 出力される項目（ruleId、severity、message、start、end）はこれまで通り維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->