### PR TITLE
⚡ Bolt: [performance improvement] Optimize WASM JSON serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -24,6 +24,7 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 # The built-in rules (`RULE_IDS`/`build_rule`) the linter resolves the active set from.
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
+serde = { workspace = true }
 serde_json = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -139,21 +139,29 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
         .collect()
 }
 
+#[derive(serde::Serialize)]
+struct DiagnosticJson<'a> {
+    #[serde(rename = "ruleId")]
+    rule_id: &'a str,
+    severity: &'static str,
+    message: &'a str,
+    start: u32,
+    end: u32,
+}
+
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    let items: Vec<DiagnosticJson> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| DiagnosticJson {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: d.message.as_str(),
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Refactored `diagnostics_to_json` in `crates/tzlint_wasm/src/lib.rs` to replace the `serde_json::json!` macro implementation. It now uses a local `DiagnosticJson` struct deriving `serde::Serialize` to stream directly to JSON.
🎯 Why: `serde_json::json!` constructs a dynamic DOM (`serde_json::Value` with inner allocs for Maps and Strings) per diagnostic which triggers numerous heap allocations and degrades speed.
📊 Impact: Substantially reduces WASM boundary serialization overhead and minimizes heap fragmentation by directly serializing Rust structs to strings.
🔬 Measurement: Verify memory footprint and latency drop in large documents processed in browser environments via standard benchmark profilers. Added `serde` to workspace `Cargo.toml`.

---
*PR created automatically by Jules for task [15544859778068146584](https://jules.google.com/task/15544859778068146584) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 診断結果の JSON 出力を改善し、より安定してシリアライズされるようになりました。
  * 出力生成に失敗した場合でも、空の配列を返すようになり、予期しないエラーを避けやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->