### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via Teredo IPv6 transition addresses

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -301,7 +301,7 @@ mod tests {
             "[64:ff9b::10.0.0.1]",                       // NAT64 private
             "[2002:7f00:0001::]",                        // 6to4 loopback (127.0.0.1)
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
-            "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo private (192.0.2.45)
+            "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -125,6 +125,7 @@ fn ipv4_is_blocked(addr: Ipv4Addr) -> bool {
 /// - IPv4-mapped and IPv4-compatible (`::ffff:a.b.c.d` and `::a.b.c.d` via `to_ipv4`)
 /// - NAT64 well-known prefix (`64:ff9b::a.b.c.d` — RFC 6052)
 /// - 6to4 (`2002:abcd:efgh::` — RFC 3056)
+/// - Teredo (`2001:0000::` — RFC 4380)
 fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
     if let Some(v4) = addr.to_ipv4() {
         return Some(v4);
@@ -150,6 +151,14 @@ fn extract_ipv4(addr: Ipv6Addr) -> Option<Ipv4Addr> {
         let b = (segments[1] & 0xff) as u8;
         let c = (segments[2] >> 8) as u8;
         let d = (segments[2] & 0xff) as u8;
+        return Some(Ipv4Addr::new(a, b, c, d));
+    }
+    // Teredo (RFC 4380): 2001:0000::/32
+    if segments[0] == 0x2001 && segments[1] == 0x0000 {
+        let a = ((segments[6] ^ 0xffff) >> 8) as u8;
+        let b = ((segments[6] ^ 0xffff) & 0xff) as u8;
+        let c = ((segments[7] ^ 0xffff) >> 8) as u8;
+        let d = ((segments[7] ^ 0xffff) & 0xff) as u8;
         return Some(Ipv4Addr::new(a, b, c, d));
     }
     None
@@ -280,18 +289,20 @@ mod tests {
     #[test]
     fn rejects_blocked_ipv6_literals() {
         for host in [
-            "[::1]",                // loopback
-            "[::]",                 // unspecified
-            "[fc00::1]",            // unique local
-            "[fe80::1]",            // link-local
-            "[ff02::1]",            // multicast
-            "[::ffff:127.0.0.1]",   // IPv4-mapped loopback
-            "[::ffff:10.0.0.1]",    // IPv4-mapped private
-            "[::127.0.0.1]",        // IPv4-compatible loopback
-            "[64:ff9b::127.0.0.1]", // NAT64 loopback
-            "[64:ff9b::10.0.0.1]",  // NAT64 private
-            "[2002:7f00:0001::]",   // 6to4 loopback (127.0.0.1)
-            "[2002:0a00:0001::]",   // 6to4 private (10.0.0.1)
+            "[::1]",                                     // loopback
+            "[::]",                                      // unspecified
+            "[fc00::1]",                                 // unique local
+            "[fe80::1]",                                 // link-local
+            "[ff02::1]",                                 // multicast
+            "[::ffff:127.0.0.1]",                        // IPv4-mapped loopback
+            "[::ffff:10.0.0.1]",                         // IPv4-mapped private
+            "[::127.0.0.1]",                             // IPv4-compatible loopback
+            "[64:ff9b::127.0.0.1]",                      // NAT64 loopback
+            "[64:ff9b::10.0.0.1]",                       // NAT64 private
+            "[2002:7f00:0001::]",                        // 6to4 loopback (127.0.0.1)
+            "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
+            "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo private (192.0.2.45)
+            "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The SSRF protection in `validate_dictionary_url` extracted embedded IPv4 addresses from transition-form IPv6 addresses (like NAT64 and 6to4) to prevent bypassing IPv4 blocklists via mapped IPs. However, it missed the Teredo transition mechanism (`2001:0000::/32`). This allowed malicious Teredo addresses containing internal IPv4 addresses to bypass the blocklist because their IPv6 payload wasn't evaluated against the IPv4 constraints.
🎯 Impact: An attacker could supply a specially crafted Teredo IPv6 address (e.g., `[2001:0000:4136:e378:8000:63bf:80ff:fffe]`) to `validate_dictionary_url`, which would bypass the literal IP restrictions and allow SSRF probes against internal network services (like `127.0.0.1` or `192.168.x.x`).
🔧 Fix: Updated `extract_ipv4` in `crates/tzlint_core/src/net.rs` to identify Teredo addresses (`2001:0000::/32`) and extract the encapsulated client's IPv4 address by XORing the 32 least significant bits (bits 96-127) with `0xFFFF`. The extracted IPv4 address is then evaluated against the existing IPv4 blocklist rules.
✅ Verification: Added new unit tests for Teredo private and loopback addresses to `rejects_blocked_ipv6_literals`. Verified all tests pass with `cargo test --workspace`, formatted with `cargo fmt`, and linted with `cargo clippy`.

---
*PR created automatically by Jules for task [9662566175535497803](https://jules.google.com/task/9662566175535497803) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6アドレスの判定が改善され、Teredo由来のアドレスから埋め込まれたIPv4を正しく扱えるようになりました。
  * これにより、ブロック対象のTeredoアドレスは適切に拒否されるようになります。
  * IPv6リテラルの拒否判定に、Teredo関連のケースが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->