### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-05-28 - serde_json to_string optimization
+**Library:** serde_json v1.0
+**Discovery:** Constructing intermediate JSON DOMs via `serde_json::json!` or `Value::Array` before string serialization incurs unnecessary heap allocations. Using a local `#[derive(Serialize)]` struct and passing it to `serde_json::to_string` is significantly faster.
+**Application:** Replaced the intermediate array allocations in `tzlint_wasm::diagnostics_to_json` with a local `JsonDiagnostic` struct.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,6 +2410,7 @@ name = "tzlint_wasm"
 version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
+ "serde",
  "serde_json",
  "tzlint_core",
  "tzlint_morphology_native",

--- a/crates/tzlint_wasm/Cargo.toml
+++ b/crates/tzlint_wasm/Cargo.toml
@@ -24,6 +24,7 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 # The built-in rules (`RULE_IDS`/`build_rule`) the linter resolves the active set from.
 tzlint_rules = { path = "../tzlint_rules", version = "0.0.0" }
 # Serialize the diagnostics to JSON for the JS boundary (the diagnostic model is serde-free).
+serde = { workspace = true }
 serde_json = { workspace = true }
 # The native morphology backend — pulled ONLY by the `morphology` feature, so the default (lean)
 # wasm artifact is tokenizer-free and tiny. The backend and its deps are pure Rust and build for wasm32.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -141,19 +141,28 @@ fn resolve_rules(config: &Config) -> Vec<Box<dyn Rule>> {
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<Value> = diagnostics
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct JsonDiagnostic<'a> {
+        rule_id: &'a str,
+        severity: &'a str,
+        message: &'a str,
+        start: u32,
+        end: u32,
+    }
+
+    let items: Vec<JsonDiagnostic> = diagnostics
         .iter()
-        .map(|d| {
-            serde_json::json!({
-                "ruleId": d.rule_id.as_str(),
-                "severity": severity_str(d.severity),
-                "message": d.message,
-                "start": d.span.start,
-                "end": d.span.end,
-            })
+        .map(|d| JsonDiagnostic {
+            rule_id: d.rule_id.as_str(),
+            severity: severity_str(d.severity),
+            message: d.message.as_str(),
+            start: d.span.start,
+            end: d.span.end,
         })
         .collect();
-    Value::Array(items).to_string()
+
+    serde_json::to_string(&items).unwrap_or_else(|_| "[]".to_string())
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: serde_json performance documentation
💡 Insight: Constructing dynamic JSON objects via `serde_json::json!` creates unnecessary heap-allocated DOM elements when all we need is string serialization.
🛠️ Change: Refactored `diagnostics_to_json` to map `Diagnostic` objects to a local struct deriving `Serialize`, allowing direct serialization without intermediate generic JSON DOM structures.
✨ Benefit: Increased efficiency and performance by eliminating heap allocation overhead during JSON serialization in WASM.

---
*PR created automatically by Jules for task [10017303744654841534](https://jules.google.com/task/10017303744654841534) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 診断情報の JSON 出力が高速化され、より軽快に取得できるようになりました。
* **Bug Fixes**
  * JSON 変換時の一時的なメモリ使用を抑え、不要な負荷を減らしました。
* **Documentation**
  * 変更内容の要点を補足する説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->