### PR TITLE
chore(deps): bump lindera + lindera-dictionary to 4.0.0 together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,19 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
+      # `lindera` and `lindera-dictionary` are co-versioned (the meta-crate pulls the dictionary
+      # crate at its own exact version), and `tzlint_morphology_native` depends on BOTH directly.
+      # A split bump leaves two `lindera-dictionary` versions in the graph and fails to compile
+      # (`expected Dictionary, found a different Dictionary`), so they must move together — majors
+      # included. Listed before `cargo-minor-and-patch` so it wins the match for every update type.
+      lindera:
+        patterns:
+          - "lindera"
+          - "lindera-*"
+        update-types:
+          - major
+          - minor
+          - patch
       # Batch low-risk updates into one PR; majors still get their own for careful review.
       cargo-minor-and-patch:
         update-types:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,9 +1101,9 @@ checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "lindera"
-version = "3.0.7"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cda79d7161e99b414e4d292ff673cc3f8d22f070d8be3b6185c033363a9216"
+checksum = "947b566e47adbe67d50c6be170309c3b18259877cb36e7f2c70c7edae8c7282f"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1129,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "lindera-dictionary"
-version = "3.0.7"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2385456ca9fe87c29072c5f156b52fdd5e28d5b5738ddfb3979501dbd736530"
+checksum = "6ee9be0de7cbe3f2764b9e7f6715243958e43140703114acdcae8be2b2e6f24d"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -1162,15 +1162,11 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic"
-version = "3.0.7"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130c598519a40bbfb762c4c06d6ad29315331eb4c154fcb2d1d6b46776cee7d9"
+checksum = "b547c618c4b26471f8ff6f9822ada23c3c0d659a3eca0412721fd2becc4b8ff9"
 dependencies = [
- "anyhow",
- "byteorder",
- "csv",
  "lindera-dictionary",
- "serde_json",
  "tokio",
 ]
 

--- a/crates/tzlint_morphology_native/Cargo.toml
+++ b/crates/tzlint_morphology_native/Cargo.toml
@@ -20,13 +20,13 @@ tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 # The morphological analyzer. NATIVE-ONLY by construction: this crate has no dependency edge from
 # the wasm-facing crates (ast/pdk/core), so cargo never resolves lindera for the `wasm32` build,
 # and the crate's `lib.rs` is `#![cfg(not(target_arch = "wasm32"))]` as a second guard. MIT.
-lindera = "3.0.7"
+lindera = "4.0.0"
 # The dictionary component types + their byte-`load()`s (PrefixDictionary, ConnectionCostMatrix,
 # CharacterDefinition, UnknownDictionary, Metadata, and the `Dictionary` struct), which the
 # `lindera` meta-crate does not re-export. Needed to assemble a `Dictionary` in memory from the
 # container's component byte ranges (`from_dictionary_bytes`). Already in the graph as a transitive
 # dependency of `lindera` at this exact version; MIT.
-lindera-dictionary = "3.0.7"
+lindera-dictionary = "4.0.0"
 # The wasm-clean, lindera-free dictionary-container codec (`tzlint_core::dict::container`) used to
 # split the decompressed blob into component byte ranges. A native-only edge (core never depends on
 # this crate, so there is no cycle and the wasm graph is untouched).


### PR DESCRIPTION
## Summary

Bumps both `lindera` and `lindera-dictionary` from 3.0.7 to **4.0.0 in lockstep**, superseding the split Dependabot PRs #113 and #114.

`crates/tzlint_morphology_native` depends **directly on both** crates, which are co-versioned (the `lindera` meta-crate pulls `lindera-dictionary` at its own exact version). Each split PR bumped only one of the two, leaving **two `lindera-dictionary` versions in the dependency graph**. `Segmenter::new(Mode::Normal, dictionary, None)` then receives a cross-version `Dictionary` and the whole workspace fails to compile:

```
error[E0308]: mismatched types
  --> crates/tzlint_morphology_native/src/lib.rs:157:54
   |  expected `Dictionary`, found a different `Dictionary`
note: there are multiple different versions of crate `lindera_dictionary` in the dependency graph
```

That single compile error is why every build/test/clippy/coverage/wasm job failed on #113 and #114.

## Why no source changes were needed

lindera v4 is a major release, but per its [v3→v4 migration guide](https://github.com/lindera/lindera/blob/main/docs/src/migration_v3_to_v4.md) every breaking change lands in:

- the language bindings (Python/Node/Ruby/PHP/WASM) — schema field names, `Token.details` nullability, removed binding `Segmenter`;
- the removed `LINDERA_CACHE` build env var;
- the user-dictionary `.bin` binary format;
- the `lindera-dictionary` **viterbi** internals (`WordId`/`WordEntry`/… field encapsulation).

This crate touches none of those. It uses the `lindera` facade (whose public Rust API is **unchanged** in v4) plus the `Dictionary` struct / dictionary-component `load()` functions (not viterbi), so it compiles and behaves identically.

## Dependabot grouping

Adds a `lindera` group (majors included, listed before `cargo-minor-and-patch`) so the two co-versioned crates always upgrade together in one PR — this split-bump breakage cannot recur.

## Verification

- `just lint` (rustfmt + clippy `--workspace --all-targets -D warnings`) — clean
- `just test` — **707 passed, 0 failed** (incl. doctests)
- `just test-native` (embedded IPADIC) — **18 passed**, including the container round-trip and the end-to-end `no-doubled-joshi` firing test (no tokenization regression)

Closes #113
Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)