### PR TITLE
docs(0.1.0): textlint migration guide + quickstart/install/rule catalog (R16, R19 docs)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,103 @@
+# TsuzuLint
+
+[日本語](README.md) | **English**
+
+> **Status: pre-release (0.1.0 in progress).** The Japanese linting core is complete — full parity
+> with the 23-rule `textlint-rule-preset-ja-technical-writing` (26 built-in rules in total),
+> morphology-driven style rules, and a `prh`-equivalent terminology rule. The VSCode extension and
+> release packaging are the remaining 0.1.0 work. See [`docs/roadmap.md`](docs/roadmap.md) for milestones.
+
+**TsuzuLint** is a high-performance natural-language linter written in Rust — a fast, embeddable
+**Japanese `textlint` replacement** (Korean/Chinese planned). On the full `ja-technical-writing`
+preset it runs roughly **15× faster** than Node `textlint` using far less memory
+(see [benchmarks](docs/benchmarks.md)), and is **migration-friendly**: its rules deliberately mirror
+textlint's names and it imports existing `prh` `.prh.yml` dictionaries
+(see [migrating from textlint](docs/migration-from-textlint.md)).
+
+- **Brand:** TsuzuLint. **Command / crates:** `tzlint` (`tzlint_*`). A short command name
+  behind a longer brand is a common convention (e.g. Visual Studio Code → `code`).
+- **Goals:** execution speed (index-based AST, zero-copy plugin reads, single-traversal
+  scheduler), portability (native + `wasm32`, browser as a first-class design target),
+  easy rule extension (Rust PDK now; layered ABI for future TS/AssemblyScript), safe
+  breaking changes (frozen AST core + additive tables + `bytecheck`), strong tests & docs.
+
+## Usage
+
+[Install `tzlint`](docs/install.md) — from source today (`cargo install --git …` or
+`cargo build --release` → `target/release/tzlint`); prebuilt binaries, an npm wrapper, and the
+editor extension ship with 0.1.0. Then:
+
+```sh
+# Lint files, directories (recursed for Markdown), or globs; `-` reads stdin.
+tzlint lint README.md docs/ 'src/**/*.md'
+cat draft.md | tzlint lint -
+
+# Pick an output format (text | json | sarif).
+tzlint lint --format json docs/
+tzlint lint --format sarif docs/ > results.sarif   # e.g. GitHub code scanning
+
+# Apply autofixes in place (preview with --dry-run); `fix -` filters stdin to stdout.
+tzlint fix docs/
+tzlint fix --dry-run docs/
+cat draft.md | tzlint fix - > fixed.md
+
+# Write a starter .tzlintrc.json in the working directory.
+tzlint init
+
+# Inspect the resolved rule set (honors --config / discovery).
+tzlint rules list
+tzlint rules explain max-ten
+```
+
+A directory argument is searched recursively for `.md`/`.markdown` files (hidden entries and
+symlinks are skipped); globs (`*`, `?`, `[...]`, `**`) match exactly, so quote them to keep the
+shell from expanding them first.
+
+Global options: `-c/--config <PATH>` (use a specific config instead of upward discovery),
+`-v/--verbose` (extra notes to stderr), `--no-cache` (skip the document cache).
+
+`lint` exits `0` when clean, `1` when it reports one or more diagnostics, and `2` on an
+operational error (bad config, unreadable file, …) — the conventional codes for CI. The text
+format is `path:line:col: severity: message [rule]`, where `col` is the diagnostic's 1-based
+start column:
+
+```text
+$ printf 'これはﾊﾛｰという文です。\n' | tzlint lint -
+<stdin>:1:4: warning: 半角カタカナは推奨されません。全角カタカナを使ってください。 [no-hankaku-kana]
+1 file(s) checked, 1 issue(s) found
+```
+
+See [`docs/install.md`](docs/install.md) for install methods,
+[`docs/config-reference.md`](docs/config-reference.md) for configuration (and the full rule list),
+[`docs/migration-from-textlint.md`](docs/migration-from-textlint.md) for switching from textlint,
+[`docs/json-output.md`](docs/json-output.md) for the `--format json` contract,
+[`docs/processors.md`](docs/processors.md) for CSV/TSV column linting, and
+[`docs/benchmarks.md`](docs/benchmarks.md) for the textlint performance comparison.
+
+## Workspace layout
+
+```
+crates/
+  tzlint_ast    frozen ABI types (index-based AST, Span)
+  tzlint_core   parser + lint engine + config + cache + io
+  tzlint_rules  built-in native rules
+  tzlint_pdk    rule-author SDK
+  tzlint_abi    shared-memory plugin ABI
+  tzlint_cli    the `tzlint` binary
+  tzlint_lsp    LSP server (scaffold in v1)
+```
+
+## Build
+
+```sh
+cargo build          # or: just build
+cargo test           # or: just test
+just check           # rustfmt + clippy + tests (CI-equivalent)
+```
+
+MSRV: Rust **1.94** — rolling policy: **latest stable − 2** (tracking wasmtime's "last 3
+stable releases"); bumped each Rust release. Development uses the latest stable.
+License: **Apache-2.0**.
+
+Documentation lives under [`docs/`](docs/) and is written in English. The Japanese-facing landing
+page is [`README.md`](README.md); this file mirrors it in English.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # TsuzuLint
 
-> **Status: pre-release (0.1.0 in progress).** The Japanese linting core is complete — full
-> `textlint-rule-preset-ja-technical-writing` parity (26 built-in rules), morphology-driven style
-> rules, and a `prh`-equivalent terminology rule. The VSCode extension and release packaging are
-> the remaining 0.1.0 work. See [`docs/roadmap.md`](docs/roadmap.md) for milestones.
+> **Status: pre-release (0.1.0 in progress).** The Japanese linting core is complete — full parity
+> with the 23-rule `textlint-rule-preset-ja-technical-writing` (26 built-in rules in total),
+> morphology-driven style rules, and a `prh`-equivalent terminology rule. The VSCode extension and
+> release packaging are the remaining 0.1.0 work. See [`docs/roadmap.md`](docs/roadmap.md) for milestones.
 
 **TsuzuLint** is a high-performance natural-language linter written in Rust — a fast, embeddable
 **Japanese `textlint` replacement** (Korean/Chinese planned). On the full `ja-technical-writing`
-preset it runs roughly **15× faster** than Node `textlint` at a fraction of the memory
+preset it runs roughly **15× faster** than Node `textlint` using far less memory
 (see [benchmarks](docs/benchmarks.md)), and is **migration-friendly**: its rules deliberately mirror
 textlint's names and it imports existing `prh` `.prh.yml` dictionaries
 (see [migrating from textlint](docs/migration-from-textlint.md)).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # TsuzuLint
 
-> **Status: research / WIP — clean redesign in progress.** This repository is the
-> ground-up redesign of TsuzuLint. See [`docs/roadmap.md`](docs/roadmap.md) for milestones.
+> **Status: pre-release (0.1.0 in progress).** The Japanese linting core is complete — full
+> `textlint-rule-preset-ja-technical-writing` parity (26 built-in rules), morphology-driven style
+> rules, and a `prh`-equivalent terminology rule. The VSCode extension and release packaging are
+> the remaining 0.1.0 work. See [`docs/roadmap.md`](docs/roadmap.md) for milestones.
 
-**TsuzuLint** is a high-performance natural-language linter written in Rust, inspired by
-textlint and specialized for CJK (Japanese first; Korean/Chinese planned).
+**TsuzuLint** is a high-performance natural-language linter written in Rust — a fast, embeddable
+**Japanese `textlint` replacement** (Korean/Chinese planned). On the full `ja-technical-writing`
+preset it runs roughly **15× faster** than Node `textlint` at a fraction of the memory
+(see [benchmarks](docs/benchmarks.md)), and is **migration-friendly**: its rules deliberately mirror
+textlint's names and it imports existing `prh` `.prh.yml` dictionaries
+(see [migrating from textlint](docs/migration-from-textlint.md)).
 
 - **Brand:** TsuzuLint. **Command / crates:** `tzlint` (`tzlint_*`). A short command name
   behind a longer brand is a common convention (e.g. Visual Studio Code → `code`).
@@ -15,7 +21,9 @@ textlint and specialized for CJK (Japanese first; Korean/Chinese planned).
 
 ## Usage
 
-Build the binary (`cargo build --release` → `target/release/tzlint`), then:
+[Install `tzlint`](docs/install.md) — from source today (`cargo install --git …` or
+`cargo build --release` → `target/release/tzlint`); prebuilt binaries, an npm wrapper, and the
+editor extension ship with 0.1.0. Then:
 
 ```sh
 # Lint files, directories (recursed for Markdown), or globs; `-` reads stdin.
@@ -57,9 +65,12 @@ $ printf 'これはﾊﾛｰという文です。\n' | tzlint lint -
 1 file(s) checked, 1 issue(s) found
 ```
 
-See [`docs/config-reference.md`](docs/config-reference.md) for configuration,
-[`docs/json-output.md`](docs/json-output.md) for the `--format json` contract, and
-[`docs/processors.md`](docs/processors.md) for CSV/TSV column linting.
+See [`docs/install.md`](docs/install.md) for install methods,
+[`docs/config-reference.md`](docs/config-reference.md) for configuration (and the full rule list),
+[`docs/migration-from-textlint.md`](docs/migration-from-textlint.md) for switching from textlint,
+[`docs/json-output.md`](docs/json-output.md) for the `--format json` contract,
+[`docs/processors.md`](docs/processors.md) for CSV/TSV column linting, and
+[`docs/benchmarks.md`](docs/benchmarks.md) for the textlint performance comparison.
 
 ## Workspace layout
 

--- a/README.md
+++ b/README.md
@@ -1,63 +1,62 @@
 # TsuzuLint
 
-> **Status: pre-release (0.1.0 in progress).** The Japanese linting core is complete — full parity
-> with the 23-rule `textlint-rule-preset-ja-technical-writing` (26 built-in rules in total),
-> morphology-driven style rules, and a `prh`-equivalent terminology rule. The VSCode extension and
-> release packaging are the remaining 0.1.0 work. See [`docs/roadmap.md`](docs/roadmap.md) for milestones.
+**日本語** | [English](README.en.md)
 
-**TsuzuLint** is a high-performance natural-language linter written in Rust — a fast, embeddable
-**Japanese `textlint` replacement** (Korean/Chinese planned). On the full `ja-technical-writing`
-preset it runs roughly **15× faster** than Node `textlint` using far less memory
-(see [benchmarks](docs/benchmarks.md)), and is **migration-friendly**: its rules deliberately mirror
-textlint's names and it imports existing `prh` `.prh.yml` dictionaries
-(see [migrating from textlint](docs/migration-from-textlint.md)).
+> **ステータス: プレリリース（0.1.0 開発中）。** 日本語リントの中核は完成済みです — 23ルールの
+> `textlint-rule-preset-ja-technical-writing` と完全パリティ（組み込みルールは合計26）、形態素解析
+> ベースの文体ルール、`prh` 相当の表記ゆれ/用語ルールを搭載。残る 0.1.0 の作業は VSCode 拡張とリリース
+> パッケージングです。マイルストーンは [`docs/roadmap.md`](docs/roadmap.md) を参照してください。
 
-- **Brand:** TsuzuLint. **Command / crates:** `tzlint` (`tzlint_*`). A short command name
-  behind a longer brand is a common convention (e.g. Visual Studio Code → `code`).
-- **Goals:** execution speed (index-based AST, zero-copy plugin reads, single-traversal
-  scheduler), portability (native + `wasm32`, browser as a first-class design target),
-  easy rule extension (Rust PDK now; layered ABI for future TS/AssemblyScript), safe
-  breaking changes (frozen AST core + additive tables + `bytecheck`), strong tests & docs.
+**TsuzuLint** は Rust 製の高速な自然言語リンターで、**日本語版 `textlint` の置き換え**を目指しています
+（韓国語・中国語も将来対応予定）。`ja-technical-writing` プリセット全体で Node 版 `textlint` の約 **15倍
+高速**、メモリ使用量も大幅に少なく動作します（[ベンチマーク](docs/benchmarks.md)）。さらに**移行しやすい**
+設計です: ルール名は textlint に意図的に揃えてあり、既存の `prh` `.prh.yml` 辞書をそのまま読み込めます
+（[textlint からの移行](docs/migration-from-textlint.md)）。
 
-## Usage
+- **ブランド:** TsuzuLint。**コマンド / クレート:** `tzlint`（`tzlint_*`）。長いブランド名に短いコマンド
+  名を割り当てるのは一般的な慣習です（例: Visual Studio Code → `code`）。
+- **目標:** 実行速度（インデックスベース AST、ゼロコピーのプラグイン読み取り、単一走査スケジューラ）、
+  移植性（ネイティブ + `wasm32`、ブラウザを第一級の設計対象に）、容易なルール拡張（現在は Rust PDK、
+  将来は TS/AssemblyScript 向けの階層化 ABI）、安全な破壊的変更（凍結された AST コア + 追加専用テーブル
+  + `bytecheck`）、充実したテストとドキュメント。
 
-[Install `tzlint`](docs/install.md) — from source today (`cargo install --git …` or
-`cargo build --release` → `target/release/tzlint`); prebuilt binaries, an npm wrapper, and the
-editor extension ship with 0.1.0. Then:
+## 使い方
+
+[`tzlint` をインストール](docs/install.md)してください — 現時点ではソースからビルドします
+（`cargo install --git …` または `cargo build --release` → `target/release/tzlint`）。プリビルドバイナリ・
+npm ラッパー・エディタ拡張は 0.1.0 で提供予定です。その後:
 
 ```sh
-# Lint files, directories (recursed for Markdown), or globs; `-` reads stdin.
+# ファイル・ディレクトリ（Markdown は再帰探索）・glob をリント。`-` は標準入力を読む。
 tzlint lint README.md docs/ 'src/**/*.md'
 cat draft.md | tzlint lint -
 
-# Pick an output format (text | json | sarif).
+# 出力フォーマットを選択（text | json | sarif）。
 tzlint lint --format json docs/
-tzlint lint --format sarif docs/ > results.sarif   # e.g. GitHub code scanning
+tzlint lint --format sarif docs/ > results.sarif   # 例: GitHub code scanning
 
-# Apply autofixes in place (preview with --dry-run); `fix -` filters stdin to stdout.
+# 自動修正をその場で適用（--dry-run でプレビュー）。`fix -` は標準入力→標準出力。
 tzlint fix docs/
 tzlint fix --dry-run docs/
 cat draft.md | tzlint fix - > fixed.md
 
-# Write a starter .tzlintrc.json in the working directory.
+# 作業ディレクトリに雛形 .tzlintrc.json を書き出す。
 tzlint init
 
-# Inspect the resolved rule set (honors --config / discovery).
+# 解決後のルールセットを確認（--config / 設定探索を尊重）。
 tzlint rules list
 tzlint rules explain max-ten
 ```
 
-A directory argument is searched recursively for `.md`/`.markdown` files (hidden entries and
-symlinks are skipped); globs (`*`, `?`, `[...]`, `**`) match exactly, so quote them to keep the
-shell from expanding them first.
+ディレクトリ引数は `.md`/`.markdown` を再帰的に探索します（隠しエントリとシンボリックリンクはスキップ）。
+glob（`*`, `?`, `[...]`, `**`）は厳密にマッチするため、シェルが先に展開しないようクォートしてください。
 
-Global options: `-c/--config <PATH>` (use a specific config instead of upward discovery),
-`-v/--verbose` (extra notes to stderr), `--no-cache` (skip the document cache).
+グローバルオプション: `-c/--config <PATH>`（上位探索の代わりに指定の設定ファイルを使用）、`-v/--verbose`
+（追加の注記を stderr へ）、`--no-cache`（ドキュメントキャッシュを無効化）。
 
-`lint` exits `0` when clean, `1` when it reports one or more diagnostics, and `2` on an
-operational error (bad config, unreadable file, …) — the conventional codes for CI. The text
-format is `path:line:col: severity: message [rule]`, where `col` is the diagnostic's 1-based
-start column:
+`lint` は問題なしで `0`、診断が1件以上で `1`、運用エラー（不正な設定、読み取り不能なファイルなど）で `2`
+を返します — CI 向けの慣例的な終了コードです。text フォーマットは `path:line:col: severity: message [rule]`
+で、`col` は診断開始位置の1始まりの桁です:
 
 ```text
 $ printf 'これはﾊﾛｰという文です。\n' | tzlint lint -
@@ -65,36 +64,36 @@ $ printf 'これはﾊﾛｰという文です。\n' | tzlint lint -
 1 file(s) checked, 1 issue(s) found
 ```
 
-See [`docs/install.md`](docs/install.md) for install methods,
-[`docs/config-reference.md`](docs/config-reference.md) for configuration (and the full rule list),
-[`docs/migration-from-textlint.md`](docs/migration-from-textlint.md) for switching from textlint,
-[`docs/json-output.md`](docs/json-output.md) for the `--format json` contract,
-[`docs/processors.md`](docs/processors.md) for CSV/TSV column linting, and
-[`docs/benchmarks.md`](docs/benchmarks.md) for the textlint performance comparison.
+各ドキュメントへのリンク（いずれも英語）: 設定は [`docs/config-reference.md`](docs/config-reference.md)
+（全ルール一覧も）、textlint からの移行は [`docs/migration-from-textlint.md`](docs/migration-from-textlint.md)、
+インストール方法は [`docs/install.md`](docs/install.md)、`--format json` の仕様は
+[`docs/json-output.md`](docs/json-output.md)、CSV/TSV の列リントは [`docs/processors.md`](docs/processors.md)、
+textlint との性能比較は [`docs/benchmarks.md`](docs/benchmarks.md) を参照してください。
 
-## Workspace layout
+## ワークスペース構成
 
 ```
 crates/
-  tzlint_ast    frozen ABI types (index-based AST, Span)
-  tzlint_core   parser + lint engine + config + cache + io
-  tzlint_rules  built-in native rules
-  tzlint_pdk    rule-author SDK
-  tzlint_abi    shared-memory plugin ABI
-  tzlint_cli    the `tzlint` binary
-  tzlint_lsp    LSP server (scaffold in v1)
+  tzlint_ast    凍結 ABI 型（インデックスベース AST、Span）
+  tzlint_core   パーサ + リントエンジン + 設定 + キャッシュ + io
+  tzlint_rules  組み込みネイティブルール
+  tzlint_pdk    ルール作成者向け SDK
+  tzlint_abi    共有メモリのプラグイン ABI
+  tzlint_cli    `tzlint` バイナリ
+  tzlint_lsp    LSP サーバ（v1 では雛形）
 ```
 
-## Build
+## ビルド
 
 ```sh
-cargo build          # or: just build
-cargo test           # or: just test
-just check           # rustfmt + clippy + tests (CI-equivalent)
+cargo build          # または: just build
+cargo test           # または: just test
+just check           # rustfmt + clippy + tests（CI と同等）
 ```
 
-MSRV: Rust **1.94** — rolling policy: **latest stable − 2** (tracking wasmtime's "last 3
-stable releases"); bumped each Rust release. Development uses the latest stable.
-License: **Apache-2.0**.
+MSRV: Rust **1.94** — ローリングポリシー: **最新安定版 − 2**（wasmtime の「直近3つの安定版」に追従）。
+Rust のリリースごとに更新します。開発は最新安定版で行います。
+ライセンス: **Apache-2.0**。
 
-Documentation lives under [`docs/`](docs/) and is written in English.
+ドキュメント（[`docs/`](docs/)）と Rustdoc は英語で記述されています。この README の英語版は
+[README.en.md](README.en.md) を参照してください。

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -35,12 +35,20 @@
   collision). Built-in presets:
   - `ja-basic` — `no-hankaku-kana`, `no-mixed-zenkaku-hankaku-alphabet`, `no-nfd`,
     `no-zero-width-spaces`, `ja-no-mixed-period`.
-  - `ja-technical-writing` — the above plus `no-exclamation-question-mark`, thresholds
-    (`sentence-length` `max: 100`, `max-ten` `max: 3`, `max-kanji-continuous-len` `max: 6`), and the
-    morphology-backed style rules `no-doubled-joshi`, `no-mix-dearu-desumasu`,
-    `no-doubled-conjunctive-particle-ga`, `ja-no-redundant-expression`, `no-dropping-the-ra`, and
-    `no-double-negative-ja` (mirroring `textlint-rule-preset-ja-technical-writing`). `ja-prh` is not
-    bundled — its term list is project-specific, so configure it explicitly.
+  - `ja-technical-writing` — full parity with the 23-rule
+    [`textlint-rule-preset-ja-technical-writing`](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing):
+    the upstream thresholds copied verbatim (`sentence-length` `max: 100`, `max-comma` `max: 3`,
+    `max-ten` `max: 3`, `max-kanji-continuous-len` `max: 6`) plus every other preset rule enabled —
+    the surface rules (`arabic-kanji-numbers`, `ja-no-mixed-period`, `no-nfd`,
+    `no-invalid-control-character`, `no-zero-width-spaces`, `no-exclamation-question-mark`,
+    `no-hankaku-kana`, `ja-no-weak-phrase`, `ja-no-abusage`, `ja-unnatural-alphabet`,
+    `no-unmatched-pair`) and the morphology-backed style rules (`no-doubled-joshi`,
+    `no-mix-dearu-desumasu`, `no-doubled-conjunction`, `no-doubled-conjunctive-particle-ga`,
+    `no-double-negative-ja`, `no-dropping-the-ra`, `ja-no-redundant-expression`,
+    `ja-no-successive-word`). It also bundles the tsuzulint-original `no-mixed-zenkaku-hankaku-alphabet`
+    (no upstream counterpart). `ja-prh` is **not** bundled — its term list is project-specific, so
+    configure it explicitly. See [`docs/migration-from-textlint.md`](migration-from-textlint.md) for
+    the full rule-name mapping.
 
   The `ja-*` presets imply `language: ja` (your own `language` overrides it), so their Japanese
   rules run out of the box. Because activation is opt-out, a preset does **not** restrict *which*
@@ -85,6 +93,56 @@
   dictionary fingerprint (the pins of the dictionaries active for the run), so any change that
   could alter diagnostics — including a dictionary upgrade — invalidates the entry. A cache
   read/write failure only warns; results are unaffected.
+
+## Built-in rules
+
+Every rule below is **on by default** (opt-out); disable one with `rule-id: false`. The
+**Lang** column reflects rule scoping (see *Language* above): language-neutral rules always run,
+`ja` rules run only when the document language is Japanese. Morphology-backed rules are marked
+**(morph)** — they are inert until a [`morphology`](#morphology--dictionary-for-morphology-dependent-rules)
+dictionary is configured. Use `tzlint rules list` for the resolved on/off + severity and
+`tzlint rules explain <id>` for one rule's effective options.
+
+### Language-neutral
+
+| Rule | What it flags |
+| --- | --- |
+| `no-nfd` | NFD (decomposed) Unicode; prefer NFC (autofix) |
+| `no-zero-width-spaces` | zero-width space characters (autofix) |
+| `no-mixed-zenkaku-hankaku-alphabet` | mixing full-width and half-width Latin letters in one run |
+| `no-exclamation-question-mark` | `!` / `?` (and full-width `！` / `？`) in prose |
+| `max-kanji-continuous-len` | runs longer than `max` (default 6) continuous kanji |
+| `no-invalid-control-character` | invalid C0 / DEL control characters |
+| `no-todo` | `TODO` / `FIXME` markers left in prose |
+
+### Japanese — surface (no morphology)
+
+| Rule | What it flags |
+| --- | --- |
+| `no-hankaku-kana` | half-width katakana; prefer full-width (autofix) |
+| `ja-no-mixed-period` | mixed sentence-ending punctuation (`。` vs `.`) |
+| `sentence-length` | sentences longer than `max` (default 100) |
+| `max-ten` | more than `max` (default 3) 読点「、」 per sentence |
+| `max-comma` | more than `max` (default 3) ASCII commas per sentence |
+| `arabic-kanji-numbers` | inconsistent Arabic vs. kanji numeral usage (JTF 2.2.2) |
+| `ja-unnatural-alphabet` | a stray single Latin letter between Japanese characters (likely IME error) |
+| `no-unmatched-pair` | unmatched brackets / quotes (`detectOrphanedClosers` opts in to orphaned closers) |
+| `ja-no-weak-phrase` | weak / hedging expressions (the 「かも」 family) |
+| `ja-no-abusage` | common Japanese misuses (誤用) |
+| `ja-prh` | 表記ゆれ / terminology from term lists + `.prh.yml` (autofix; see below) |
+
+### Japanese — morphology-backed (need a dictionary)
+
+| Rule | What it flags |
+| --- | --- |
+| `no-doubled-joshi` | the same 助詞 repeated within one sentence |
+| `no-mix-dearu-desumasu` | mixing である (plain) and ですます (polite) styles in a document |
+| `no-doubled-conjunction` | the same 接続詞 opening consecutive sentences |
+| `no-doubled-conjunctive-particle-ga` | the 逆接の接続助詞「が」 used more than once in one sentence |
+| `no-double-negative-ja` | a rhetorical double negative (ないことはない / なくはない) |
+| `no-dropping-the-ra` | ら抜き言葉 (見れる → 見られる) |
+| `ja-no-redundant-expression` | the redundant「〜することができる」family (reads as「〜できる」) |
+| `ja-no-successive-word` | a word repeated in immediate succession |
 
 ## `formats` — per-format options
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -35,18 +35,18 @@
   collision). Built-in presets:
   - `ja-basic` — `no-hankaku-kana`, `no-mixed-zenkaku-hankaku-alphabet`, `no-nfd`,
     `no-zero-width-spaces`, `ja-no-mixed-period`.
-  - `ja-technical-writing` — full parity with the 23-rule
-    [`textlint-rule-preset-ja-technical-writing`](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing):
-    the upstream thresholds copied verbatim (`sentence-length` `max: 100`, `max-comma` `max: 3`,
-    `max-ten` `max: 3`, `max-kanji-continuous-len` `max: 6`) plus every other preset rule enabled —
-    the surface rules (`arabic-kanji-numbers`, `ja-no-mixed-period`, `no-nfd`,
+  - `ja-technical-writing` — full parity with the upstream 23-rule
+    [`textlint-rule-preset-ja-technical-writing`](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing),
+    plus the tsuzulint-original `no-mixed-zenkaku-hankaku-alphabet` (no upstream counterpart) —
+    **24 rules in total**. The upstream thresholds are copied verbatim (`sentence-length` `max: 100`,
+    `max-comma` `max: 3`, `max-ten` `max: 3`, `max-kanji-continuous-len` `max: 6`) and every other
+    preset rule is enabled: the surface rules (`arabic-kanji-numbers`, `ja-no-mixed-period`, `no-nfd`,
     `no-invalid-control-character`, `no-zero-width-spaces`, `no-exclamation-question-mark`,
     `no-hankaku-kana`, `ja-no-weak-phrase`, `ja-no-abusage`, `ja-unnatural-alphabet`,
     `no-unmatched-pair`) and the morphology-backed style rules (`no-doubled-joshi`,
     `no-mix-dearu-desumasu`, `no-doubled-conjunction`, `no-doubled-conjunctive-particle-ga`,
     `no-double-negative-ja`, `no-dropping-the-ra`, `ja-no-redundant-expression`,
-    `ja-no-successive-word`). It also bundles the tsuzulint-original `no-mixed-zenkaku-hankaku-alphabet`
-    (no upstream counterpart). `ja-prh` is **not** bundled — its term list is project-specific, so
+    `ja-no-successive-word`). `ja-prh` is **not** bundled — its term list is project-specific, so
     configure it explicitly. See [`docs/migration-from-textlint.md`](migration-from-textlint.md) for
     the full rule-name mapping.
 
@@ -96,12 +96,18 @@
 
 ## Built-in rules
 
-Every rule below is **on by default** (opt-out); disable one with `rule-id: false`. The
-**Lang** column reflects rule scoping (see *Language* above): language-neutral rules always run,
-`ja` rules run only when the document language is Japanese. Morphology-backed rules are marked
-**(morph)** — they are inert until a [`morphology`](#morphology--dictionary-for-morphology-dependent-rules)
-dictionary is configured. Use `tzlint rules list` for the resolved on/off + severity and
-`tzlint rules explain <id>` for one rule's effective options.
+Every built-in rule is **on by default** (opt-out); disable one with `rule-id: false`. The rules
+are grouped by scoping (see *Language* above): **language-neutral** rules always run, while the
+**Japanese** rules run only when the document language is Japanese. The morphology-backed group is
+inert until a [`morphology`](#morphology--dictionary-for-morphology-dependent-rules) dictionary is
+configured (the engine skips those rules otherwise). Use `tzlint rules list` for the resolved
+on/off + severity and `tzlint rules explain <id>` for one rule's effective options.
+
+This catalog lists **all** built-in rules, which is not the same as preset membership: `no-todo` is
+a standalone rule (not in `ja-technical-writing`, and not an upstream textlint-preset rule), `ja-prh`
+is intentionally not bundled (see above), and `no-mixed-zenkaku-hankaku-alphabet` is a
+tsuzulint-original that *is* bundled into the preset. See
+[`docs/migration-from-textlint.md`](migration-from-textlint.md) for the textlint preset mapping.
 
 ### Language-neutral
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,74 @@
+# Installing TsuzuLint
+
+TsuzuLint is the single `tzlint` binary. Pick whichever install method fits your environment;
+all of them give you the same command.
+
+> Prebuilt binaries, the npm wrapper, and the editor extension are published **from the 0.1.0
+> release onward**. Until then, install from source.
+
+## From source (works today)
+
+With a [Rust toolchain](https://rustup.rs/) (MSRV **1.94**):
+
+```sh
+# Install the latest from git (the binary lands in ~/.cargo/bin):
+cargo install --git https://github.com/simorgh3196/tsuzulint tzlint_cli
+
+# …or build a local checkout:
+git clone https://github.com/simorgh3196/tsuzulint
+cd tsuzulint
+cargo build --release          # produces target/release/tzlint
+```
+
+Once 0.1.0 is published to crates.io, `cargo install tzlint_cli` will work without `--git`.
+
+## Prebuilt binaries (0.1.0 onward)
+
+Each [GitHub Release](https://github.com/simorgh3196/tsuzulint/releases) attaches a
+self-contained `tzlint` archive per platform:
+
+| Platform | Asset |
+| --- | --- |
+| Linux x86_64 | `tzlint-<version>-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux aarch64 | `tzlint-<version>-aarch64-unknown-linux-gnu.tar.gz` |
+| macOS (Apple Silicon) | `tzlint-<version>-aarch64-apple-darwin.tar.gz` |
+| macOS (Intel) | `tzlint-<version>-x86_64-apple-darwin.tar.gz` |
+| Windows x86_64 | `tzlint-<version>-x86_64-pc-windows-msvc.zip` |
+
+Download, verify against `SHA256SUMS`, extract, and put `tzlint` on your `PATH`:
+
+```sh
+tar xzf tzlint-*-x86_64-unknown-linux-gnu.tar.gz
+sudo mv tzlint /usr/local/bin/
+```
+
+## npm (0.1.0 onward)
+
+For Node-based projects, a thin wrapper downloads the matching prebuilt binary on install:
+
+```sh
+npm install --save-dev tzlint     # or: npx tzlint lint docs/
+```
+
+The wrapper just fetches the release binary for your platform and execs it — there is no
+JavaScript reimplementation.
+
+## Editor extension
+
+A CLI-backed VSCode extension is in progress; it will be published to the Marketplace alongside
+the editor MVP. A full LSP server is the 0.2.0 upgrade. Until then, run `tzlint` from the
+terminal or your build pipeline.
+
+## Verify
+
+```sh
+tzlint --version
+printf 'これはﾊﾛｰという文です。\n' | tzlint lint -
+```
+
+## Optional: morphology dictionary
+
+The morphology-backed Japanese rules (e.g. `no-doubled-joshi`) stay inert until you point the
+config at a hash-pinned dictionary. This is never bundled in the binary — see
+[`docs/morphology.md`](morphology.md) and the
+[`morphology` config key](config-reference.md#morphology--dictionary-for-morphology-dependent-rules).

--- a/docs/migration-from-textlint.md
+++ b/docs/migration-from-textlint.md
@@ -118,7 +118,7 @@ Existing `prh` `.prh.yml` dictionaries (as used by `textlint-rule-prh`) load dir
 `version`, `imports`, and `rules` (`expected` + `pattern`/`patterns`) are read; `expected` is the
 replacement and may use `$1`-style capture references for a regex (`/source/flags`) pattern.
 
-Limitations to be aware of when migrating: matching uses a smaller regex engine
+Migration limitations: matching uses a smaller regex engine
 (`regex-lite`), so Unicode-property classes (`\p{…}`) and lookaround/backreferences are
 unsupported — a pattern using them is skipped rather than failing the load (Japanese matched as
 literals is unaffected). The prh `specs`, `regexpMustEmpty`, and `options.wordBoundary` fields are

--- a/docs/migration-from-textlint.md
+++ b/docs/migration-from-textlint.md
@@ -1,21 +1,122 @@
 # Migration from textlint
 
-> Status: template (M0).
+> Status: **shipped (0.1.0).** TsuzuLint implements the full
+> [`textlint-rule-preset-ja-technical-writing`](https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing)
+> rule set plus a `prh` counterpart, so a Japanese textlint project can switch with a small
+> config translation. This page is the concrete switch guide.
 
-**Compatibility scope (v1 intends to mirror):** the node-kind vocabulary (mdast/TxtAST-
-derived), config concepts (rules map, per-rule options, presets, include/exclude), and
-preset naming close to `textlint-rule-preset-ja-technical-writing`.
+TsuzuLint deliberately names its rules after the textlint preset's, so for most projects the
+migration is a config translation rather than a rewrite. The linting still runs through the same
+[`tzlint lint`](../README.md#usage) dispatch, so editor and CI results match byte-for-byte.
 
-**Intentional divergence:** config filename `.tzlintrc.*` (closer to `.textlintrc`); rules
-are authored against the Rust PDK (no binary rule-API compatibility).
+## At a glance
 
-## `prh` terminology dictionaries
+| | textlint | TsuzuLint |
+| --- | --- | --- |
+| Runtime | Node.js + npm dependency tree | a single native binary (`tzlint`) |
+| Config file | `.textlintrc.{json,yml,…}` | `.tzlintrc.{jsonc,json,yaml,yml}` |
+| Preset | `preset-ja-technical-writing` | `extends: "ja-technical-writing"` |
+| Terminology | `textlint-rule-prh` (`.prh.yml`) | `ja-prh` rule (imports the same `.prh.yml`) |
+| Rule activation | opt-in (rules listed are on) | **opt-out** (every built-in rule is on; set `false` to disable) |
+
+## 1. Install and initialize
+
+```sh
+cargo install --git https://github.com/simorgh3196/tsuzulint tzlint_cli   # see docs/install.md
+tzlint init                                                               # writes a starter .tzlintrc.json
+```
+
+See [`docs/install.md`](install.md) for the other install methods.
+
+## 2. Translate the config
+
+A typical Japanese `.textlintrc`:
+
+```json
+{
+  "plugins": ["@textlint/markdown"],
+  "rules": {
+    "preset-ja-technical-writing": {
+      "sentence-length": { "max": 100 },
+      "no-exclamation-question-mark": false
+    },
+    "prh": { "rulePaths": ["./prh/tech.yml"] }
+  }
+}
+```
+
+becomes `.tzlintrc.jsonc`:
+
+```jsonc
+{
+  // `ja-technical-writing` implies `language: ja`, so the Japanese rules run out of the box.
+  "extends": "ja-technical-writing",
+  "rules": {
+    "sentence-length": { "options": { "max": 100 } },
+    "no-exclamation-question-mark": false,
+    "ja-prh": { "options": { "dictionaries": ["./prh/tech.yml"] } }
+  }
+}
+```
+
+Key differences to keep in mind:
+
+- **Markdown is built in** — there is no `plugins` key; TsuzuLint parses Markdown natively.
+- **Per-rule options move under `options`** — textlint's `"rule": { "max": 100 }` becomes
+  `"rule": { "options": { "max": 100 } }`. Severity is a sibling key (`{ "severity": "error" }`).
+- **Activation is opt-out** — listing a rule is not what turns it on (every built-in rule is on by
+  default). Disable a rule with `false`, exactly as textlint does. To run a *narrow* set, disable
+  the rest explicitly.
+- **`language: ja`** — set it (or extend a `ja-*` preset, which implies it) so the Japanese rules
+  run; with `language` unset only the language-neutral rules fire. See the
+  [config reference](config-reference.md).
+
+## 3. Rule mapping
+
+Every rule of `textlint-rule-preset-ja-technical-writing` (23 rules) has a same-named TsuzuLint
+rule, all bundled in the `ja-technical-writing` preset.
+
+| textlint preset rule | TsuzuLint rule id | Notes |
+| --- | --- | --- |
+| `sentence-length` | `sentence-length` | |
+| `max-comma` | `max-comma` | |
+| `max-ten` | `max-ten` | |
+| `max-kanji-continuous-len` | `max-kanji-continuous-len` | |
+| `arabic-kanji-numbers` | `arabic-kanji-numbers` | |
+| `no-mix-dearu-desumasu` | `no-mix-dearu-desumasu` | needs a [morphology dictionary](config-reference.md#morphology--dictionary-for-morphology-dependent-rules) |
+| `ja-no-mixed-period` | `ja-no-mixed-period` | |
+| `no-double-negative-ja` | `no-double-negative-ja` | needs a morphology dictionary |
+| `no-dropping-the-ra` | `no-dropping-the-ra` | needs a morphology dictionary |
+| `no-doubled-conjunction` | `no-doubled-conjunction` | needs a morphology dictionary |
+| `no-doubled-conjunctive-particle-ga` | `no-doubled-conjunctive-particle-ga` | needs a morphology dictionary |
+| `no-doubled-joshi` | `no-doubled-joshi` | needs a morphology dictionary |
+| `no-nfd` | `no-nfd` | |
+| `no-zero-width-spaces` | `no-zero-width-spaces` | |
+| `no-exclamation-question-mark` | `no-exclamation-question-mark` | |
+| `no-hankaku-kana` | `no-hankaku-kana` | |
+| `ja-no-weak-phrase` | `ja-no-weak-phrase` | |
+| `ja-no-successive-word` | `ja-no-successive-word` | needs a morphology dictionary |
+| `ja-no-abusage` | `ja-no-abusage` | |
+| `ja-no-redundant-expression` | `ja-no-redundant-expression` | needs a morphology dictionary |
+| `ja-unnatural-alphabet` | `ja-unnatural-alphabet` | |
+| `no-unmatched-pair` | `no-unmatched-pair` | only unclosed openers by default; `detectOrphanedClosers` opts in |
+| `no-invalid-control-character` | `no-invalid-control-character` | |
+| `textlint-rule-prh` (plugin) | `ja-prh` | imports `.prh.yml` — see below |
+
+The morphology-backed rules are **on by default but inert until a `morphology` dictionary is
+configured** (the engine skips them otherwise), so the preset never silently requires one. See
+[`docs/morphology.md`](morphology.md) to turn them on.
+
+TsuzuLint also ships two rules with no upstream-preset counterpart: `no-mixed-zenkaku-hankaku-alphabet`
+(bundled in `ja-technical-writing`) and `no-todo`.
+
+## 4. `prh` terminology dictionaries
 
 Existing `prh` `.prh.yml` dictionaries (as used by `textlint-rule-prh`) load directly into the
 `ja-prh` rule — point at them from `rules.ja-prh.options.dictionaries` (see the
-[config reference](config-reference.md)). The dictionary's `version`, `imports`, and `rules`
-(`expected` + `pattern`/`patterns`) are read; `expected` is the replacement and may use `$1`-style
-capture references for a regex (`/source/flags`) pattern.
+[config reference](config-reference.md)). The dictionary's
+`version`, `imports`, and `rules` (`expected` + `pattern`/`patterns`) are read; `expected` is the
+replacement and may use `$1`-style capture references for a regex (`/source/flags`) pattern.
 
 Limitations to be aware of when migrating: matching uses a smaller regex engine
 (`regex-lite`), so Unicode-property classes (`\p{…}`) and lookaround/backreferences are
@@ -23,4 +124,26 @@ unsupported — a pattern using them is skipped rather than failing the load (Ja
 literals is unaffected). The prh `specs`, `regexpMustEmpty`, and `options.wordBoundary` fields are
 parsed but not yet applied.
 
-Migration notes (config keys, rule-name mapping) filled in as rules land.
+## What's not covered yet
+
+- **Markdown-structural rules** (the `markdownlint`-style MD0xx family) and a bundled Markdown
+  preset are deferred to 0.2.0 — keep using `markdownlint`/`textlint` for those for now.
+- **Off-preset prose rules** outside `textlint-rule-preset-ja-technical-writing` — e.g. pangu-style
+  spacing (`ja-space-between-half-and-full-width` and friends) — are not implemented yet.
+- **Custom textlint rules / plugins** authored in JavaScript do not run; TsuzuLint rules are
+  authored against the Rust PDK (no binary rule-API compatibility). A WebAssembly plugin ABI is on
+  the roadmap (M3).
+- **Editor integration** ships first as a CLI-backed VSCode extension; a full LSP server is the
+  0.2.0 upgrade (M5).
+- **Some `prh` fields** (`specs`, `regexpMustEmpty`, `options.wordBoundary`) and regex features
+  (lookaround, `\p{…}`) are parsed-but-skipped, as noted above.
+
+## Compatibility scope and intentional divergence
+
+**Compatibility scope (v1 mirrors):** the node-kind vocabulary (mdast/TxtAST-derived), config
+concepts (rules map, per-rule options, presets, include/exclude), and preset naming close to
+`textlint-rule-preset-ja-technical-writing`.
+
+**Intentional divergence:** config filename `.tzlintrc.*` (closer to `.textlintrc`); per-rule
+options nest under an `options` key; activation is opt-out; rules are authored against the Rust PDK
+(no binary rule-API compatibility).


### PR DESCRIPTION
Part of #57 (0.1.0 release track). Documentation half of the two-PR docs + release-engineering split. Branched off `main`; **no Rust/source changes** (docs only).

## What this does (R16 + R19 docs)

- **R16 — migration-from-textlint, flipped to shipped.** `docs/migration-from-textlint.md` goes from the M0 template to a concrete switch guide:
  - an at-a-glance textlint↔TsuzuLint table,
  - a `.textlintrc` → `.tzlintrc` config-translation walkthrough (opt-out activation, `options` nesting, `language: ja`),
  - a **rule-name mapping table** for the full 23-rule `textlint-rule-preset-ja-technical-writing` (+ `textlint-rule-prh` → `ja-prh`), marking which rules need a morphology dictionary,
  - the `prh` `.prh.yml` import path, and an honest **"what's not covered yet"** section (Markdown-structural rules deferred to 0.2.0, off-preset rules, JS plugins, LSP).

- **R19 docs — quickstart / install / config refresh:**
  - `docs/config-reference.md`: `ja-technical-writing` now documented as full 23-rule parity, plus a new **"Built-in rules"** catalog (all 26 rules grouped by language scope / morphology need).
  - new `docs/install.md` (from-source today; prebuilt binaries / npm / extension from 0.1.0 onward).
  - `README.md`: status + tagline reworked to position TsuzuLint as the Japanese textlint replacement, linking install, migration, and benchmarks.

> R19's final step (cut 0.1.0) is intentionally **not** included — it waits on the release-engineering PR.

## Notes / verification
- Pure Markdown; no crate/source touched, so `just check` is unaffected (no Rust changes). README is not included as a doctest anywhere (verified).
- Internal doc links checked; the `npm/README.md` link is deliberately omitted here since that file lands in the sibling release-engineering PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * インストール手順を整理し、ソースビルド・GitHub配布バイナリ・npmラッパーでの導入方法を案内しました。
  * 設定リファレンスを拡充し、プリセットの到達状況（23ルール完全パリティ）やビルトインルールの一覧・挙動、参照コマンドをわかりやすくしました。
  * 移行ガイドを追加し、textlintからの設定変換例、互換性の注意点、未対応範囲をまとめました。
  * README（日本語/英語）を更新し、提供状況・参照リンク・実行例などを明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->