### PR TITLE
chore(release): binary release workflow + npm wrapper + changelog (R18)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+name: Release
+
+# Cut a release by pushing a SemVer tag (e.g. `v0.1.0`). This builds a prebuilt `tzlint`
+# binary per platform, attaches the archives + a SHA256SUMS manifest to a GitHub Release, and
+# (when an NPM_TOKEN secret is configured) publishes the thin npm wrapper at the same version.
+# `workflow_dispatch` allows a dry rehearsal that builds + uploads artifacts without releasing.
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            linker: gcc-aarch64-linux-gnu
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      # aarch64 Linux is cross-compiled from the x86_64 runner: install the GNU cross linker and
+      # point cargo at it. Everything in the tree is pure Rust (blake3 `pure`, rustls TLS), so no
+      # C toolchain beyond the linker is needed.
+      - name: Install aarch64 cross linker
+        if: matrix.linker != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.linker }}
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+
+      - name: Build
+        run: cargo build --release --locked -p tzlint_cli --target ${{ matrix.target }}
+
+      # Package a self-contained archive named `tzlint-<version>-<target>.{tar.gz,zip}` plus a
+      # per-asset `.sha256`. `<version>` is the tag without the leading `v` (workflow_dispatch
+      # rehearsals fall back to the commit short SHA so nothing collides with a real release).
+      - name: Package (unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          ref="${GITHUB_REF_NAME:-}"
+          version="${ref#v}"
+          [ "${{ github.event_name }}" = "push" ] || version="0.0.0-${GITHUB_SHA::8}"
+          base="tzlint-${version}-${{ matrix.target }}"
+          mkdir -p dist
+          tar -czf "dist/${base}.tar.gz" -C "target/${{ matrix.target }}/release" tzlint
+          shasum -a 256 "dist/${base}.tar.gz" | awk '{print $1}' > "dist/${base}.tar.gz.sha256"
+
+      - name: Package (windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          ref="${GITHUB_REF_NAME:-}"
+          version="${ref#v}"
+          [ "${{ github.event_name }}" = "push" ] || version="0.0.0-${GITHUB_SHA::8}"
+          base="tzlint-${version}-${{ matrix.target }}"
+          mkdir -p dist
+          7z a "dist/${base}.zip" "./target/${{ matrix.target }}/release/tzlint.exe" >/dev/null
+          certutil -hashfile "dist/${base}.zip" SHA256 | sed -n 2p | tr -d ' \r' > "dist/${base}.zip.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+
+  release:
+    name: publish GitHub Release
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the release and upload assets
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: dist-*
+          merge-multiple: true
+
+      # Collect every per-asset hash into one signed-off SHA256SUMS manifest next to the archives.
+      - name: Assemble SHA256SUMS
+        working-directory: artifacts
+        run: |
+          : > SHA256SUMS
+          for f in *.sha256; do
+            printf '%s  %s\n' "$(cat "$f")" "${f%.sha256}" >> SHA256SUMS
+          done
+          rm -f *.sha256
+          echo "--- SHA256SUMS ---"; cat SHA256SUMS
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --verify-tag \
+            artifacts/*
+
+  npm:
+    name: publish npm wrapper
+    needs: release
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      # Publishing is opt-in: without an NPM_TOKEN secret the job is a no-op (the binaries are
+      # already released above), so a fork or an unconfigured repo never fails here.
+      - name: Publish (skips when NPM_TOKEN is unset)
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "NPM_TOKEN not set — skipping npm publish."
+            exit 0
+          fi
+          version="${GITHUB_REF_NAME#v}"
+          npm version "$version" --no-git-tag-version --allow-same-version
+          npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -80,7 +80,7 @@ jobs:
           [ "${{ github.event_name }}" = "push" ] || version="0.0.0-${GITHUB_SHA::8}"
           base="tzlint-${version}-${{ matrix.target }}"
           mkdir -p dist
-          7z a "dist/${base}.zip" "./target/${{ matrix.target }}/release/tzlint.exe" >/dev/null
+          (cd "target/${{ matrix.target }}/release" && 7z a "../../../dist/${base}.zip" "tzlint.exe" >/dev/null)
           certutil -hashfile "dist/${base}.zip" SHA256 | sed -n 2p | tr -d ' \r' > "dist/${base}.zip.sha256"
 
       - uses: actions/upload-artifact@v4
@@ -97,7 +97,7 @@ jobs:
     permissions:
       contents: write # create the release and upload assets
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -131,8 +131,11 @@ jobs:
     needs: release
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
             os: windows-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -98,6 +100,8 @@ jobs:
       contents: write # create the release and upload assets
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -136,6 +140,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ accumulate as the release is built.
   transform over the frozen `AstCoreV1` (rkyv) layout, a single-traversal lint engine
   with a stable `(span.start, span.end, rule_id, message)` diagnostic order, a
   document-level in-memory cache keyed by every input that can change a result, a
-  multi-format configuration loader (TOML / JSON / YAML) with presets, a byte-offset →
+  multi-format configuration loader (JSON / JSONC / YAML) with presets, a byte-offset →
   line/column position mapper, and an `io` / `Host` boundary that routes all filesystem
   and network access through a single abstraction.
 - **Diagnostic and fix model.** A `Diagnostic` / `Fix` model with a convergent
@@ -79,6 +79,10 @@ accumulate as the release is built.
   which has no upstream counterpart.
 - **Command-line interface (`tzlint`).** `lint`, `fix`, `init`, and `rules`
   subcommands with `text`, `json`, and `sarif` output formats.
+- **Distribution.** Prebuilt `tzlint` binaries per platform (Linux x64 / arm64, macOS
+  x64 / arm64, Windows x64) attached to each tagged GitHub Release with a `SHA256SUMS`
+  manifest, plus a thin [`tzlint` npm wrapper](https://github.com/simorgh3196/tsuzulint/tree/main/npm)
+  that downloads and verifies the matching binary on install.
 - **Japanese morphology.** A language-neutral `MorphologyProvider` seam over the
   frozen `MorphologyV1` token table, a Japanese backend (native, feature-gated), and a
   dynamic, non-embedded dictionary pipeline — hash-pinned provisioning, verification,

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,4 @@
+# The native binary is downloaded at install time, never committed or published.
+node_modules/
+bin/tzlint-bin
+bin/tzlint-bin.exe

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,41 @@
+# tzlint (npm wrapper)
+
+A thin npm wrapper for [**TsuzuLint**](https://github.com/simorgh3196/tsuzulint) — a fast,
+embeddable Japanese `textlint` replacement written in Rust.
+
+This package ships **no JavaScript linter**. On install it downloads the prebuilt native
+`tzlint` binary matching your platform from the matching GitHub Release, verifies it against the
+release `SHA256SUMS`, and the `tzlint` command execs that binary directly.
+
+## Install
+
+```sh
+npm install --save-dev tzlint
+# or run ad hoc:
+npx tzlint lint docs/
+```
+
+```sh
+tzlint lint README.md docs/
+tzlint fix docs/
+tzlint rules list
+```
+
+See the [main README](https://github.com/simorgh3196/tsuzulint#usage) and
+[`docs/`](https://github.com/simorgh3196/tsuzulint/tree/main/docs) for usage and configuration.
+
+## How it works
+
+- `postinstall` runs [`install.js`](install.js): it resolves your `platform`-`arch` to a release
+  asset (`tzlint-<version>-<target>.{tar.gz,zip}`), downloads it, checks its SHA-256 against the
+  release `SHA256SUMS`, extracts it, and stores it as `bin/tzlint-bin`.
+- The `tzlint` bin entry ([`bin/tzlint.js`](bin/tzlint.js)) is a launcher that forwards argv,
+  stdio, and the exit code to that native binary.
+
+Supported targets: Linux (x64, arm64), macOS (x64, arm64), Windows (x64).
+
+Set `TZLINT_SKIP_DOWNLOAD=1` to skip the download (e.g. when building from a source checkout). If
+no prebuilt binary exists for your platform, [build from source](https://github.com/simorgh3196/tsuzulint/blob/main/docs/install.md).
+
+> Published from the 0.1.0 release onward. The package version tracks the `tzlint` release it
+> installs.

--- a/npm/bin/tzlint.js
+++ b/npm/bin/tzlint.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Thin launcher: exec the native `tzlint` binary fetched by install.js, forwarding argv, stdio,
+// and the exit code unchanged. This is the only JavaScript that runs at lint time.
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const bin = path.join(__dirname, process.platform === "win32" ? "tzlint-bin.exe" : "tzlint-bin");
+
+if (!fs.existsSync(bin)) {
+  console.error(
+    "[tzlint] native binary not found. Reinstall the package, or build from source:\n" +
+      "  https://github.com/simorgh3196/tsuzulint (see docs/install.md)",
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
+if (result.error) {
+  console.error(`[tzlint] failed to run binary: ${result.error.message}`);
+  process.exit(1);
+}
+// Mirror signal-kills as the conventional 128+signal code; otherwise pass the exit status through.
+if (result.signal) process.exit(1);
+process.exit(result.status === null ? 1 : result.status);

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// postinstall: download the prebuilt `tzlint` binary matching this package's version and the
+// host platform from the GitHub Release, verify it against the release SHA256SUMS, and place it
+// next to the launcher. There is no JavaScript reimplementation — this only fetches and verifies.
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const https = require("https");
+const crypto = require("crypto");
+const { execFileSync } = require("child_process");
+
+const REPO = "simorgh3196/tsuzulint";
+const pkg = require("./package.json");
+const version = pkg.version;
+
+// `process.platform`-`process.arch` -> Rust target triple (must match the release asset names).
+const TARGETS = {
+  "linux-x64": "x86_64-unknown-linux-gnu",
+  "linux-arm64": "aarch64-unknown-linux-gnu",
+  "darwin-x64": "x86_64-apple-darwin",
+  "darwin-arm64": "aarch64-apple-darwin",
+  "win32-x64": "x86_64-pc-windows-msvc",
+};
+
+function fail(msg) {
+  console.error(`[tzlint] ${msg}`);
+  process.exit(1);
+}
+
+// A dev checkout (version 0.0.0) or an explicit opt-out has no release to download from; the
+// launcher then points at `cargo build`. Skipping keeps `npm install` in this repo from failing.
+if (version === "0.0.0" || process.env.TZLINT_SKIP_DOWNLOAD === "1") {
+  console.log("[tzlint] skipping binary download (dev checkout or TZLINT_SKIP_DOWNLOAD set).");
+  process.exit(0);
+}
+
+const key = `${process.platform}-${process.arch}`;
+const target = TARGETS[key];
+if (!target) {
+  // Exit 0 so installs in mixed-platform workspaces don't break; the launcher reports the gap.
+  console.warn(`[tzlint] no prebuilt binary for ${key}; build from source: https://github.com/${REPO}`);
+  process.exit(0);
+}
+
+const isWindows = process.platform === "win32";
+const ext = isWindows ? "zip" : "tar.gz";
+const archiveName = `tzlint-${version}-${target}.${ext}`;
+const releaseBase = `https://github.com/${REPO}/releases/download/v${version}`;
+const binDir = path.join(__dirname, "bin");
+const finalBin = path.join(binDir, isWindows ? "tzlint-bin.exe" : "tzlint-bin");
+
+function get(url) {
+  // Follow GitHub's redirect to the asset CDN; resolve with the response body Buffer.
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { "User-Agent": "tzlint-npm-installer" } }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          resolve(get(res.headers.location));
+          return;
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+          return;
+        }
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => resolve(Buffer.concat(chunks)));
+      })
+      .on("error", reject);
+  });
+}
+
+// Parse a `sha256  filename` manifest into the expected hash for `archiveName`.
+function expectedHash(sumsText) {
+  for (const line of sumsText.split(/\r?\n/)) {
+    const m = line.trim().match(/^([0-9a-f]{64})\s+\*?(.+)$/i);
+    if (m && path.basename(m[2]) === archiveName) return m[1].toLowerCase();
+  }
+  return null;
+}
+
+(async () => {
+  console.log(`[tzlint] downloading ${archiveName} ...`);
+  let archive, sumsText;
+  try {
+    archive = await get(`${releaseBase}/${archiveName}`);
+    sumsText = (await get(`${releaseBase}/SHA256SUMS`)).toString("utf8");
+  } catch (e) {
+    fail(`download failed: ${e.message}`);
+  }
+
+  const expected = expectedHash(sumsText);
+  const actual = crypto.createHash("sha256").update(archive).digest("hex");
+  if (!expected) {
+    fail(`${archiveName} is not listed in SHA256SUMS; refusing to install an unverifiable binary.`);
+  }
+  if (actual !== expected) {
+    fail(`checksum mismatch for ${archiveName}\n  expected ${expected}\n  actual   ${actual}`);
+  }
+
+  // Extract with the system `tar` (bsdtar handles .zip on Windows 10+ and .tar.gz everywhere),
+  // then rename the extracted `tzlint`/`tzlint.exe` to the name the launcher execs.
+  const tmp = path.join(os.tmpdir(), `tzlint-${process.pid}-${archiveName}`);
+  fs.writeFileSync(tmp, archive);
+  fs.mkdirSync(binDir, { recursive: true });
+  try {
+    execFileSync("tar", ["-xf", tmp, "-C", binDir], { stdio: "inherit" });
+  } catch (e) {
+    fail(`extraction failed (is \`tar\` on PATH?): ${e.message}`);
+  } finally {
+    fs.rmSync(tmp, { force: true });
+  }
+
+  const extracted = path.join(binDir, isWindows ? "tzlint.exe" : "tzlint");
+  if (!fs.existsSync(extracted)) {
+    fail(`archive did not contain the expected \`${path.basename(extracted)}\` binary.`);
+  }
+  fs.rmSync(finalBin, { force: true });
+  fs.renameSync(extracted, finalBin);
+  if (!isWindows) fs.chmodSync(finalBin, 0o755);
+
+  console.log(`[tzlint] installed ${target} binary (verified).`);
+})();

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "tzlint",
+  "version": "0.0.0",
+  "description": "TsuzuLint — a fast, embeddable Japanese textlint replacement. Thin wrapper that installs the native `tzlint` binary.",
+  "keywords": [
+    "textlint",
+    "linter",
+    "japanese",
+    "prose",
+    "tzlint",
+    "tsuzulint"
+  ],
+  "homepage": "https://github.com/simorgh3196/tsuzulint",
+  "bugs": "https://github.com/simorgh3196/tsuzulint/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/simorgh3196/tsuzulint.git",
+    "directory": "npm"
+  },
+  "license": "Apache-2.0",
+  "author": "simorgh3196 <simorgh3196@gmail.com>",
+  "bin": {
+    "tzlint": "bin/tzlint.js"
+  },
+  "files": [
+    "bin/tzlint.js",
+    "install.js",
+    "README.md"
+  ],
+  "scripts": {
+    "postinstall": "node ./install.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ]
+}


### PR DESCRIPTION
Part of #57 (0.1.0 release track). Release-engineering half of the two-PR docs + release-engineering split. Branched off `main`; **no Rust/source changes** (CI + npm wrapper + CHANGELOG).

## What this does (R18)

- **`.github/workflows/release.yml`** — on a SemVer tag (`v*.*.*`):
  - cross-builds the `tzlint` binary for **Linux x64/arm64, macOS x64/arm64, Windows x64** (aarch64-linux via the GNU cross linker — the tree is pure Rust: blake3 `pure`, rustls TLS),
  - packages each as `tzlint-<version>-<target>.{tar.gz,zip}` with a per-asset hash,
  - publishes a **GitHub Release** with the archives + an assembled `SHA256SUMS` manifest (`contents: write`, scoped to that job only),
  - a final job **publishes the npm wrapper** at the tagged version — a no-op unless an `NPM_TOKEN` secret is set.
  - `workflow_dispatch` builds/uploads artifacts **without** releasing, for a dry rehearsal.

- **`npm/`** — a thin `tzlint` wrapper (no JS linter):
  - `postinstall` (`install.js`) downloads the prebuilt binary for the host platform, **verifies it against the release `SHA256SUMS`**, and stores it as `bin/tzlint-bin`;
  - `bin/tzlint.js` execs that binary, forwarding argv/stdio/exit code;
  - skips cleanly on a `0.0.0` dev checkout or with `TZLINT_SKIP_DOWNLOAD=1`; the native binary is gitignored, never committed/published.

- **`CHANGELOG.md`** — fix the config-loader format list (**JSON / JSONC / YAML**, not TOML) and record the new distribution channels.

## Verification
- `release.yml` parses as valid YAML; no untrusted GitHub inputs in `run:` steps (only matrix values + GitHub-provided env vars, quoted).
- `install.js` / `bin/tzlint.js` pass `node --check`; smoke-tested: install skips on `0.0.0`, launcher errors cleanly when the binary is absent.
- ⚠️ The tag-triggered release path has **not** been executed end-to-end (no tag pushed). Recommend a `workflow_dispatch` rehearsal before the first real tag.

## Scope notes
- Version bump to 0.1.0 is **R1 (#65)**, kept separate. `vsce`/Marketplace publishing waits on the VSCode extension (deferred), so it is not included here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * npm経由で `tzlint` をインストール・実行できるようになりました。
  * インストール時にプラットフォーム別バイナリを自動取得し、SHA256で検証して実行します。
  * 引数・入出力・終了コードをネイティブへ透過し、対応外ではダウンロードをスキップして切り替えます。  
* **ドキュメント**
  * インストール手順、設定、配布バイナリと検証の説明を README/CHANGELOG へ追加しました。  
* **自動化**
  * リリース用アセット（バイナリと検証情報）を自動生成し、タグに合わせて公開します。npm公開は設定時のみ実行です。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->