### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Serialize Iterator directly
+**Library:** serde_json v1.0.150
+**Discovery:** In memory-constrained environments or to reduce allocations, you can implement `serde::Serialize` to serialize data without intermediate `Vec` collections. Use `serializer.collect_seq()` to stream iterator elements.
+**Application:** Used in `crates/tzlint_wasm/src/lib.rs` to stream the diagnostics to JSON, avoiding a `Vec<DiagnosticJson>` allocation.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/ser/trait.Serializer.html#method.collect_seq
💡 Insight: Serde serializers provide `collect_seq` to stream items from an iterator into a sequence without an intermediate allocation.
🛠️ Change: Added `DiagnosticList` to wrap the `[Diagnostic]` slice, implementing `serde::Serialize` to map elements to `DiagnosticJson` iteratively, replacing a `.collect::<Vec<_>>()` call.
✨ Benefit: Reduces memory allocation by skipping the intermediate `Vec` during WebAssembly bindings JSON serialization.

---
*PR created automatically by Jules for task [11284393711547081965](https://jules.google.com/task/11284393711547081965) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断結果の JSON 生成を、より省メモリな逐次処理に変更しました。
  * 大きな診断一覧でも中間データを余分に作らず、安定して出力できるようになりました。
  * 変換に失敗した場合の既存のフォールバック動作は維持しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->