### PR TITLE
⚡ Bolt: Remove intermediate vector allocation in WASM diagnostics serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Optimize WebAssembly JSON Serialization
+**Learning:** In performance-critical WebAssembly bindings, allocating intermediate `Vec` collections for JSON serialization (e.g., mapping elements then calling `collect()`) incurs unnecessary heap allocations. Using a custom wrapper struct with `serde::Serialize` and `serializer.collect_seq()` streams the data directly, bypassing the intermediate allocation and improving speed, especially in memory-constrained targets like WASM.
+**Action:** When serializing collections in performance-critical paths (especially in WASM), avoid `collect::<Vec<_>>()`. Instead, use `serializer.collect_seq()` inside a custom `Serialize` implementation to stream the iterator directly.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,27 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsJsonWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsJsonWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsJsonWrapper(diagnostics))
+        .unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Refactored `diagnostics_to_json` in `tzlint_wasm` to use a custom wrapper struct with `serde::Serialize` and `serializer.collect_seq()` instead of mapping the iterator to an intermediate `Vec`.

🎯 Why: In performance-critical WebAssembly bindings, allocating intermediate `Vec` collections (e.g., via `collect::<Vec<_>>()`) incurs unnecessary heap allocations. Using `serializer.collect_seq()` streams the data directly into the JSON serializer, bypassing the intermediate allocation.

📊 Impact: Reduces memory footprint and allocator overhead during serialization, making the WASM binary execution faster.

🔬 Measurement: Compile with `cargo build --target wasm32-unknown-unknown --release` and measure the serialization speed via benchmark or direct browser invocation. All tests verify correctness is preserved.

---
*PR created automatically by Jules for task [925659117939568088](https://jules.google.com/task/925659117939568088) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **パフォーマンス改善**
  * 診断情報の JSON 出力を、より省メモリで効率的に生成するようになりました。
  * 大きな診断一覧でも、余計な一時データの作成を減らして安定して処理できます。

* **信頼性**
  * JSON への変換に失敗した場合でも、従来どおり空配列を返す挙動は維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->