### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Serialize with `serializer.collect_seq()` to avoid allocating intermediate vectors
+**Library:** serde v1.0.228
+**Discovery:** Instead of allocating an intermediate `Vec` or iterating and using `.collect::<Vec<_>>()`, `serde::Serializer` provides `collect_seq` which streams elements into the sequence directly.
+**Application:** Used in `crates/tzlint_wasm/src/lib.rs` to stream `Diagnostic` to `DiagnosticJson` avoiding `Vec` allocations, which improves performance and avoids memory pressure in WASM.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsSeq<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsSeq<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsSeq(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/ser/trait.Serializer.html#method.collect_seq
💡 Insight: By directly streaming an iterator via `collect_seq` into `serde::Serializer`, we avoid creating an intermediate `Vec` to hold converted items before serializing them, which is especially important in constrained environments like WebAssembly.
🛠️ Change: Added a new `DiagnosticsSeq` wrapper implementing `serde::Serialize` calling `collect_seq` on `DiagnosticJson` elements and used it inside `diagnostics_to_json` instead of a mapping `Vec`.
✨ Benefit: Reduces memory pressure and CPU cycles required to compute intermediate collections when formatting output locally in WASM.

---
*PR created automatically by Jules for task [14816618922289225784](https://jules.google.com/task/14816618922289225784) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断情報の JSON 生成をより効率的にし、不要な一時データの生成を減らしました。
  * 既存の出力形式やエラー時のフォールバックはそのまま維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->