### PR TITLE
⚡ Bolt: [performance improvement] Avoid Vec allocation in diagnostics JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-07-01 - Avoid iterator to Vec collection before serialization
+**Learning:** To optimize serialization performance (especially in memory-constrained targets like WebAssembly), avoid collecting iterators into intermediate `Vec` collections prior to serialization.
+**Action:** Wrap the slice or iterator in a custom struct and implement `serde::Serialize` utilizing `serializer.collect_seq()` to stream data directly without intermediate allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Refactored `diagnostics_to_json` in `tzlint_wasm` to use a custom `DiagnosticList` struct implementing `serde::Serialize` instead of collecting mapped `DiagnosticJson` elements into an intermediate `Vec`.

🎯 Why: To eliminate an unnecessary heap allocation of an intermediate `Vec` during JSON serialization of linting diagnostics. This is particularly important for WebAssembly targets where memory is constrained.

📊 Impact: Removes `O(N)` memory allocation for the diagnostics array serialization, potentially lowering peak memory usage and slightly improving serialization speed.

🔬 Measurement: Run standard `cargo test` and manual benchmarking to verify exact JSON output consistency and observe reduced memory allocations in profiling for the `lint` binding.

---
*PR created automatically by Jules for task [9181148022558829157](https://jules.google.com/task/9181148022558829157) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * 診断情報のJSON出力を、より効率的に逐次シリアル化する方式に変更しました。
  * 一時的なデータ作成を減らし、大量の診断でも安定して処理しやすくなりました。
* **ドキュメント**
  * シリアル化方針に関する記録を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->