### PR TITLE
🎓 Scholar: [serde] usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-07-02 - Eliminate intermediate allocation during serialization
+**Library:** serde v1.0
+**Discovery:** Serde provides `serializer.collect_seq()` which streams elements from an iterator sequentially.
+**Application:** Used a struct wrapping an iterator (slice of diagnostics) to serialize directly to JSON using `serializer.collect_seq`, which avoids allocating an intermediate vector that could be expensive, especially on WebAssembly targets where memory constraints apply.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -150,18 +150,25 @@ struct DiagnosticJson<'a> {
 }
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: [serde::Serializer::collect_seq](https://docs.rs/serde/latest/serde/trait.Serializer.html#method.collect_seq)
💡 Insight: `serde_json` allows streaming iterators sequentially by wrapping them with `serializer.collect_seq()` instead of eagerly allocating a `Vec` prior to JSON serialization.
🛠️ Change: Refactored `diagnostics_to_json` in `crates/tzlint_wasm/src/lib.rs` to pass a wrapped iterator of `DiagnosticJson` to `serde_json::to_string`, discarding the `.collect::<Vec<_>>()` step.
✨ Benefit: Completely eliminates the intermediate heap allocation in the serialization hot path, saving precious memory cycles in WebAssembly target builds.

---
*PR created automatically by Jules for task [5600314816392728686](https://jules.google.com/task/5600314816392728686) started by @simorgh3196*