### PR TITLE
⚡ Bolt: Wasm diagnostic JSON serialization performance improvement

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - Zero-Copy JSON Array Serialization in Wasm
+**Learning:** Collecting iterators into intermediate `Vec` allocations (e.g. `Vec<DiagnosticJson>`) just to pass to `serde_json::to_string` causes unnecessary memory overhead, particularly impactful in memory-constrained targets like WebAssembly where allocations are slower.
+**Action:** Instead of collecting into an intermediate `Vec`, wrap the slice/iterator in a proxy struct and implement `serde::Serialize` on it directly, utilizing `serializer.serialize_seq()` to stream elements dynamically without intermediate heap allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,32 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
+struct DiagnosticsJsonWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsJsonWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for d in self.0 {
+            seq.serialize_element(&DiagnosticJson {
+                rule_id: d.rule_id.as_str(),
+                severity: severity_str(d.severity),
+                message: d.message.as_str(),
+                start: d.span.start,
+                end: d.span.end,
+            })?;
+        }
+        seq.end()
+    }
+}
+
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
-            rule_id: d.rule_id.as_str(),
-            severity: severity_str(d.severity),
-            message: d.message.as_str(),
-            start: d.span.start,
-            end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+    serde_json::to_string(&DiagnosticsJsonWrapper(diagnostics))
+        .unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Implement zero-copy serialization for diagnostics JSON output in `tzlint_wasm`.
🎯 Why: Collecting iterators into intermediate `Vec` allocations (e.g. `Vec<DiagnosticJson>`) just to pass to `serde_json::to_string` causes unnecessary memory overhead. This is particularly impactful in memory-constrained targets like WebAssembly where allocations are slower.
📊 Impact: Eliminates the `Vec` allocation entirely, utilizing `serializer.serialize_seq()` to stream elements directly, which saves memory and execution speed in Wasm execution.
🔬 Measurement: Run the Wasm tests and observe identical output logic but with fewer heap allocations during linting.

---
*PR created automatically by Jules for task [2192732922211223132](https://jules.google.com/task/2192732922211223132) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断結果のJSON出力が、より効率的に生成されるようになりました。
  * 余分な一時データを作らずに逐次処理するため、特にWebAssembly環境でのメモリ使用量が抑えられ、処理負荷の軽減が期待できます。
  * 出力形式はこれまでどおり維持され、取得できる項目や失敗時の空配列応答も変わりません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->