### PR TITLE
⚡ Bolt: stream JSON serialization to avoid Wasm allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Streaming Serialization in WebAssembly
+**Learning:** Collecting iterators into intermediate `Vec` collections prior to serialization introduces unnecessary heap allocations, which is especially detrimental in memory-constrained targets like WebAssembly.
+**Action:** Wrap the slice or iterator in a custom struct and implement `serde::Serialize` utilizing `serializer.collect_seq()` or `serializer.serialize_seq()` to stream data directly without intermediate heap allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsJson<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsJson<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsJson(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Replaced the intermediate `Vec<DiagnosticJson>` allocation in `tzlint_wasm`'s `diagnostics_to_json` with a streaming serialization approach using a custom wrapper struct and `serializer.collect_seq()`.
🎯 Why: Collecting the mapped diagnostics into a `Vec` before serialization performs unnecessary heap allocations. In memory-constrained WebAssembly environments, avoiding intermediate allocations during tight operations like JSON stringification significantly reduces memory pressure and execution time.
📊 Impact: Completely eliminates one O(N) heap allocation (where N is the number of diagnostics) per linting operation, slightly improving execution speed and reducing peak memory usage in the Wasm module.
🔬 Measurement: The change was verified locally with `cargo check`, `cargo fmt`, `cargo clippy`, and `cargo test`, showing no regressions and identical output logic.

---
*PR created automatically by Jules for task [3679014080228454369](https://jules.google.com/task/3679014080228454369) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断結果の JSON 変換を、途中の一時データを作らずに順次処理するよう改善しました。
  * メモリ使用量が抑えられ、WebAssembly のような制約のある環境でも安定して動作しやすくなりました。
  * 出力される JSON の内容と、変換失敗時に空配列を返す挙動はそのままです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->