### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2024-07-04 - Zero-copy JSON serialization with Serde
+**Library:** serde v1.0 / serde_json v1.0
+**Discovery:** According to Serde best practices and memory constraints optimization guidelines, when serializing slices or iterators of structs, collecting them into intermediate `Vec` collections is unnecessary and expensive in WebAssembly targets. We can use a custom wrapper struct that implements `serde::Serialize` and utilizes `serializer.collect_seq()` to stream the data directly without any intermediate heap allocations.
+**Application:** Applied to `diagnostics_to_json` in `tzlint_wasm` where the diagnostics slice was unnecessarily collected into a `Vec<DiagnosticJson>` prior to serialization. Wrapping `&[Diagnostic]` and implementing `Serialize` with `serializer.collect_seq()` bypasses this intermediate heap allocation.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -150,18 +150,25 @@ struct DiagnosticJson<'a> {
 }
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/ser/trait.Serializer.html#method.collect_seq
💡 Insight: According to Serde documentation, collecting elements into an intermediate slice or `Vec` prior to serialization is unnecessary. Implementing `Serialize` on a custom wrapper allows us to use `serializer.collect_seq()` to stream iterators directly.
🛠️ Change: Refactored `diagnostics_to_json` in `crates/tzlint_wasm/src/lib.rs` by wrapping `&[Diagnostic]` in a custom struct that implements `serde::Serialize` via `collect_seq()`.
✨ Benefit: Avoids an unnecessary heap allocation of `Vec<DiagnosticJson>`, improving performance and efficiency, especially for memory-constrained WebAssembly environments.

---
*PR created automatically by Jules for task [10354226344761681645](https://jules.google.com/task/10354226344761681645) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * JSON 変換の処理を見直し、不要な一時データの生成を減らしました。
  * 診断情報の出力がより効率的になり、メモリ使用量の削減が期待できます。
  * 変換に失敗した場合の空配列を返す挙動はこれまで通り維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->