### PR TITLE
⚡ Bolt: Optimize diagnostics serialization to avoid heap allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-30 - WASM Serialization Allocation Optimization
+**Learning:** In WebAssembly targets, collecting iterators into intermediate `Vec` collections (e.g. `Vec<DiagnosticJson>`) before `serde_json` serialization introduces unnecessary heap allocation and memory overhead, which can be detrimental in memory-constrained environments.
+**Action:** Always wrap slices or iterators in a custom struct and implement `serde::Serialize` using `serializer.collect_seq()` to stream data directly without intermediate heap allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,27 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    let list = DiagnosticList(diagnostics);
+    serde_json::to_string(&list).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What:
Refactored `diagnostics_to_json` in the `tzlint_wasm` crate to implement a custom `DiagnosticList` struct that explicitly implements `serde::Serialize`. This streams the iterator of diagnostics directly to the serializer via `serializer.collect_seq()`, eliminating the intermediate collection step into a `Vec<DiagnosticJson>`.

🎯 Why:
In memory-constrained WebAssembly environments, unnecessary heap allocations can cause out-of-memory errors or degrade performance through excessive garbage collection and memory fragmentation. Collecting diagnostics into an intermediate `Vec` immediately before serialization is an inefficient pattern when the data can be streamed.

📊 Impact:
Removes a O(N) heap allocation (where N is the number of diagnostics) during the final WebAssembly serialization step, decreasing peak memory usage and potentially improving the execution speed of `lint_to_json` calls.

🔬 Measurement:
Verified through `cargo clippy --workspace --all-targets` and `cargo test --workspace` that the functionality remains identical and all tests pass with the new zero-allocation streaming setup.

---
*PR created automatically by Jules for task [5057209635186171689](https://jules.google.com/task/5057209635186171689) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * WASM環境での診断結果JSON生成を、より省メモリな逐次シリアライズ方式に改善しました。
* **改善**
  * 中間データの作成を減らし、ヒープ確保の増加を抑えることで、出力処理の効率を向上しました。
* **ドキュメント**
  * WASM向けのシリアライズ方針と運用メモを追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->