### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-02-09 - Serde zero-copy array/sequence serialization
+**Library:** serde v1.0 / serde_json v1.0
+**Discovery:** When serializing a collection into a JSON array, collecting items into an intermediate `Vec` introduces unnecessary heap allocation. We can avoid this allocation by wrapping the slice in a custom struct and implementing `serde::Serialize` utilizing `serializer.collect_seq()` or `serializer.serialize_seq()` to stream data directly without intermediate heap allocations.
+**Application:** Used this technique in `tzlint_wasm::diagnostics_to_json` to serialize the list of `Diagnostic` into JSON without an intermediate `Vec<DiagnosticJson>`.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,33 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for d in self.0 {
+            seq.serialize_element(&DiagnosticJson {
+                rule_id: d.rule_id.as_str(),
+                severity: severity_str(d.severity),
+                message: d.message.as_str(),
+                start: d.span.start,
+                end: d.span.end,
+            })?;
+        }
+        seq.end()
+    }
+}
+
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+/// This uses a custom wrapper to avoid allocating an intermediate `Vec<DiagnosticJson>`,
+/// following `serde` best practices.
 fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
-            rule_id: d.rule_id.as_str(),
-            severity: severity_str(d.severity),
-            message: d.message.as_str(),
-            start: d.span.start,
-            end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/ser/trait.Serializer.html#method.collect_seq (and https://docs.rs/serde/latest/serde/ser/trait.Serializer.html#method.serialize_seq)
💡 Insight: The serde documentation recommends avoiding collecting iterators into intermediate allocations (like a `Vec`) when serializing sequence structures. The serializer can instead stream sequences using `serialize_seq` / `SerializeSeq` trait methods on a wrapper struct implementing `Serialize`.
🛠️ Change: Refactored `diagnostics_to_json` to wrap the `&[Diagnostic]` slice inside a `DiagnosticsWrapper` custom struct instead of `.collect()`-ing it into a `Vec<DiagnosticJson>`. The custom `Serialize` implementation calls `serialize_seq` and streams each item.
✨ Benefit: Improves efficiency by avoiding an intermediate heap allocation per linter result execution, saving memory and processing overhead.

---
*PR created automatically by Jules for task [5803751861946977122](https://jules.google.com/task/5803751861946977122) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 診断結果の JSON 生成を改善し、中間配列の作成を減らしてメモリ使用量を抑えました。
  * 大量の診断データでも、より効率よくシリアライズできるようになりました。

* **Documentation**
  * シリアライズ処理の改善内容について、開発メモを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->