### PR TITLE
🦀 Ferris: [refactor] optimize WASM diagnostic serialization

### DIFF
--- a/.jules/ferris.md
+++ b/.jules/ferris.md
@@ -1,0 +1,3 @@
+## 2024-07-05 - Avoid intermediate Vec allocations during JSON serialization
+**Learning:** Collecting mapped iterators into a `Vec` before calling `serde_json::to_string` causes unnecessary heap allocations, particularly detrimental in memory-constrained WebAssembly environments.
+**Action:** Define a custom wrapper struct for slices or iterators and implement `serde::Serialize` utilizing `serializer.collect_seq()` to stream data directly without intermediate heap allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsJson<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsJson<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsJson(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 Improvement: Refactored `diagnostics_to_json` in `tzlint_wasm/src/lib.rs` to stream the `Diagnostic` iterator directly to the JSON serializer using a custom `DiagnosticsJson` struct and `serializer.collect_seq()`.
🦀 Why: Idiomatic Rust > Clever Rust. Collecting mapped iterators into a `Vec` prior to passing to `serde_json::to_string` causes unnecessary heap allocations, particularly detrimental in memory-constrained WebAssembly environments. The zero-cost abstraction directly implements `serde::Serialize` to prevent this overhead.
🔍 Verification: Ran `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --all --check` locally. The serialization logic is functionally identical and passes existing tests.

---
*PR created automatically by Jules for task [3712164817018170292](https://jules.google.com/task/3712164817018170292) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 診断情報の JSON 出力が、余分な一時データを作らずに逐次生成されるようになりました。
  * これにより、JSON 変換時のメモリ使用量が削減され、より軽快に動作します。
  * 変換に失敗した場合の出力は従来どおり `"[]"` です。
* **Documentation**
  * メモに、JSON シリアライズ時の効率改善に関する知見を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->