### PR TITLE
⚡ Bolt: [performance improvement] avoid intermediate Vec for WASM JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-05 - Avoid intermediate collections prior to JSON serialization
+**Learning:** In performance-critical paths like WASM bindings, intermediate `Vec` collections allocated strictly to feed into `serde_json::to_string` incur unneeded memory allocation and latency, especially in a constrained target.
+**Action:** Instead of collecting into an intermediate `Vec`, wrap the slice in a custom struct and implement `serde::Serialize` calling `serializer.collect_seq()` to stream data directly without intermediate heap allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Replaced the intermediate `Vec<DiagnosticJson>` collection inside `diagnostics_to_json` with a custom `DiagnosticList` struct that implements `serde::Serialize` utilizing `serializer.collect_seq()`.
🎯 Why: Collecting into a `Vec` prior to passing it to `serde_json::to_string` causes unnecessary heap allocations. By streaming the iterator directly, we avoid this allocation overhead, which is especially important in constrained environments like WebAssembly.
📊 Impact: Eliminates a `Vec` heap allocation during diagnostic JSON serialization, improving memory usage and reducing latency.
🔬 Measurement: Verified that tests continue to pass and output is identically structured. Use a memory profiler or WASM benchmark on large markdown files to observe reduced allocation counts.

---
*PR created automatically by Jules for task [10379429569552732510](https://jules.google.com/task/10379429569552732510) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断情報のJSON出力が、よりメモリ効率よく処理されるようになりました。大量の診断でも、安定性と応答性の向上が期待できます。
* **ドキュメント**
  * JSONシリアライズ時に中間データを増やさない運用方針に関するメモを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->