### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via special-purpose IPv6 addresses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-07-05 - Enhanced SSRF protection for IPv6
+
+**Vulnerability:** The `validate_dictionary_url` SSRF protection in `tzlint_core` did not block certain special-purpose IPv6 address ranges defined in RFCs, potentially allowing an attacker to probe or fetch internal resources via documentation (2001:db8::/32), BMWG benchmarking (2001:2::/48), or discard (100::/64) IPv6 prefixes.
+
+**Learning:** It's important to cross-reference IP blocklists with IANA's Special-Purpose Address Registries to ensure comprehensive coverage against SSRF vectors. Even seemingly harmless prefixes like the documentation block could be routed internally depending on the network configuration. Additionally, when implementing subnet checks based on segment arrays (e.g., `segments[0] == 0x2001 && segments[1] == 0x0002`), always ensure the bitmask is correctly mapped (e.g., a `/48` requires checking the first 3 segments: `&& segments[2] == 0x0000`).
+
+**Prevention:** Regularly audit the IP blocklist against updated IANA registries, and write precise unit tests that explicitly test boundary conditions for blocked prefixes to prevent mathematical inaccuracies in the mask checks.

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,8 +177,10 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000) // 2001:2::/48 (BMWG)
+        || (segments[0] == 0x0100 && segments[1] == 0x0000 && segments[2] == 0x0000 && segments[3] == 0x0000) // 100::/64 (discard)
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -303,6 +305,9 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[2001:2::1]",                               // BMWG
+            "[100::1]",                                  // discard
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `validate_dictionary_url` SSRF protection did not block certain special-purpose IPv6 address ranges defined in RFCs, potentially allowing an attacker to probe or fetch internal resources via documentation (`2001:db8::/32`), BMWG benchmarking (`2001:2::/48`), or discard (`100::/64`) IPv6 prefixes.
🎯 Impact: This could be exploited by an attacker to bypass SSRF protections and access restricted endpoints on a network if those blocks are routed internally.
🔧 Fix: Explicitly added these three IPv6 blocklist conditions to `ipv6_is_blocked` in `crates/tzlint_core/src/net.rs`.
✅ Verification: Ran `cargo test --workspace` and verified with new tests adding assertions for these IPv6 ranges. Run `cargo clippy` and `cargo fmt`.

---
*PR created automatically by Jules for task [1713196489316502391](https://jules.google.com/task/1713196489316502391) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 一部の特別用途 IPv6 アドレスを含む URL が、適切にブロックされるようになりました。
  * これにより、外部通信の制限がより厳密になり、想定外の内部到達リスクを低減します。

* **Tests**
  * IPv6 の境界条件を含むケースの確認が追加され、ブロック判定の信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->