### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Serialize Iterators Directly
+**Library:** serde v1.0
+**Discovery:** `serde::Serializer::collect_seq` allows serializing an iterator directly without collecting into an intermediate collection.
+**Application:** Replaced the intermediate `Vec` allocation in `diagnostics_to_json` with a custom struct wrapping the slice and using `collect_seq` to stream the data, improving memory efficiency in the WASM target.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.collect_seq
💡 Insight: `serde::Serializer::collect_seq` allows serializing an iterator directly without collecting into an intermediate collection. Our previous code was collecting diagnostics into a `Vec<DiagnosticJson>` before passing it to `serde_json::to_string`.
🛠️ Change: Replaced the intermediate `Vec` allocation in `diagnostics_to_json` with a custom `DiagnosticList<'a>` struct that wraps the slice and implements `serde::Serialize` by streaming the iterator via `collect_seq`.
✨ Benefit: Improves memory efficiency in the WASM target by eliminating the need to allocate and populate an intermediate vector when generating JSON output.

---
*PR created automatically by Jules for task [1961360619933930774](https://jules.google.com/task/1961360619933930774) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 診断情報の JSON 出力を見直し、より効率的に生成されるよう改善しました。出力形式はこれまでどおりです。
* **Documentation**
  * 変更内容に関する説明をドキュメントへ追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->