### PR TITLE
⚡ Bolt: Stream JSON serialization in Wasm

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-06 - Stream JSON serialization for WebAssembly
+**Learning:** Serializing slices of data to JSON by first mapping to an intermediate `Vec<T>` allocates memory unnecessarily. This overhead is particularly detrimental in Wasm where allocations are expensive.
+**Action:** Implement `serde::Serialize` on a wrapper struct and use `serializer.collect_seq()` to stream iterator values directly into the JSON serializer, bypassing the intermediate heap allocation.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Replaced intermediate `Vec` allocation in Wasm diagnostics serialization with direct struct streaming via `serde::Serialize` using `collect_seq()`.
🎯 Why: To reduce unnecessary heap allocations and GC overhead in WebAssembly by directly serializing structural slices.
📊 Impact: Significantly minimizes memory allocations and speeds up JSON conversion of output diagnostics from Wasm layer.
🔬 Measurement: Observe reduction in memory overhead/allocations when processing large documents with numerous linting diagnostics.

---
*PR created automatically by Jules for task [14399504419809808924](https://jules.google.com/task/14399504419809808924) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * WebAssembly向けのJSON出力が、より効率的にストリーミング生成されるようになりました。
* **改善**
  * 余分な一時領域を使わずに診断結果をJSON化するため、メモリ使用量の削減と処理効率の向上が期待できます。
  * JSONの出力形式や、変換失敗時に空配列を返す挙動はこれまで通り維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->