### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SSRF blocklist bypass for IPv6 special prefixes

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,9 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000) // 2001:2::/48 (benchmarking)
+        || (segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0) // 100::/64 (discard)
 }
 
 #[cfg(test)]
@@ -303,6 +306,9 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[2001:2::1]",                               // benchmarking
+            "[100::1]",                                  // discard
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: SSRF blocklist missing IPv6 Documentation, Benchmarking, and Discard prefixes.
🎯 Impact: Potential SSRF bypass allowing fetch requests to internal test/discard networks.
🔧 Fix: Added segment checks for 2001:db8::/32, 2001:2::/48, and 100::/64.
✅ Verification: Tests passing.

---
*PR created automatically by Jules for task [1644620120719087770](https://jules.google.com/task/1644620120719087770) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6アドレスの判定が拡張され、特定の予約済みプレフィックスを含むリテラルがより適切に拒否されるようになりました。
  * ドキュメント用、ベンチマーク用、破棄用のIPv6範囲もブロック対象に追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->