### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-07-07 - Avoid Intermediate Vec Allocations in Serde
+**Library:** serde v1.0
+**Discovery:** Serde serializers provide a `collect_seq` method (and related `serialize_seq`) that accepts an iterator. This allows streaming data directly to the serializer without needing to collect elements into an intermediate `Vec`.
+**Application:** Used a wrapper struct `DiagnosticList` with a custom `Serialize` implementation using `serializer.collect_seq()` in the WebAssembly boundary to serialize diagnostics directly to JSON, eliminating a `Vec` heap allocation in a performance-critical path.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -150,18 +150,25 @@ struct DiagnosticJson<'a> {
 }
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/trait.Serializer.html#method.collect_seq
💡 Insight: Serde serializers provide a `collect_seq` method to serialize an iterator directly. Currently we collect `DiagnosticJson` elements into an intermediate `Vec` before serialization.
🛠️ Change: Created a wrapper `DiagnosticList` struct and implemented `serde::Serialize` utilizing `serializer.collect_seq()` to stream iterator elements without heap allocations.
✨ Benefit: Avoids a `Vec` heap allocation in the serialization path, optimizing performance especially for WebAssembly.

---
*PR created automatically by Jules for task [13580267249183827005](https://jules.google.com/task/13580267249183827005) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 診断結果の JSON 変換時に、不要な中間確保を減らしてメモリ使用量を改善しました。
  * WebAssembly 経由の出力でも、従来どおり同じ JSON 形式を維持します。
  * シリアライズに失敗した場合は、これまで通り空配列を返します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->