### PR TITLE
⚡ Bolt: [performance improvement] Stream diagnostic serialization in WASM to eliminate Vec allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-30 - Serialization Allocations in WASM
+**Learning:** In WebAssembly performance, building intermediate Vecs for JSON serialization allocates on the heap unnecessarily.
+**Action:** Wrap slices in structs and use serde's `collect_seq` instead of collecting maps into a Vec before passing to `serde_json::to_string()`.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What:
Replaced the intermediate `Vec<DiagnosticJson>` allocation in `tzlint_wasm`'s `diagnostics_to_json` with a custom `DiagnosticsList` wrapper struct. The wrapper implements `serde::Serialize` directly and utilizes `serializer.collect_seq()` to stream the JSON serialization.

🎯 Why:
To avoid unnecessary intermediate heap allocations. Previously, `diagnostics_to_json` collected an iterator over `Diagnostic` into a newly allocated `Vec<DiagnosticJson>` before passing it to `serde_json::to_string()`. This causes heap allocations that are unnecessary and can be an architectural bottleneck in memory-constrained environments like WebAssembly.

📊 Impact:
Reduces memory footprint and eliminates one heap allocation scale factor bounded to the document's diagnostic count per linter invocation on the WASM boundary. Time spent in malloc/free memory management is effectively circumvented.

🔬 Measurement:
Run the workspace tests. Both `tzlint_wasm` integration bounds and native CLI rules must pass flawlessly. Memory profiling (or observing instructions during WebAssembly execution with Extism) should reflect fewer heap expansions during document returns.

---
*PR created automatically by Jules for task [16758511891338997350](https://jules.google.com/task/16758511891338997350) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebAssembly 環境での診断結果の JSON 出力を改善し、不要な中間データ生成を減らしました。
  * 大量の診断でも、より安定して JSON を生成できるようになりました。

* **Documentation**
  * WebAssembly での JSON シリアライズに関する注意点と推奨手順を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->