### PR TITLE
🛡️ Sentinel: [HIGH] Fix incomplete IPv6 SSRF blocklist (documentation & benchmarking prefixes)

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,8 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0) // 2001:2::/48 (benchmarking)
 }
 
 #[cfg(test)]
@@ -303,6 +305,8 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[2001:2::1]",                               // benchmarking
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing blocks for IPv6 documentation (2001:db8::/32) and benchmarking (2001:2::/48) prefixes in SSRF validation.
🎯 Impact: Linter could be coerced to target these addresses to probe or leak details.
🔧 Fix: Manually validate these prefixes in `ipv6_is_blocked()`.
✅ Verification: Unit tests ensure these prefixes are rejected during URL validation.

---
*PR created automatically by Jules for task [9761796083642773331](https://jules.google.com/task/9761796083642773331) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6リテラルの判定が更新され、ドキュメント用・ベンチマーク用のアドレスがブロック対象に追加されました。
  * これらのアドレスを含むURLが、適切に拒否されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->