### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2026-06-30 - Optimize intermediate JSON allocations with serde_json
+**Library:** serde_json v1.0
+**Discovery:** In memory-constrained environments, building a dynamic `serde_json::Value` only to stringify it with `.to_string()` incurs unnecessary heap allocations. We can implement `serde::Serialize` to stream data directly without intermediate collections.
+**Application:** Replaced the intermediate mapping of `Diagnostic` into a `Vec<DiagnosticJson>` with a custom struct `DiagnosticList` that implements `serde::Serialize`. It uses `serializer.collect_seq()` to directly stream the data without creating a new `Vec`, avoiding allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: serde documentation on serializing iterators directly
💡 Insight: Constructing an intermediate `Vec<DiagnosticJson>` before calling `serde_json::to_string()` incurs an unnecessary heap allocation. Using a custom struct that implements `serde::Serialize` and delegating to `serializer.collect_seq()` allows streaming directly from an iterator.
🛠️ Change: Added `DiagnosticList` which wraps a slice of `Diagnostic` and implements `Serialize`. Replaced the `Vec<DiagnosticJson>` map-collect step in `diagnostics_to_json()` with passing the `DiagnosticList` to `serde_json::to_string()`.
✨ Benefit: Reduces heap allocations and memory footprint when generating diagnostic output for the WebAssembly boundary.

---
*PR created automatically by Jules for task [17569350373581594005](https://jules.google.com/task/17569350373581594005) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断情報のJSON生成を最適化し、余分な中間データを減らして出力効率を向上しました。
  * 大量の診断を扱う際のメモリ使用量を抑え、応答の安定性を改善しました。
  * JSON出力に失敗した場合の安全なフォールバックは引き続き維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->