### PR TITLE
⚡ Bolt: [performance improvement] Stream JSON diagnostics without intermediate allocation in WASM

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-30 - WASM Diagnostics JSON Serialization Optimization
+**Learning:** Collecting iterators into intermediate `Vec` instances before JSON serialization introduces unnecessary heap allocations, particularly impactful in memory-constrained targets like WebAssembly.
+**Action:** Instead, wrap the slice in a custom struct and implement `serde::Serialize` using `serializer.collect_seq()` to stream data directly without intermediate allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Refactors `diagnostics_to_json` in `tzlint_wasm` to stream diagnostics directly to JSON without allocating an intermediate `Vec<DiagnosticJson>`.
🎯 Why: In `tzlint_wasm/src/lib.rs`, the code collected `Diagnostic` iterators into a `Vec` before calling `serde_json::to_string`. This introduces unnecessary heap allocations which is particularly undesirable and impactful in memory-constrained targets like WebAssembly.
📊 Impact: Completely eliminates the intermediate `Vec<DiagnosticJson>` allocation for every lint execution returning diagnostics.
🔬 Measurement: Verify tests run smoothly and ensure the generated JSON structure remains intact (as tested with existing unit tests in `tzlint_wasm/src/lib.rs` and `cargo test`).

---
*PR created automatically by Jules for task [4594470745533909140](https://jules.google.com/task/4594470745533909140) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **パフォーマンス改善**
  * 診断情報の JSON 変換を最適化し、中間データの生成を減らしてメモリ使用量を抑えました。
  * 変換失敗時の出力はこれまで通り空配列になります。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->