### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF bypass via unhandled IPv6 special prefixes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-08 - SSRF bypass via unhandled IPv6 special prefixes
+**Vulnerability:** The SSRF blocklist for IPv6 in `validate_dictionary_url` did not block documentation (`2001:db8::/32`), benchmarking (`2001:2::/48`), and discard-only (`100::/64`) prefix ranges, which could theoretically be routed internally in specific configurations.
+**Learning:** Rust's `Ipv6Addr::is_documentation()` is currently unstable (issue #27709), so manual segment checks are necessary. Furthermore, the number of segment checks must match the CIDR prefix length (e.g., `/48` needs exactly three 16-bit segment checks).
+**Prevention:** Ensure all special-purpose IP ranges are manually checked for SSRF blocklists using `addr.segments()` when standard library helpers are unstable.

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,9 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000) // 2001:2::/48 (benchmarking)
+        || (segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0) // 100::/64 (discard-only)
 }
 
 #[cfg(test)]
@@ -303,6 +306,9 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:0db8::1]",                            // Documentation
+            "[2001:0002:0000::1]",                       // Benchmarking
+            "[0100:0000:0000:0000::1]",                  // Discard-only
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing blocks for IPv6 documentation/benchmarking/discard ranges
🎯 Impact: Potential minor SSRF bypass in unusual internal routing setups
🔧 Fix: Added manual segment blocks for 2001:db8::/32, 2001:2::/48, and 100::/64
✅ Verification: Unit tests pass.

---
*PR created automatically by Jules for task [13098014923059613019](https://jules.google.com/task/13098014923059613019) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 辞書URLの検証で、特定の IPv6 リテラルが許可されてしまう問題を修正しました。
  * ドキュメント用・ベンチマーク用・廃棄用のアドレス範囲を拒否対象に追加し、より安全に判定されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->