### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2026-07-09 - Zero-copy sequence serialization in memory-constrained targets
+**Library:** serde v1.0
+**Discovery:** Iterators can be serialized directly without allocating intermediate memory via `serializer.collect_seq()` or `serializer.serialize_seq()`.
+**Application:** Avoids unnecessary intermediate heap collections into `Vec` prior to serialization, crucial for WebAssembly where avoiding heap allocations significantly improves performance.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -150,18 +150,25 @@ struct DiagnosticJson<'a> {
 }
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/trait.Serializer.html#method.collect_seq
💡 Insight: `serde::Serializer::collect_seq` allows serializing an iterator directly without pre-allocating memory for a temporary sequence (like `Vec`), reducing heap allocations.
🛠️ Change: Refactored `diagnostics_to_json` in `tzlint_wasm` to wrap the slice in a custom `DiagnosticsList` struct and use `collect_seq` instead of collecting into a `Vec<DiagnosticJson>`.
✨ Benefit: Significantly lowers heap allocations, which is especially beneficial for WebAssembly targets by increasing execution speed and reducing memory footprint.

---
*PR created automatically by Jules for task [16422423571222679383](https://jules.google.com/task/16422423571222679383) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 制約のある環境でも、診断結果を中間メモリ確保なしで JSON 化できるようになりました。これにより、より軽量に出力できます。
* **ドキュメント**
  * メモリ効率のよいシリアライズ手法に関する解説ノートを追加しました。
* **バグ修正**
  * JSON 変換時の不要な一時データ生成を減らし、失敗時は従来どおり `[]` を返す動作を維持しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->