### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SSRF bypass via unblocked IPv6 prefixes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-07-09 - SSRF Fix: Manual IPv6 Subnet Blocking
+**Vulnerability:** IPv6 documentation (2001:db8::/32) and benchmarking (2001:2::/48) prefixes were unblocked in `net.rs`, which could allow SSRF bypasses via reserved non-local prefixes routing internally.
+**Learning:** `Ipv6Addr::to_ipv4()` only handles mapped/compatible addresses, and many standard library segment inspection functions are unstable or unavailable. Validating specific subnets requires explicit mapping of CIDR lengths to 16-bit segment comparisons in the form `segments[N] == 0xXXXX`.
+**Prevention:** Always manually validate and implement required internal or reserved IP blocklist masks using strict segment-level checks when using standard Rust networking primitives without `std::net`'s unstable subnet methods, and write dedicated tests for any edge cases.

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,8 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000) // 2001:2::/48 (benchmarking)
 }
 
 #[cfg(test)]
@@ -303,6 +305,8 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:0db8::1]",                            // documentation
+            "[2001:0002::1]",                            // benchmarking
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: IPv6 documentation and benchmarking ranges were not blocked, allowing potential SSRF bypasses via reserved non-local prefixes routing internally.
🎯 Impact: Could allow probing of internal services or unexpected behavior in some environments.
🔧 Fix: Manually validated address segments for 2001:db8::/32 and 2001:2::/48 in `ipv6_is_blocked`.
✅ Verification: Added unit tests for these ranges and verified they pass.

---
*PR created automatically by Jules for task [2566272572880611308](https://jules.google.com/task/2566272572880611308) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * URL の検証で、特定の IPv6 アドレスが誤って許可される問題を修正しました。
  * ドキュメント用・予約用途の IPv6 範囲をブロック対象に追加し、危険なホストへのアクセスをより確実に拒否するようになりました。
  * 該当する IPv6 リテラルに対する拒否テストも追加され、検証の安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->