### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,8 @@
+## 2023-11-20 - [Example]
+**Library:** [Name vX.Y.Z]
+**Discovery:** [Details]
+**Application:** [Details]
+## 2024-07-10 - [Serde Streaming Serialization]
+**Library:** [serde v1.0]
+**Discovery:** [The `Serializer::collect_seq` and `Serializer::serialize_seq` methods allow streaming an iterator directly without allocating an intermediate container.]
+**Application:** [Refactored `diagnostics_to_json` in `tzlint_wasm` to stream diagnostics directly to JSON, bypassing intermediate `Vec` heap allocations.]

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: `serde::Serializer::collect_seq` (https://docs.rs/serde/latest/serde/trait.Serializer.html#method.collect_seq)

💡 Insight: Serde supports streaming an iterator directly into a sequence using `collect_seq` on the `Serializer`. In `crates/tzlint_wasm/src/lib.rs`, `diagnostics_to_json` was allocating an intermediate `Vec<DiagnosticJson>` merely to construct a JSON array via `serde_json::to_string`. This unnecessary heap allocation is particularly costly in a memory-constrained WebAssembly environment.

🛠️ Change: Refactored `diagnostics_to_json` to introduce a custom wrapper struct `DiagnosticsWrapper<'a>(&'a [Diagnostic])` that implements `serde::Serialize`. Within the `serialize` method, it uses `serializer.collect_seq` to stream the transformed iterators directly to JSON without the intermediate `Vec`.

✨ Benefit: This eliminates a heap allocation and the associated overhead during the `lint_to_json` serialization boundary in the WebAssembly artifact, improving performance and memory efficiency.

---
*PR created automatically by Jules for task [15141724735820198763](https://jules.google.com/task/15141724735820198763) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 診断結果のJSON出力をストリーミング方式に変更し、大量の診断結果でも中間データの生成を抑えて効率化しました。
  - JSONの項目内容やエラー時の空配列フォールバックは従来どおり維持されています。

- **ドキュメント**
  - 研究記録を追加し、関連ライブラリや実装上の知見を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->