### PR TITLE
⚡ Bolt: Remove intermediate JSON DOM allocation overhead for serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-10 - Serde JSON macro overhead
+**Learning:** The `serde_json::json!` macro allocates an intermediate DOM (`serde_json::Value`) which introduces overhead for serialization in performance-critical paths, especially in WebAssembly targets.
+**Action:** Use a local struct with `#[derive(serde::Serialize)]` and pass it directly to `serde_json::to_string()` (or `serde_json::to_vec()`) instead of using `serde_json::json!`.

--- a/crates/tzlint_core/Cargo.toml
+++ b/crates/tzlint_core/Cargo.toml
@@ -16,7 +16,7 @@ tzlint_ast = { path = "../tzlint_ast", version = "0.0.0" }
 tzlint_pdk = { path = "../tzlint_pdk", version = "0.0.0" }
 markdown = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json.workspace = true
 yaml_serde = { workspace = true }
 blake3 = { workspace = true }
 ruzstd = { workspace = true }

--- a/crates/tzlint_core/src/cache.rs
+++ b/crates/tzlint_core/src/cache.rs
@@ -397,17 +397,65 @@ impl DocumentCache {
     /// the in-memory bytes before the write keeps it TOCTOU-free. (`MAX_CACHE_FILE` in practice;
     /// the parameter lets tests drive the bound without a 64 MiB fixture.)
     fn save_within(&self, host: &dyn Host, path: &Path, limit: usize) -> Result<(), CacheError> {
-        let mut entries = serde_json::Map::with_capacity(self.entries.len());
-        for (key, diagnostics) in &self.entries {
-            let array: Vec<Value> = diagnostics.iter().map(diagnostic_to_value).collect();
-            entries.insert(key.to_hex(), Value::Array(array));
+        #[derive(serde::Serialize)]
+        struct CacheDocument<'a> {
+            version: u64,
+            entries: std::collections::BTreeMap<String, Vec<CacheDiagnostic<'a>>>,
         }
-        let document = serde_json::json!({
-            "version": CACHE_FILE_VERSION,
-            "entries": Value::Object(entries),
-        });
-        // `Value`'s `Display` is infallible, so no serialization error to handle here.
-        let text = document.to_string();
+
+        #[derive(serde::Serialize)]
+        struct CacheDiagnostic<'a> {
+            rule_id: &'a str,
+            severity: &'a str,
+            message: &'a str,
+            span: CacheSpan,
+            fixes: Vec<CacheFix<'a>>,
+        }
+
+        #[derive(serde::Serialize)]
+        struct CacheSpan {
+            start: u32,
+            end: u32,
+        }
+
+        #[derive(serde::Serialize)]
+        struct CacheFix<'a> {
+            span: CacheSpan,
+            replacement: &'a str,
+        }
+
+        let mut entries = std::collections::BTreeMap::new();
+        for (key, diagnostics) in &self.entries {
+            let array: Vec<CacheDiagnostic> = diagnostics
+                .iter()
+                .map(|diagnostic| CacheDiagnostic {
+                    rule_id: diagnostic.rule_id.as_str(),
+                    severity: severity_name(diagnostic.severity),
+                    message: diagnostic.message.as_str(),
+                    span: CacheSpan {
+                        start: diagnostic.span.start,
+                        end: diagnostic.span.end,
+                    },
+                    fixes: diagnostic
+                        .fixes
+                        .iter()
+                        .map(|fix| CacheFix {
+                            span: CacheSpan {
+                                start: fix.span.start,
+                                end: fix.span.end,
+                            },
+                            replacement: fix.replacement.as_str(),
+                        })
+                        .collect(),
+                })
+                .collect();
+            entries.insert(key.to_hex(), array);
+        }
+        let document = CacheDocument {
+            version: CACHE_FILE_VERSION,
+            entries,
+        };
+        let text = serde_json::to_string(&document).unwrap_or_default();
         if text.len() > limit {
             return Err(CacheError::Io(IoError::TooLarge { limit }));
         }
@@ -561,24 +609,6 @@ fn severity_from_name(name: &str) -> Option<Severity> {
         "hint" => Some(Severity::Hint),
         _ => None,
     }
-}
-
-/// Serialize one diagnostic to the cache-file JSON shape.
-fn diagnostic_to_value(diagnostic: &Diagnostic) -> Value {
-    serde_json::json!({
-        "rule_id": diagnostic.rule_id.as_str(),
-        "severity": severity_name(diagnostic.severity),
-        "message": diagnostic.message,
-        "span": { "start": diagnostic.span.start, "end": diagnostic.span.end },
-        "fixes": diagnostic
-            .fixes
-            .iter()
-            .map(|fix| serde_json::json!({
-                "span": { "start": fix.span.start, "end": fix.span.end },
-                "replacement": fix.replacement,
-            }))
-            .collect::<Vec<_>>(),
-    })
 }
 
 /// Reconstruct a diagnostic from the cache-file JSON shape, or `None` if any field is missing or


### PR DESCRIPTION
💡 What: Replace the use of `serde_json::json!` and `Value::Object` in `cache.rs` with explicitly defined structs that derive `serde::Serialize` (e.g., `CacheDocument`, `CacheDiagnostic`).
🎯 Why: `serde_json::json!` constructs an intermediate JSON DOM structure (`Value`), which adds overhead and allocations, negatively impacting serialization performance, especially for WebAssembly targets. Bypassing the intermediate representation and passing structs directly to `serde_json::to_string` speeds up execution.
📊 Impact: Eliminates unnecessary allocations per diagnostics and rule entry in the cache saving path.
🔬 Measurement: Observe memory allocations / profiling or check WASM blob performance on cache serialization, which avoids generating thousands of intermediate `Value` nodes for larger files.

---
*PR created automatically by Jules for task [17656374170881181515](https://jules.google.com/task/17656374170881181515) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - キャッシュデータの保存処理を見直し、JSON生成の効率と安定性を向上しました。
  - 保存される診断情報（重大度、範囲、修正内容）の形式は従来どおり維持されます。

- **ドキュメント**
  - JSONシリアライズの性能最適化に関する開発ノートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->