### PR TITLE
🛡️ Sentinel: [security improvement] Block IPv6 special purpose ranges

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Unstable IPv6 Helpers & SSRF Blocklist
+**Vulnerability:** Insufficient SSRF protection for IPv6 special-purpose ranges (Documentation, Benchmarking, Discard-only).
+**Learning:** Ipv6Addr helper methods like is_documentation() are currently unstable (issue #27709).
+**Prevention:** Manually validate the address segments mapping CIDR prefix length to the number of 16-bit segments (e.g., segments[0] == 0x2001 && segments[1] == 0x0db8 for 2001:db8::/32).

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,9 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0) // 2001:2::/48 (benchmarking)
+        || (segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0) // 100::/64 (discard-only)
 }
 
 #[cfg(test)]
@@ -303,6 +306,9 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[2001:2::1]",                               // benchmarking
+            "[100::1]",                                  // discard-only
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing SSRF protection for some IPv6 special-purpose blocklists.
🎯 Impact: Potential SSRF via IPv6 specific blocklists like documentation, benchmarking, or discard-only subnets.
🔧 Fix: Manually validated address segments in `ipv6_is_blocked` and updated tests.
✅ Verification: Added tests and ran the test suite successfully.

---
*PR created automatically by Jules for task [8857661921493286166](https://jules.google.com/task/8857661921493286166) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * IPv6のSSRF保護を強化し、ドキュメント用・ベンチマーク用・discard-onlyの特殊目的アドレスをブロックするようにしました。
  * 該当するIPv6リテラルが適切に拒否されることを確認しました。

* **ドキュメント**
  * IPv6特殊目的アドレスの分類と検証に関する注意事項を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->