### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Zero-copy Sequence Serialization in Serde
+**Library:** serde v1.0
+**Discovery:** To avoid allocating intermediate collections (`Vec`) when serializing iterators/slices, `serde::Serializer` provides methods like `collect_seq()`. This allows a custom `Serialize` implementation to stream items directly to the underlying format.
+**Application:** Replaced the intermediate `Vec<DiagnosticJson>` allocation in `crates/tzlint_wasm/src/lib.rs` by wrapping the slice in a custom struct and implementing `Serialize` with `collect_seq()`. This minimizes heap fragmentation and allocation overhead, critical for the WebAssembly target.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,27 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+/// A zero-allocation wrapper to stream diagnostics directly to JSON.
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/trait.Serializer.html#method.collect_seq
💡 Insight: When serializing a sequence mapped from another type, collecting into an intermediate `Vec` introduces unnecessary heap allocation. `serde::Serializer::collect_seq` allows streaming an iterator directly to the format.
🛠️ Change: Refactored `diagnostics_to_json` in `crates/tzlint_wasm` to use a custom wrapper struct with a `Serialize` implementation that uses `collect_seq()`.
✨ Benefit: Eliminates an intermediate `Vec` allocation per lint run, reducing heap pressure and improving performance for the Wasm target.

---
*PR created automatically by Jules for task [15169143515840822778](https://jules.google.com/task/15169143515840822778) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断結果のJSON変換で中間データの生成を減らし、メモリ使用量を抑えました。
  * 診断結果の出力内容と、変換失敗時のフォールバック動作は従来どおりです。

* **ドキュメント**
  * 診断結果を効率的にシリアライズする方針を記録しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->