### PR TITLE
🦀 Ferris: [performance improvement]

### DIFF
--- a/.jules/ferris.md
+++ b/.jules/ferris.md
@@ -1,0 +1,3 @@
+## 2025-01-01 - Optimize Wasm serialization
+**Learning:** Collecting iterators into an intermediate `Vec` before serialization wastes memory and time, especially in Wasm.
+**Action:** Wrap slices in a custom struct and use `serializer.collect_seq()` to stream data.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
🦀 Ferris: [performance improvement]

💡 Improvement:
Optimize Wasm diagnostic serialization by directly streaming the JSON array instead of allocating an intermediate `Vec<DiagnosticJson>`.

🦀 Why:
Idiomatic Rust > Clever Rust. Using `serializer.collect_seq()` is a zero-cost abstraction that avoids an unnecessary intermediate heap allocation. Memory efficiency is particularly critical in WebAssembly environments where memory growth translates to heavy reallocation overhead.

🔍 Verification:
Ran `cargo clippy` and `cargo test`. Behavior remains functionally identical, outputting the exact same JSON array, but avoiding a redundant memory allocation.

---
*PR created automatically by Jules for task [15150966163643969870](https://jules.google.com/task/15150966163643969870) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **パフォーマンス改善**
  * WebAssembly環境での診断情報のJSONシリアライズを最適化し、中間データの生成を省いてメモリ使用量と処理時間を削減しました。
  * 診断情報の出力内容とエラー時の挙動は従来どおりです。

* **ドキュメント**
  * シリアライズ最適化に関する知見と対応内容を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->