### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via IPv6 benchmarking/documentation blocks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - SSRF bypass via IPv6 benchmarking/documentation blocks
+**Vulnerability:** The SSRF protection in `net::ipv6_is_blocked` failed to block the IPv6 documentation (`2001:db8::/32`) and benchmarking (`2001:2::/48`) prefix blocks.
+**Learning:** These blocks can be routed in internal/private networks or used as unallocated space, leading to SSRF if they are re-assigned or point to internal machines or proxies by configuration. The standard `Ipv6Addr::is_documentation()` is unstable in Rust, so manual segment checking is necessary.
+**Prevention:** Explicitly match segments against known documentation (`2001:db8::/32`) and benchmarking (`2001:2::/48`) prefixes when validating IPv6 literals.

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,8 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000) // 2001:2::/48 (benchmarking)
 }
 
 #[cfg(test)]
@@ -303,6 +305,8 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[2001:2::1]",                               // benchmarking
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The URL validation in `validate_dictionary_url` did not block the IPv6 documentation (`2001:db8::/32`) and benchmarking (`2001:2::/48`) prefix blocks. These blocks can be misused for SSRF by pointing to internal hosts/networks.
🎯 Impact: An attacker could supply an explicitly configured malicious URL (if authorized) resolving to an internal host under these blocks, potentially probing the internal network bypassing SSRF protections.
🔧 Fix: Added explicit block checks for the benchmarking and documentation subnets in `ipv6_is_blocked`. This relies on manual segment checks rather than `is_documentation` which is currently unstable in Rust standard library.
✅ Verification: Ran `cargo test --workspace` which verified the two newly added prefix literal strings are successfully blocked. Also removed a leftover scratchpad file.

---
*PR created automatically by Jules for task [8573934976240292407](https://jules.google.com/task/8573934976240292407) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * IPv6のSSRF保護を強化し、ドキュメント用およびベンチマーク用の予約アドレス帯をブロック対象に追加しました。
  * 該当するIPv6リテラルが拒否されることを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->