### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Streamlining JSON serialization with serde
+**Library:** serde v1.0 / serde_json v1.0
+**Discovery:** Instead of allocating an intermediate `Vec<DiagnosticJson>` and relying on `serde_json::to_string(&items)`, we can wrap the slice `&[Diagnostic]` in a custom type and implement `serde::Serialize` utilizing `serializer.collect_seq()` to stream array elements without memory allocation for the intermediate `Vec`.
+**Application:** `tzlint_wasm::diagnostics_to_json` was allocating `Vec<DiagnosticJson>` before turning into a JSON string. We can wrap the slice with a custom struct, and implement `serde::Serialize` directly to `serde_json::to_string` to avoid allocating `Vec<DiagnosticJson>`.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/trait.Serializer.html#method.collect_seq
💡 Insight: `serde_json::to_string` was serializing an intermediate allocated `Vec<DiagnosticJson>`. Serde provides a `Serializer::collect_seq` method to stream elements directly from an iterator, bypassing the intermediate heap allocation.
🛠️ Change: Created a `DiagnosticList` wrapper over `&[Diagnostic]` and implemented `serde::Serialize` using `serializer.collect_seq` to stream the diagnostics directly.
✨ Benefit: Avoids a `Vec` heap allocation during JSON serialization, which is critical for Wasm performance.

---
*PR created automatically by Jules for task [7843408200692736745](https://jules.google.com/task/7843408200692736745) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **パフォーマンス改善**
  * 診断情報のJSON変換時に中間データの生成を省き、メモリ使用量を抑えながら効率的に処理できるよう改善しました。
  * 出力されるJSON形式と、変換失敗時のフォールバック動作は従来どおりです。

* **ドキュメント**
  * JSONシリアライズの効率化手法に関する説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->