### PR TITLE
⚡ Bolt: remove intermediate Vec allocation in WASM diagnostics serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-12 - Streaming Serialization for Diagnostics JSON
+**Learning:** In memory-constrained targets like WebAssembly, collecting iterators into intermediate `Vec` collections prior to serialization creates unnecessary heap allocations and slows down serialization.
+**Action:** Instead of `collect()`ing into a `Vec`, wrap the slice or iterator in a custom struct and implement `serde::Serialize` utilizing `serializer.collect_seq()` to stream data directly without intermediate heap allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Replaced the `.collect::<Vec<DiagnosticJson>>()` call inside `diagnostics_to_json` with a custom `DiagnosticsWrapper` that implements `serde::Serialize` to stream directly via `serializer.collect_seq()`.
🎯 Why: In memory-constrained WASM environments, allocating an intermediate heap `Vec` just to serialize an array is unnecessary and degrades performance. Streaming the mapping iterator directly into `serde_json::to_string` bypasses the O(N) allocation entirely.
📊 Impact: Eliminates a dynamic heap allocation proportional to the number of diagnostics, speeding up the serialization step before handing off to JavaScript.
🔬 Measurement: The overall benchmark for JSON formatting in WASM bounds the memory consumption much closer to the size of the final serialized string itself, avoiding memory fragmentation.

---
*PR created automatically by Jules for task [12938793097134611188](https://jules.google.com/task/12938793097134611188) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 診断データのJSON出力をストリーミング方式に変更し、不要な中間データ生成を削減しました。
  * 出力形式（ルールID、重要度、メッセージ、位置情報）と、エラー時の空配列へのフォールバックは従来どおりです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->