### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via unstable IPv6 ranges

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-12 - Missing Unstable IPv6 Prefix Protection in SSRF Blocklist
+**Vulnerability:** The SSRF blocklist failed to block the documentation (`2001:db8::/32`) and benchmarking (`2001:2::/48`) prefix ranges for IPv6, relying on standard Rust `Ipv6Addr` which has unstable helpers for these ranges.
+**Learning:** Always manually validate specific IPv6 prefix ranges (e.g., checking `segments`) when building security boundaries, as standard library features might be incomplete or unstable.
+**Prevention:** Ensure explicit prefix range checks for IPv6 addresses that shouldn't be routable or fetched to avoid bypasses, specifically checking documentation, benchmark, and discard prefixes if necessary.

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,8 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000) // 2001:2::/48 (benchmarking)
 }
 
 #[cfg(test)]
@@ -303,6 +305,8 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[2001:2::1]",                               // benchmarking
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `ipv6_is_blocked` SSRF boundary check did not block IPv6 addresses in the documentation (`2001:db8::/32`) and benchmarking (`2001:2::/48`) prefix ranges. Attackers could potentially abuse these ranges in certain environments or mock setups to bypass SSRF restrictions.
🎯 Impact: Minor risk of SSRF bypass or leakage of internal service structure/metadata if documentation/benchmarking subnets are resolvable or utilized internally.
🔧 Fix: Added explicit bitwise and segment checks for the `2001:db8::/32` and `2001:2::/48` prefix ranges in the `ipv6_is_blocked` logic.
✅ Verification: Expanded `ipv6_is_blocked` test suite in `net.rs` to assert that documentation and benchmarking prefixes are blocked. Verified tests pass.

---
*PR created automatically by Jules for task [15818311805499804228](https://jules.google.com/task/15818311805499804228) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **セキュリティ**
  * SSRF対策を強化し、IPv6のドキュメント用およびベンチマーク用アドレスへのアクセスをブロックするようになりました。
  * URL検証時に、対象アドレスを確実に拒否できるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->