### PR TITLE
🎓 Scholar: serde_json usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-01-20 - serde_json Serialization Optimization
+**Library:** serde v1.0, serde_json v1.0
+**Discovery:** Avoid collecting iterators into intermediate Vec collections prior to serialization in performance-critical paths (like WASM bindings). Wrapping the slice/iterator in a custom struct and implementing `serde::Serialize` utilizing `serializer.collect_seq()` or `serializer.serialize_seq()` streams data directly without intermediate heap allocations.
+**Application:** Used to optimize WASM `diagnostics_to_json` serialization to reduce intermediate memory allocations.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/trait.Serializer.html#method.collect_seq
💡 Insight: Serde documentation recommends using `collect_seq` to stream iterators directly into serialization, rather than allocating an intermediate `Vec`. The current code in `diagnostics_to_json` mapped `Diagnostic` structs and collected them into a `Vec<DiagnosticJson>` prior to calling `serde_json::to_string`.
🛠️ Change: Created a `DiagnosticList` struct wrapping the slice and implemented `serde::Serialize` utilizing `serializer.collect_seq()` to stream `DiagnosticJson` elements.
✨ Benefit: Avoids a heap allocation in a performance-critical path, ensuring better runtime efficiency for the WebAssembly bindings.

---
*PR created automatically by Jules for task [10060258820440415277](https://jules.google.com/task/10060258820440415277) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断情報のJSON変換を最適化し、中間データによるメモリ使用量を削減しました。
  * 診断結果をより効率的にストリーミング処理できるようになり、WASM環境での処理性能向上が期待できます。
  * JSON変換に失敗した場合は、従来どおり空の配列を返します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->