### PR TITLE
⚡ Bolt: [performance improvement] Avoid intermediate Vec allocation in Wasm diagnostics serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-13 - Wasm diagnostics serialization intermediate allocation
+**Learning:** In the `tzlint_wasm` crate, building an intermediate `Vec<DiagnosticJson>` in `diagnostics_to_json` adds heap overhead that can be bypassed using `serializer.collect_seq()` through a custom wrapper struct implementing `serde::Serialize`.
+**Action:** Use streaming serialization and wrapper types rather than intermediate vectors to keep allocations minimal in WASM context and performance critical code.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What:
Replaced the intermediate `Vec<DiagnosticJson>` in `diagnostics_to_json` with a custom `DiagnosticsWrapper` struct that implements `serde::Serialize` utilizing `serializer.collect_seq()`.

🎯 Why:
To avoid the intermediate heap allocation (`.collect::<Vec<_>>()`) when serializing diagnostics in the WASM target, which improves execution speed and keeps memory overhead minimal, which is critical in constrained WASM environments.

📊 Impact:
Eliminates one O(n) heap allocation (where n is the number of diagnostics) per `lint` call in the WASM bindings.

🔬 Measurement:
WASM execution profiling will show zero intermediate allocations in `diagnostics_to_json`. Tests pass.

---
*PR created automatically by Jules for task [12481384225913283482](https://jules.google.com/task/12481384225913283482) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断情報をJSONへ変換する際のメモリ使用量を削減し、より効率的に処理できるようになりました。
  * 診断結果のJSON形式、各項目の内容、エラー時の戻り値は従来どおり維持されています。

* **ドキュメント**
  * 診断情報のシリアライズ方式に関する技術的な方針を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->