### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-13 - SSRF Bypass via Incomplete IPv6 Blocklist
+**Vulnerability:** The IPv6 URL blocklist for dictionary fetching missed the documentation (`2001:db8::/32`), benchmarking (`2001:2::/48`), and discard-only (`100::/64`) prefixes, potentially allowing bypasses.
+**Learning:** Rust's `Ipv6Addr::is_documentation()` is unstable (issue #27709), so we must manually check prefix segments.
+**Prevention:** Explicitly validate segment ranges for blocked prefixes when standard library methods are unstable.

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,9 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000) // 2001:2::/48 (benchmarking)
+        || (segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0) // 100::/64 (discard-only)
 }
 
 #[cfg(test)]
@@ -303,6 +306,9 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[2001:2::1]",                               // benchmarking
+            "[100::1]",                                  // discard-only
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: LOW (Defense in Depth)
💡 Vulnerability: The IPv6 URL blocklist for dictionary fetching missed the documentation (`2001:db8::/32`), benchmarking (`2001:2::/48`), and discard-only (`100::/64`) prefixes, potentially allowing bypasses to internal or non-routable targets.
🎯 Impact: An attacker could potentially bypass the SSRF guard and probe these non-routable address spaces.
🔧 Fix: Explicitly added segment validation for these prefixes to `ipv6_is_blocked`.
✅ Verification: Ran unit tests with new tests explicitly verifying the blocked prefixes.

---
*PR created automatically by Jules for task [13937874447504014182](https://jules.google.com/task/13937874447504014182) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 辞書取得時に、ドキュメンテーション用・ベンチマーク用・破棄専用の特定IPv6アドレスをブロックするよう改善しました。
  * 対象アドレスを使用した取得リクエストが適切に拒否されるようになりました。

* **セキュリティ**
  * IPv6アドレスの検証を強化し、ブロックリストの回避によるSSRFリスクを抑制しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->