### PR TITLE
🎓 Scholar: Serde zero-copy serialization improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-05-19 - Avoid Vec allocation during Serde JSON serialization
+**Library:** Serde v1.0.x
+**Discovery:** Iterating and collecting into an intermediate `Vec` just to serialize a sequence allocates memory unnecessarily. Serde provides `Serializer::collect_seq()` to stream an iterator directly into the sequence serialization.
+**Application:** Replaced `.collect::<Vec<_>>()` and `serde_json::to_string(&vec)` in `diagnostics_to_json` with a wrapper struct that implements `serde::Serialize` utilizing `serializer.collect_seq()`. This avoids a heap allocation on the hot path of formatting diagnostics to JSON (especially important in `wasm32` constraints).

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/ser/trait.Serializer.html#method.collect_seq
💡 Insight: Serde provides `Serializer::collect_seq()` to stream iterators directly during sequence serialization, avoiding the need to collect elements into an intermediate, heap-allocated collection (like `Vec`) before serialization.
🛠️ Change: Refactored `diagnostics_to_json` in `crates/tzlint_wasm/src/lib.rs`. Replaced the intermediate `.collect::<Vec<_>>()` and `serde_json::to_string(&vec)` with a custom `DiagnosticsWrapper` struct that implements `serde::Serialize` utilizing `serializer.collect_seq()`.
✨ Benefit: Performance and efficiency gain. This avoids an unnecessary heap allocation on the hot path of formatting diagnostics to JSON, which is especially important for memory constraints in the `wasm32` build target.

---
*PR created automatically by Jules for task [12701311655577888023](https://jules.google.com/task/12701311655577888023) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断情報のJSON出力処理を効率化し、不要な中間データ生成を削減しました。
  * 大量の診断情報を扱う際のメモリ使用量の改善が期待されます。
  * JSON変換に失敗した場合は、従来どおり空の配列を返します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->