### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF bypass via unblocked IPv6 prefixes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-14 - SSRF bypass via unblocked IPv6 prefixes
+**Vulnerability:** The SSRF blocklist in `crates/tzlint_core/src/net.rs` lacked protection against IPv6 documentation (`2001:db8::/32`) and benchmarking (`2001:2::/48`) prefixes, allowing potential internal probing.
+**Learning:** Using `Ipv6Addr::segments()` for manual prefix matching is required when standard unstable helpers are unavailable. Prefix lengths explicitly determine the number of 16-bit segments matched (e.g., `/48` needs exactly three segment matches).
+**Prevention:** Always manually validate exact IPv6 prefix segment definitions in security-critical network fetch validation when built-in methods are unstable.

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,8 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000) // 2001:2::/48 (benchmarking)
 }
 
 #[cfg(test)]
@@ -303,6 +305,8 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[2001:2::1]",                               // benchmarking
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing documentation and benchmarking IP blocks for IPv6 SSRF protection.
🎯 Impact: Allows SSRF bypass probing internal nodes using reserved IPv6 blocks.
🔧 Fix: Manually validated address segments against `2001:db8::/32` and `2001:2::/48`.
✅ Verification: Added tests, executed `cargo nextest run --workspace` and `cargo clippy`.

---
*PR created automatically by Jules for task [8277876009018387636](https://jules.google.com/task/8277876009018387636) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * IPv6のドキュメント用およびベンチマーク用アドレスを含む辞書URLを適切にブロックするよう改善しました。
  * IPv6ホストのアクセス制限に関する検証を強化しました。

* **ドキュメント**
  * SSRF対策におけるIPv6アドレス判定の注意点と予防方針を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->