### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2024-05-19 - Serde Streaming Serialization
+**Library:** serde v1.0.x
+**Discovery:** Serde's `Serializer` trait provides `collect_seq` which allows streaming data into a sequence directly from an iterator. This avoids collecting intermediate vectors when serializing collections, leading to faster execution and reduced heap allocations, especially beneficial for memory-constrained targets like WebAssembly.
+**Application:** Refactored `diagnostics_to_json` in `crates/tzlint_wasm/src/lib.rs` to use `serializer.collect_seq()` through a custom wrapper struct `DiagnosticsWrapper`, eliminating the intermediate `Vec<DiagnosticJson>` allocation before serialization.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -150,18 +150,26 @@ struct DiagnosticJson<'a> {
 }
 
 /// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/1.0.x/serde/ser/trait.Serializer.html#tymethod.collect_seq
💡 Insight: Serde's `Serializer` trait provides a method `collect_seq` which allows streaming data into a sequence directly from an iterator. This avoids collecting data into an intermediate collection like `Vec` before serialization.
🛠️ Change: Refactored `diagnostics_to_json` in `crates/tzlint_wasm/src/lib.rs`. Created a wrapper struct `DiagnosticsWrapper` and manually implemented `serde::Serialize` to call `serializer.collect_seq()`.
✨ Benefit: Avoids an unnecessary intermediate heap allocation of `Vec<DiagnosticJson>`, increasing serialization efficiency. This is especially beneficial for performance and memory in WebAssembly targets.

---
*PR created automatically by Jules for task [3233197173566391727](https://jules.google.com/task/3233197173566391727) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断情報のJSON変換処理を見直し、不要な中間データ生成を削減しました。
  * 診断結果の出力形式と、変換に失敗した場合に空の配列を返す動作は従来どおり維持されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->