### PR TITLE
⚡ Bolt: [performance improvement] Stream WebAssembly diagnostic JSON serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-15 - Streamlined serialization without intermediate Vec allocation
+**Learning:** In WebAssembly (and performance-critical paths), collecting iterators into a `Vec` just to serialize them to JSON introduces unnecessary heap allocations. Using `serde::Serializer::collect_seq()` allows streaming elements directly from an iterator, bypassing the intermediate buffer.
+**Action:** Always consider using a wrapper struct with a custom `Serialize` implementation using `collect_seq()` when serializing slices/iterators, rather than allocating a temporary `Vec` (like `let items: Vec<_> = ...collect()`).

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,27 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    // Avoid intermediate Vec allocation by streaming elements directly
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Replaced intermediate `Vec<DiagnosticJson>` allocation in `crates/tzlint_wasm/src/lib.rs` with `DiagnosticsWrapper` calling `serializer.collect_seq()`.
🎯 Why: In WebAssembly targets, minimizing heap allocations along critical output paths improves runtime performance. Creating a massive vector of diagnostics to immediately serialize it introduces an unnecessary memory allocation step that can be circumvented via native serde iterators.
📊 Impact: Completely elides the O(n) heap allocation (where n is the number of diagnostics) of the intermediate `Vec` during `diagnostics_to_json` calls inside `tzlint_wasm`.
🔬 Measurement: Verify changes via WebAssembly functional tests running effectively identically without breaking output correctness (`RUSTUP_HOME=/tmp/rustup CARGO_HOME=/tmp/cargo cargo test --workspace` passes). Validated zero output layout shift on serialization.

---
*PR created automatically by Jules for task [10859284661100572113](https://jules.google.com/task/10859284661100572113) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断結果のJSON変換を効率化し、一時的なデータ生成を抑えてメモリ使用量を削減しました。
  * 診断結果の内容や、変換に失敗した場合のフォールバック動作は従来どおりです。

* **ドキュメント**
  * シリアライズ処理の効率的な実装方法に関する開発上の知見を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->