### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via unblocked IPv6 prefixes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-15 - Missing Special Purpose IPv6 blocks in SSRF Filter
+**Vulnerability:** The SSRF filter for `tzlint` fetches allowed special-purpose IPv6 address blocks (Documentation `2001:db8::/32`, Discard-only `0100::/64`, and Benchmarking `2001:2::/48`) that could potentially be exploited by attackers to bypass SSRF protections or waste resources.
+**Learning:** Checking `is_loopback`, `is_unspecified`, and `is_multicast` alongside `fc00::/7` and `fe80::/10` is insufficient. Many other IPv6 blocks exist that should not be queried externally, such as `2001:db8::/32` which could be sinkholed internally.
+**Prevention:** Always validate against a comprehensive list of IANA IPv6 Special-Purpose Address Registry blocks, manually masking and checking segments where stable Rust features (like `is_documentation()`) are not yet available or exhaustive.

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,9 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0) // 0100::/64 (discard-only)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0) // 2001:2::/48 (benchmarking)
 }
 
 #[cfg(test)]
@@ -303,6 +306,9 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[0100::1]",                                 // discard-only
+            "[2001:2::1]",                               // benchmarking
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The SSRF filter for `tzlint` fetches allowed special-purpose IPv6 address blocks (Documentation `2001:db8::/32`, Discard-only `0100::/64`, and Benchmarking `2001:2::/48`) that could potentially be exploited by attackers to bypass SSRF protections or waste resources.
🎯 Impact: Attackers could potentially bypass SSRF protections by using special-purpose IPv6 addresses that resolve internally.
🔧 Fix: Added explicit blocklist checks for these missing special-purpose IPv6 address blocks in `crates/tzlint_core/src/net.rs` to ensure they are properly filtered alongside loopback and private networks.
✅ Verification: Ran `RUSTUP_HOME=/tmp/rustup CARGO_HOME=/tmp/cargo cargo test --workspace` confirming that `rejects_blocked_ipv6_literals` now properly asserts these blocks are rejected.

---
*PR created automatically by Jules for task [12025108459630063716](https://jules.google.com/task/12025108459630063716) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * SSRF対策を強化し、ドキュメント用・破棄専用・ベンチマーク用のIPv6アドレスをURL検証時に拒否するようになりました。
  * 特殊用途IPv6アドレスの見落としによる不正な接続リスクを低減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->