### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-02-15 - Zero-copy Serialize for Iterators
+**Library:** serde v1.0.228
+**Discovery:** To optimize serialization performance (especially in memory-constrained targets like WebAssembly), avoid collecting iterators into intermediate `Vec` collections prior to serialization. Instead, wrap the slice or iterator in a custom struct and implement `serde::Serialize` utilizing `serializer.collect_seq()` or `serializer.serialize_seq()` to stream data directly without intermediate heap allocations.
+**Application:** Avoided an intermediate allocation when serializing diagnostics by wrapping `&[Diagnostic]` into a struct `DiagnosticsWrapper` implementing `serde::Serialize` with `serializer.collect_seq()`.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,27 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let iter = self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        });
+        serializer.collect_seq(iter)
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/ser/trait.Serializer.html#method.collect_seq
💡 Insight: To optimize serialization, avoiding intermediate heap allocations like `Vec` can greatly increase performance. We can use `serializer.collect_seq` instead of collecting data into an intermediate `Vec`.
🛠️ Change: In `diagnostics_to_json`, instead of creating a `Vec<DiagnosticJson>`, we wrap `&[Diagnostic]` in `DiagnosticsWrapper` and implement `serde::Serialize` on it.
✨ Benefit: Removed intermediate heap allocation in performance-critical path for WASM bindings.

---
*PR created automatically by Jules for task [4670704819815351164](https://jules.google.com/task/4670704819815351164) started by @simorgh3196*