### PR TITLE
⚡ Bolt: [performance improvement] Avoid intermediate Vec allocation in WASM diagnostics serialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2026-07-16 - Prevent Intermediate Allocations During Serialization
-**Learning:** Collecting iterators into intermediate collections (like `Vec`) before serialization introduces unnecessary heap allocations, degrading performance, especially in memory-constrained WebAssembly environments.
-**Action:** When serializing a list of items mapped from another structure, create a wrapper struct containing a slice and implement `serde::Serialize` manually. Inside the implementation, use `serializer.collect_seq()` or `serializer.serialize_seq()` to stream the mapped items directly, eliminating the need to allocate an intermediate `Vec`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-16 - Prevent Intermediate Allocations During Serialization
+**Learning:** Collecting iterators into intermediate collections (like `Vec`) before serialization introduces unnecessary heap allocations, degrading performance, especially in memory-constrained WebAssembly environments.
+**Action:** When serializing a list of items mapped from another structure, create a wrapper struct containing a slice and implement `serde::Serialize` manually. Inside the implementation, use `serializer.collect_seq()` or `serializer.serialize_seq()` to stream the mapped items directly, eliminating the need to allocate an intermediate `Vec`.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsWrapper<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsWrapper(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
💡 What: Replaced the intermediate `Vec` allocation in `diagnostics_to_json` with a custom `serde::Serialize` wrapper (`DiagnosticsWrapper`) that streams elements using `serializer.collect_seq()`.
🎯 Why: Collecting iterators into intermediate collections (like `Vec`) before serialization introduces unnecessary heap allocations, degrading performance, especially in memory-constrained WebAssembly environments.
📊 Impact: Eliminates a dynamic heap allocation for the `Vec` containing `DiagnosticJson` objects during serialization, saving memory and improving execution speed.
🔬 Measurement: Verified that tests pass via `cargo test --workspace` and the linting logic produces the same JSON output. No new warnings are introduced according to `clippy`.

---
*PR created automatically by Jules for task [3313873398455482604](https://jules.google.com/task/3313873398455482604) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 診断情報のJSON出力時に不要な中間データ生成を抑え、メモリ使用量を削減しました。
  * メモリ制約のある環境でも、診断情報をより効率的にシリアライズできるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->