### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via specialized IPv6 subnets

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-16 - Prevent SSRF via specialized IPv6 subnets
+**Vulnerability:** The application's SSRF blocklist allowed certain non-routable or specialized IPv6 networks such as Discard-only (0100::/64), Documentation (2001:db8::/32), and Benchmarking (2001:2::/48) prefixes, which could potentially be abused to probe internal routing or benchmarking systems.
+**Learning:** Rust's standard library has unstable IPv6 helper methods (like `is_documentation()`), requiring manual segment validation when strict prefix checks are necessary for security.
+**Prevention:** When evaluating SSRF risks, manually check the `Ipv6Addr::segments()` to block specialized IPv6 prefixes not naturally handled by standard helper methods, being mindful of prefix lengths (e.g. `/48` requires checking exactly 3 segments).

--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,9 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || segments[0] == 0x0100            // 0100::/64 (discard-only)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0x0000) // 2001:2::/48 (benchmarking)
 }
 
 #[cfg(test)]
@@ -294,6 +297,9 @@ mod tests {
             "[fc00::1]",                                 // unique local
             "[fe80::1]",                                 // link-local
             "[ff02::1]",                                 // multicast
+            "[0100::1]",                                 // discard-only
+            "[2001:db8::1]",                             // documentation
+            "[2001:2::1]",                               // benchmarking
             "[::ffff:127.0.0.1]",                        // IPv4-mapped loopback
             "[::ffff:10.0.0.1]",                         // IPv4-mapped private
             "[::127.0.0.1]",                             // IPv4-compatible loopback


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing SSRF protection for specialized IPv6 prefixes (Discard-only, Documentation, Benchmarking).
🎯 Impact: Attackers could abuse these non-routable IPv6 subnets for internal network probing or interaction with internal benchmarking services.
🔧 Fix: Implemented manual block checks via `Ipv6Addr::segments()` for `0100::/64`, `2001:db8::/32`, and `2001:2::/48`.
✅ Verification: Added explicit tests to `crates/tzlint_core/src/net.rs` ensuring they are rejected as blocked hosts.

---
*PR created automatically by Jules for task [5011315044652520727](https://jules.google.com/task/5011315044652520727) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - SSRF対策を強化し、特殊なIPv6サブネット（破棄専用、ドキュメント用、ベンチマーク用）へのアクセスをブロックするようになりました。
  - 該当するIPv6リテラルURLは、ポリシー違反として拒否されます。
  - 特殊なIPv6アドレスを悪用した意図しない外部接続のリスクを低減します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->