### PR TITLE
🎓 Scholar: serde usage improvement

### DIFF
--- a/.jules/scholar.md
+++ b/.jules/scholar.md
@@ -1,0 +1,4 @@
+## 2025-01-01 - Serde stream serialization
+**Library:** Serde v1.0
+**Discovery:** `serializer.collect_seq()` allows streaming iterators directly into serializers without intermediate collection.
+**Application:** Implemented a wrapper struct for diagnostics in `tzlint_wasm` to stream directly to JSON, bypassing an intermediate `Vec` heap allocation for better WebAssembly performance.

--- a/crates/tzlint_wasm/src/lib.rs
+++ b/crates/tzlint_wasm/src/lib.rs
@@ -149,19 +149,26 @@ struct DiagnosticJson<'a> {
     end: u32,
 }
 
-/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
-fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
-    let items: Vec<DiagnosticJson> = diagnostics
-        .iter()
-        .map(|d| DiagnosticJson {
+struct DiagnosticsJsonList<'a>(&'a [Diagnostic]);
+
+impl<'a> serde::Serialize for DiagnosticsJsonList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_seq(self.0.iter().map(|d| DiagnosticJson {
             rule_id: d.rule_id.as_str(),
             severity: severity_str(d.severity),
             message: d.message.as_str(),
             start: d.span.start,
             end: d.span.end,
-        })
-        .collect();
-    serde_json::to_string(&items).unwrap_or_else(|_| String::from("[]"))
+        }))
+    }
+}
+
+/// Serialize diagnostics to a compact JSON array. Spans are byte offsets into the source.
+fn diagnostics_to_json(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string(&DiagnosticsJsonList(diagnostics)).unwrap_or_else(|_| String::from("[]"))
 }
 
 /// The lowercase wire spelling of a severity (matches the config schema's `severity` enum).


### PR DESCRIPTION
📚 Source: https://docs.rs/serde/latest/serde/trait.Serializer.html#method.collect_seq
💡 Insight: `serde_json::to_string` was collecting diagnostics into an intermediate `Vec` before serializing.
🛠️ Change: Implemented a wrapper struct that leverages `serializer.collect_seq()` to stream the iterator directly.
✨ Benefit: Avoids an unnecessary heap allocation, optimizing memory and speed for WebAssembly execution.

---
*PR created automatically by Jules for task [13650744427733228932](https://jules.google.com/task/13650744427733228932) started by @simorgh3196*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * WebAssembly版で診断結果のJSON出力方式を改善しました。
  * 診断結果を中間データとして保持せずに処理することで、メモリ使用量を抑え、効率的に出力できるようになりました。
  * JSONの項目や出力形式、エラー時に空配列を返す動作は従来どおりです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->