### PR TITLE
🛡️ Sentinel: Fix SSRF bypass via unblocked IPv6 prefixes

### DIFF
--- a/crates/tzlint_core/src/net.rs
+++ b/crates/tzlint_core/src/net.rs
@@ -177,6 +177,9 @@ fn ipv6_is_blocked(addr: Ipv6Addr) -> bool {
         || addr.is_multicast()   // ff00::/8
         || (segments[0] & 0xfe00) == 0xfc00 // fc00::/7  (unique local)
         || (segments[0] & 0xffc0) == 0xfe80 // fe80::/10 (link-local)
+        || (segments[0] == 0x2001 && segments[1] == 0x0db8) // 2001:db8::/32 (documentation)
+        || (segments[0] == 0x0100 && segments[1] == 0 && segments[2] == 0 && segments[3] == 0) // 0100::/64 (discard-only)
+        || (segments[0] == 0x2001 && segments[1] == 0x0002 && segments[2] == 0) // 2001:2::/48 (benchmarking)
 }
 
 #[cfg(test)]
@@ -303,6 +306,9 @@ mod tests {
             "[2002:0a00:0001::]",                        // 6to4 private (10.0.0.1)
             "[2001:0000:4136:e378:8000:63bf:3fff:fdd2]", // Teredo documentation (192.0.2.45)
             "[2001:0000:4136:e378:8000:63bf:80ff:fffe]", // Teredo loopback (127.0.0.1)
+            "[2001:db8::1]",                             // documentation
+            "[0100::1]",                                 // discard-only
+            "[2001:2::1]",                               // benchmarking
         ] {
             let url = format!("https://{host}/d.zst");
             assert!(


### PR DESCRIPTION
https://github.com/simorgh3196/tsuzulint/pull/173

Fixes SSRF bypass by blocking special IPv6 ranges (discard-only, documentation, and benchmarking) without including any .jules tracking files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 辞書URLの取得時に、ドキュメント用・破棄専用・ベンチマーク用として予約されたIPv6アドレスを適切に拒否するよう改善しました。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->